### PR TITLE
Various small improvements to Fresnel code

### DIFF
--- a/docs/fresnel.rst
+++ b/docs/fresnel.rst
@@ -25,8 +25,8 @@ Usage of the Fresnel code
 
 
 The API has been kept as similar as possible to the original Fraunhofer mode of
-poppy. There are FresnelWavefront and FresnelOpticalSystem classes, which can
-be used for the most part similar to the Wavefront and OpticalSystem classes.
+poppy. There are :class:`~poppy.FresnelWavefront` and :class:`~poppy.FresnelOpticalSystem` classes, which can
+be used for the most part similar to the :class:`~poppy.Wavefront` and :class:`~poppy.OpticalSystem` classes.
 
 Users are encouraged to consult the Jupyter notebook `Fresnel_Propagation_Demo
 <https://github.com/mperrin/poppy/blob/master/notebooks/Fresnel_Propagation_Demo.ipynb>`_
@@ -57,25 +57,53 @@ the paraxial approximation.  Right now, only the Fresnel ``QuadraticLens`` class
 will actually cause the Gaussian beam parameters to change. You won't get that
 effect by adding wavefront error with some other ``OpticalElement`` class.
 
+Using the FreselOpticalSystem class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Just like the ``OpticalSystem`` serves as a high-level container for
-``OpticalElements`` in Fraunhofer propagation, the ``FresnelOpticalSystem``
-serves the same purpose in Fresnel propagation.  Note that when adding
-``OpticalElements`` to the ``FresnelOpticalSystem``, you use an ``add_optic``
-function and must specify a physical distance separating that optic from the
+Just like the :class:`~poppy.OpticalSystem` serves as a high-level container for
+:class:`~poppy.OpticalElement` instances in Fraunhofer propagation, the :class:`~poppy.FresnelOpticalSystem`
+serves the same purpose in Fresnel propagation.  Note that when adding an
+:class:`~poppy.OpticalElement` to the :class:`~poppy.FresnelOpticalSystem`, you use the function  :meth:`~poppy.FresnelOpticalSystem.add_optic`
+and must specify a physical distance separating that optic from the
 previous optic, again as an `astropy.Quantity
 <http://docs.astropy.org/en/stable/units/>`_ of dimension length. This replaces
-the ``add_image`` and ``add_pupil`` methods used in Fraunhofer propagation.
+the ``add_image`` and ``add_pupil`` methods used in Fraunhofer propagation.  For example::
+
+    
+    osys = poppy.FresnelOpticalSystem(pupil_diameter = 0.05*u.m, npix = npix, beam_ratio = 0.25)
+    osys.add_optic(poppy.CircularAperture(radius=0.025) )
+    osys.add_optic(poppy.ScalarTransmission(), distance = 10*u.m )
 
 
+If you want the output from a Fresnel calculation to have a particular pixel
+sampling, you may either (1) adjust the ``npix`` and ``oversample`` or
+``beam_ratio`` parameters so that the propagation output naturally has the
+desired sampling, or (2) add a :class:`~poppy.Detector` instance as the *last* optical plane
+to define the desired sampling, in which case the output wavefront will be
+interpolated onto the desired sampling and number of pixels. Note that when
+specifying Detectors in a Fresnel system you must use physical sizes of pixels,
+e.g. ``10*u.micron/u.pixel``, and NOT angular sizes in arcsec/pixel like in a
+regular Fraunhofer OpticalSystem. For instance::
 
-For more details and examples of code usage, consult the Jupyter notebook
-`Fresnel_Propagation_Demo
-<https://github.com/mperrin/poppy/blob/master/notebooks/Fresnel_Propagation_Demo.ipynb>`_.
+    osys.add_detector(pixelscale=20*u.micron/u.pixel, fov_pixels=512)
 
-A worked example of a compound microscope in POPPY is available
-`here <https://github.com/douglase/poppy_example_notebooks/blob/master/Fresnel/Microscope_Example.ipynb>`_,
-reproducing the microscope example case provided in the PROPER manual.
+
+Example Jupyter Notebooks
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. admonition:: Fresnel tutorial notebook
+
+   For more details and examples of code usage, consult the Jupyter
+   notebook `Fresnel_Propagation_Demo
+   <https://github.com/mperrin/poppy/blob/master/notebooks/Fresnel_Propagation_Demo.ipynb>`_.
+   In addition to details on code usage, this includes a worked example of
+   a Fresnel model of the Hubble Space Telescope.
+
+.. admonition:: A non-astronomical example
+
+    A worked example of a compound microscope in POPPY is available
+    `here <https://github.com/douglase/poppy_example_notebooks/blob/master/Fresnel/Microscope_Example.ipynb>`_,
+    reproducing the microscope example case provided in the PROPER manual.
 
 Fresnel calculations with Physical units
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1024,8 +1024,6 @@ class FresnelOpticalSystem(OpticalSystem):
         if self.verbose:
             _log.info("Added detector: {0} after separation: {1:.2e} ".format(self.planes[-1].name, distance))
 
-    add_detector = add_detector  # for compatibility with pre-pep8 names
-
     @utils.quantity_input(wavelength=u.meter)
     def input_wavefront(self, wavelength=1e-6 * u.meter):
         """Create a Wavefront object suitable for sending through a given optical system.
@@ -1049,8 +1047,8 @@ class FresnelOpticalSystem(OpticalSystem):
                                   npix=self.npix, oversample=oversample)
         _log.debug(
             "Creating input wavefront with wavelength={0} microns,"
-            "npix={1}, pixel scale={2}".format(
-                wavelength.to(u.micron).value, self.npix, self.pupil_diameter / (self.npix * u.pixel)
+            "npix={1}, diam={3}, pixel scale={2}".format(
+                wavelength.to(u.micron).value, self.npix, self.pupil_diameter / (self.npix * u.pixel), self.pupil_diameter
             ))
         return inwave
 

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -962,6 +962,10 @@ class FresnelWavefront(Wavefront):
     def _resample_wavefront_pixelscale(self, detector):
         """ Resample a Fresnel wavefront to a desired detector sampling.
 
+        The interpolation is done via the scipy.ndimage.zoom function, by default
+        using cubic interpolation.  If you wish a different order of interpolation,
+        set the `.interp_order` attribute of the detector instance.
+
         Parameters
         ----------
         detector : Detector class instance
@@ -993,8 +997,8 @@ class FresnelWavefront(Wavefront):
         # We should consider cropping out an appropriate subregion prior to performing the zoom.
         # That makes a difference if the detector is only sampling a small part of a much larger wavefront
 
-        new_wf_real = scipy.ndimage.zoom(self.wavefront.real, pixscale_ratio)
-        new_wf_imag = scipy.ndimage.zoom(self.wavefront.imag, pixscale_ratio)
+        new_wf_real = scipy.ndimage.zoom(self.wavefront.real, pixscale_ratio, order=detector.interp_order)
+        new_wf_imag = scipy.ndimage.zoom(self.wavefront.imag, pixscale_ratio, order=detector.interp_order)
         new_wf = new_wf_real + 1.j*new_wf_imag
 
         _log.debug("Cropping/padding resampled wavefront to detector shape")

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -588,7 +588,8 @@ class FresnelWavefront(Wavefront):
             self.angular_coordinates = True  # image planes want angular coordinates
             self.planetype = PlaneType.image  # needed for back compatibility when using image plane optics
         elif optic.planetype == PlaneType.detector:
-            raise NotImplemented('image plane to detector propagation (resampling) not implemented yet')
+            self._resample_wavefront_pixelscale(optic)
+            self.location = 'at detector '+optic.name
         else:
             self.location = 'before ' + optic.name
 
@@ -958,6 +959,52 @@ class FresnelWavefront(Wavefront):
         _log.debug("------ Optic: " + str(optic.name) + " applied ------")
 
 
+    def _resample_wavefront_pixelscale(self, detector):
+        """ Resample a Fresnel wavefront to a desired detector sampling.
+
+        Parameters
+        ----------
+        detector : Detector class instance
+            Detector that defines the desired pixel scale
+
+        Returns
+        -------
+        The wavefront object is modified to have the appropriate pixel scale and spatial extent.
+
+        """
+        import scipy.ndimage
+
+        if self.angular_coordinates:
+            raise NotImplementedError("Resampling to detector doesn't yet work in angular coordinates for Fresnel.")
+
+        pixscale_ratio = (self.pixelscale / detector.pixelscale).decompose().value
+        _log.info("Resampling wavefront to detector with {} pixels and {}. Zoom factor is {}".format(
+            detector.shape, detector.pixelscale, pixscale_ratio ))
+
+        _log.debug("Wavefront pixel scale: {}".format(self.pixelscale))
+        _log.debug("Wavefront FOV: {} pixels, {}".format(self.shape, self.shape[0]*u.pixel*self.pixelscale))
+
+        _log.debug("Desired detector pixel scale: {}".format(detector.pixelscale))
+        _log.debug("Desired detector FOV: {} pixels, {}".format(detector.shape,
+                                                                      detector.shape[0]*u.pixel*detector.pixelscale,
+                                                                      ))
+
+        # TODO the following works but is not optimal for performance
+        # We should consider cropping out an appropriate subregion prior to performing the zoom.
+        # That makes a difference if the detector is only sampling a small part of a much larger wavefront
+
+        new_wf_real = scipy.ndimage.zoom(self.wavefront.real, pixscale_ratio)
+        new_wf_imag = scipy.ndimage.zoom(self.wavefront.imag, pixscale_ratio)
+        new_wf = new_wf_real + 1.j*new_wf_imag
+
+        _log.debug("Cropping/padding resampled wavefront to detector shape")
+        new_wf = utils.pad_or_crop_to_shape(new_wf, detector.shape)
+
+        self.wavefront = new_wf
+        self._pixelscale_m = detector.pixelscale
+        self.n = detector.shape[0]
+
+
 class FresnelOpticalSystem(OpticalSystem):
     """ Class representing a series of optical elements,
     through which light can be propagated using the Fresnel formalism.
@@ -1018,8 +1065,20 @@ class FresnelOpticalSystem(OpticalSystem):
         return optic
 
     @u.quantity_input(distance=u.m)
-    def add_detector(self, pixelscale, distance=0.0 * u.m, **kwargs):
-        super(FresnelOpticalSystem, self).add_detector(pixelscale, **kwargs)
+    def add_detector(self, pixelscale=10*u.micron/u.pixel, fov_pixels=10*u.pixel, distance=0.0 * u.m):
+        """ Add a detector to the optical system
+
+        Parameters
+        ----------
+        pixelscale : astropy.Quantity, with units micron/pixel or equivalent
+            The pixel scale at the detector
+        fov_pixels : astropy.Quantity with units pixel
+            The number of pixels per axis of the detector. Assumes square detector.
+         distance : astropy.Quantity of dimension length
+            separation distance of this optic relative to the prior optic in the system.
+
+        """
+        super(FresnelOpticalSystem, self).add_detector(pixelscale=pixelscale, fov_pixels=fov_pixels)
         self.distances.append(distance)
         if self.verbose:
             _log.info("Added detector: {0} after separation: {1:.2e} ".format(self.planes[-1].name, distance))

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -133,9 +133,6 @@ class AnalyticOpticalElement(OpticalElement):
         else:
             return self.get_transmission(wave) * np.exp(1.j * self.get_opd(wave) * scale)
 
-    def getPhasor(self, wave):
-        warnings.warn("getPhasor is deprecated; use get_phasor instead", DeprecationWarning)
-        return self.get_phasor(wave)
 
     @utils.quantity_input(wavelength=u.meter)
     def sample(self, wavelength=1e-6 * u.meter, npix=512, grid_size=None, what='amplitude',
@@ -185,7 +182,7 @@ class AnalyticOpticalElement(OpticalElement):
             pixel_scale = fov / (npix * u.pixel)
             w = Wavefront(wavelength=wavelength, npix=npix, pixelscale=pixel_scale)
 
-        _log.info("Computing {0} for {1} sampled onto {2} pixel grid".format(what, self.name, npix))
+        _log.info("Computing {0} for {1} sampled onto {2} pixel grid with pixelscale {3}".format(what, self.name, npix, pixel_scale))
         if what == 'amplitude':
             output_array = self.get_transmission(w)
         elif what == 'intensity':
@@ -1739,7 +1736,7 @@ class GaussianAperture(AnalyticOpticalElement):
         """ Compute the transmission inside/outside of the aperture.
         """
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         y, x = self.get_coordinates(wave)
 
         r = np.sqrt(x ** 2 + y ** 2)
@@ -1767,9 +1764,9 @@ class KnifeEdge(AnalyticOpticalElement):
             name = "Knife edge at {} deg".format(rotation)
         AnalyticOpticalElement.__init__(self, name=name, rotation=rotation, **kwargs)
 
-    def get_transmission(self,wave):
+    def get_transmission(self, wave):
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("getPhasor must be called with a Wavefront to define the spacing")
+            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         y, x = self.get_coordinates(wave)
         return x < 0
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1961,22 +1961,15 @@ class OpticalElement(object):
             else:
                 self.phasor = self.get_transmission(wave) * np.exp(1.j * self.get_opd(wave) * scale)
 
-        # check whether we need to pad before returning or not.
+        # check whether we need to pad or crop the array before returning or not.
         # note: do not pad the phasor if it's just a scalar!
-        if self.planetype == PlaneType.pupil and wave.ispadded and self.phasor.size != 1:
-            # old version: pad to a fixed oversampling. All FITS arrays in an OpticalSystem must be the same size
-            # return padToOversample(self.phasor, wave.oversample)
-
-            # new version: pad to match the wavefront sampling, from whatever sized array we started with.
+        if self.phasor.size != 1 and self.phasor.shape != wave.shape:
+            # pad to match the wavefront sampling, from whatever sized array we started with.
             # Allows more flexibility for differently sized FITS arrays, so long as they all have the
             # same pixel scale as checked above!
-            return utils.pad_to_size(self.phasor, wave.shape)
+            return utils.pad_or_crop_to_shape(self.phasor, wave.shape)
         else:
             return self.phasor
-
-    def getPhasor(self, wave):
-        warnings.warn("getPhasor is deprecated; use get_phasor instead", DeprecationWarning)
-        return self.get_phasor(wave)
 
     @utils.quantity_input(opd_vmax=u.meter)
     def display(self, nrows=1, row=1, what='intensity', crosshairs=False, ax=None, colorbar=True,

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -321,7 +321,7 @@ def test_inverse_MFT():
 )
 def test_optic_resizing():
     '''
-    Tests the rescaling functionality of OpticalElement.getPhasor(),
+    Tests the rescaling functionality of OpticalElement.get_phasor(),
     by first creating an optic with a small pixel scale and then
     creating an optic with a large pixel scale, and checking the returned
     phasor of each has the dimensions of the input wavefront.
@@ -334,27 +334,27 @@ def test_optic_resizing():
     test_optic_small=fits.HDUList([fits.PrimaryHDU(np.zeros([1000,1000]))])
     test_optic_small[0].header["PUPLSCAL"]=.001
     test_optic_small_element=poppy_core.FITSOpticalElement(transmission=test_optic_small)
-    assert(test_optic_small_element.getPhasor(inputwf).shape ==inputwf.shape )
+    assert(test_optic_small_element.get_phasor(inputwf).shape ==inputwf.shape )
 
     # Test rescaling from coarser scales: diameter 1 meter, pixel scale 10 mm
     test_optic_large=fits.HDUList([fits.PrimaryHDU(np.zeros([100,100]))])
     test_optic_large[0].header["PUPLSCAL"]=.01
     test_optic_large_element=poppy_core.FITSOpticalElement(transmission=test_optic_large)
-    assert(test_optic_large_element.getPhasor(inputwf).shape ==inputwf.shape )
+    assert(test_optic_large_element.get_phasor(inputwf).shape ==inputwf.shape )
 
     # Test rescaling where we have to pad with extra zeros: 
     # diameter 0.8 mm, pixel scale 1 mm
     test_optic_pad=fits.HDUList([fits.PrimaryHDU(np.zeros([800,800]))])
     test_optic_pad[0].header["PUPLSCAL"]=.001
     test_optic_pad_element=poppy_core.FITSOpticalElement(transmission=test_optic_pad)
-    assert(test_optic_pad_element.getPhasor(inputwf).shape ==inputwf.shape )
+    assert(test_optic_pad_element.get_phasor(inputwf).shape ==inputwf.shape )
 
     # Test rescaling where we have to trim to a smaller size:
     # diameter 1.2 mm, pixel scale 1 mm
     test_optic_crop=fits.HDUList([fits.PrimaryHDU(np.zeros([1200,1200]))])
     test_optic_crop[0].header["PUPLSCAL"]=.001
     test_optic_crop_element=poppy_core.FITSOpticalElement(transmission=test_optic_crop)
-    assert(test_optic_crop_element.getPhasor(inputwf).shape ==inputwf.shape )
+    assert(test_optic_crop_element.get_phasor(inputwf).shape ==inputwf.shape )
 
 
 def test_unit_conversions():

--- a/poppy/tests/test_errorhandling.py
+++ b/poppy/tests/test_errorhandling.py
@@ -6,10 +6,6 @@ from .. import optics
 from .. import matrixDFT
 from .. import zernike
 import sys
-if sys.version_info.major < 3:
-    _PYTHON_2 = True
-else:
-    _PYTHON_2 = False
 
 try:
     import pytest
@@ -18,10 +14,7 @@ except:
     _HAVE_PYTEST = False
 
 def _exception_message_starts_with(excinfo, message_body):
-    if _PYTHON_2:
-        return excinfo.value.message.startswith(message_body)
-    else:
-        return excinfo.value.args[0].startswith(message_body)
+    return excinfo.value.args[0].startswith(message_body)
 
 if _HAVE_PYTEST:
     def test_calc_psf_catch_invalid_wavelength():

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -365,7 +365,7 @@ def test_fresnel_optical_system_Hubble(display=False, sampling=2):
         utils.display_psf(psf, imagecrop=1)
 
 
-def test_fresnel_FITS_Optical_element(tmpdir, display=False):
+def test_fresnel_FITS_Optical_element(tmpdir, display=False, verbose=False):
     """ Test that Fresnel works with FITS optical elements.
 
     Incidentally serves as a test of the fix for the FITS endian issue
@@ -381,38 +381,73 @@ def test_fresnel_FITS_Optical_element(tmpdir, display=False):
     tmpdir : string
         temporary directory for output FITS file. To be provided by py.test's
         tmpdir test fixture.
+    display : bool
+        Show plots?
+    verbose : bool
+        Print some remarks when running?
 
     """
     import os.path
     import astropy.io.fits as fits
-    from .. import wfe
+    from poppy import wfe
 
-    m1_zernike= wfe.ZernikeWFE(radius=1.2,
-        coefficients=[0,0,0,0,0,1e-7],
-        oversample=0)
+    # parameters for calculation test case:
+    radius = 1.0 * u.m
+    npix = 128
 
-    fits_zern = m1_zernike.to_fits(what='opd')
+    conv_lens = fresnel.QuadraticLens(1.0 * u.m)
+    circular_aperture = optics.CircularAperture(radius=radius)
 
-    filename=os.path.join(str(tmpdir), "astigmatism.fits")
-    fits_zern.writeto(filename, overwrite=True)
-    astig_surf = poppy_core.FITSOpticalElement(opd=filename,
-        planetype=poppy_core._INTERMED,
-        oversample=1)
+    # To test two different versions of the FITS handling, we will repeat this test twice:
+    # once with the FITS element crafted to precisely match the pixel scale of the
+    # wavefront in the Fresnel propagation, and once with a mismatch in the pixel scale
+    # so that it has to be interpolated. We should get the same result both ways within the
+    # tolerances.
 
-    osys = poppy_core.OpticalSystem()
-    circular_aperture = optics.CircularAperture(radius=1.2)
-    osys.add_pupil(circular_aperture)
-    osys.add_pupil(astig_surf)
-    osys.add_detector(pixelscale=.01, fov_arcsec=5)
+    # Below we will create a FITSOpticalElement and show that it works in the FresnelOpticalSystem.
+    # To make the test interesting we put some astigmatism in that FITS file, but this is arbitrary.
+    # We make the OPD by creating a Zernike WFE object, sampling it as desired, writing it
+    # out as a temp file, then reading back in to a FITSOpticalElement
 
-    psf_with_astigmatism, wfronts = osys.calc_psf( display_intermediates=display,return_intermediates=True)
+    for matchscale in [True, False]:
 
-    cx, cy = utils.measure_centroid(psf_with_astigmatism)
-    expected_cx, expected_cy = 499.5, 499.5
-    assert np.abs(cx-expected_cx)< 0.02, "PSF centroid is not as expected in X"
-    assert np.abs(cy-expected_cy)< 0.02, "PSF centroid is not as expected in Y"
-    assert psf_with_astigmatism[0].data.sum() > 0.99, "PSF total flux is not as expected."
-    assert np.abs(psf_with_astigmatism[0].data.max() - 0.00178667) < 1e-5, "PSF peak pixel is not as expected"
+        # Create the FITS element to test
+        m1_zernike = wfe.ZernikeWFE(radius=radius,
+                                    coefficients=[0, 0, 0, 0, 0, 1e-7])
+        if matchscale:
+            fits_zern = m1_zernike.to_fits(what='opd', grid_size=2 * radius, npix=npix)
+        else:
+            fits_zern = m1_zernike.to_fits(what='opd', npix=376)
+
+        filename = os.path.join(str(tmpdir), "astigmatism.fits")
+        fits_zern.writeto(filename, overwrite=True)
+        astig_surf = poppy_core.FITSOpticalElement(opd=filename,
+                                                   planetype=poppy_core._INTERMED,
+                                                   oversample=1)
+
+        if verbose:
+            print("Astigmatism surface from FITS has pixelscale {}, npix={}".format(astig_surf.pixelscale,
+                                                                                    astig_surf.shape[0]))
+
+        # Now we put that FITSOpticalElement into a Fresnel optical system.
+        fosys = fresnel.FresnelOpticalSystem(pupil_diameter=radius * 2, beam_ratio=0.25, npix=npix)
+        fosys.add_optic(circular_aperture)
+        fosys.add_optic(astig_surf)
+        fosys.add_optic(conv_lens)
+        fosys.add_optic(optics.ScalarTransmission(name='focus'), distance=1 * u.m)
+
+        # perform the calculation, then check results are as expected
+        psf_with_astigmatism, wfronts = fosys.calc_psf(display_intermediates=display, return_intermediates=True)
+
+        cx, cy = utils.measure_centroid(psf_with_astigmatism)
+        expected_cx = expected_cy = psf_with_astigmatism[0].data.shape[0] // 2
+        assert np.abs(cx - expected_cx) < 0.02, "PSF centroid is not as expected in X"
+        assert np.abs(cy - expected_cy) < 0.02, "PSF centroid is not as expected in Y"
+        assert psf_with_astigmatism[0].data.sum() > 0.99, "PSF total flux is not as expected."
+        assert np.abs(psf_with_astigmatism[0].data.max() - 0.033212) < 2e-5, "PSF peak pixel is not as expected"
+
+        if verbose:
+            print("Tests of FITSOpticalElement in FresnelOpticalSystem pass.")
 
 
 def test_fresnel_propagate_direct_forward_and_back():

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -1222,15 +1222,15 @@ class BackCompatibleQuantityInput(object):
 
         Examples
         --------
-
-        Python 2 and 3::
+        The desired type of the input parameter can be specified as an argument to
+        the decorator, or via an annotation on the function argument itself:
+        .. code-block:: python3
 
             import poppy.utils
             @poppy.utils.back_compatible_quantity_input(mylength=u.meter)
             def myfunction(mylength):
                 return mylength**2
 
-        Python 3 only:
 
         .. code-block:: python3
 


### PR DESCRIPTION
This PR addresses a handful of misc issues with Fresnel propagation, including:

- Fixes #242, by enabling the use of Detector instances in FresnelOpticalSystems. A new method on FresnelWavefront will resample a given wavefront onto the desired pixel scale and number of pixels to match the specified detector. To help enable this, Detector pixel scales can now optionally be specified in linear units of e.g. microns/pixel, as well as in angular units like arcsec/pixel. You have to use the linear units for Fresnel detectors. 
- Fixes #191, the lack of a unit test for Detector instances in FresnelOpticalSystems
- Fixes #251, the problem that the test case for "FITSOpticalElement in FresnelOpticalSystem" did not actually use a FresnelOpticalSystem. During the course of fixing this I discovered an edge-case bug in the FITSOpticalElement get_phasor code (didn't properly handle the case of a matching pixel scale but different array shapes between optic and wavefront), so I fixed that too.
- Some small additions to the Fresnel docs page. 
- A handful of misc code cleanup (removal of some now-unneeded Python 2 stuff  in the unit test code (see #262), some duplicated imports, etc.)