### PR TITLE
Fix travis by setting MPLBACKEND

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ env:
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
         - CONDA_DEPENDENCIES='scipy matplotlib six'
+
+        # For headless testing of code that imports PyPlot:
+        - MPLBACKEND=Agg
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'


### PR DESCRIPTION
I did an extensive test diagnostics via #269 (I reset the branch multiple times so not all the commits show). I finally used the WebbPSF's `.travis.yml` file to see if it worked. I then removed each change one by one to find that the `MPLBACKEND` definition fixes the issue we are seeing. This means that the test environment did not know which MPL backend to use. This was weird because Travis showed no errors when it crashed; but now we realize it segfaulted when trying to use/compile MPL & PyPlot. 