### PR TITLE
Add CircularPhaseMask coronagraph

### DIFF
--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -681,7 +681,8 @@ class CircularPhaseMask(AnalyticImagePlaneElement):
     """
 
     @utils.quantity_input(radius=u.arcsec, wavelength=u.meter)
-    def __init__(self, name=None, radius=1*u.arcsec, wavelength=1e-6 * u.meter, retardance=0.5, **kwargs):
+    def __init__(self, name=None, radius=1*u.arcsec, wavelength=1e-6 * u.meter, retardance=0.5,
+            **kwargs):
         if name is None:
             name = "Phase mask r={:.3g}".format(radius)
         AnalyticImagePlaneElement.__init__(self, name=name, **kwargs)
@@ -693,12 +694,12 @@ class CircularPhaseMask(AnalyticImagePlaneElement):
         self.retardance = retardance
 
     def get_opd(self, wave):
-        """ Compute the OPD appropriate for a 4QPM for some given pixel spacing
+        """ Compute the OPD appropriate for that phase mask for some given pixel spacing
         corresponding to the supplied Wavefront
         """
 
         if not isinstance(wave, Wavefront):  # pragma: no cover
-            raise ValueError("4QPM get_opd must be called with a Wavefront to define the spacing")
+            raise ValueError("get_opd must be called with a Wavefront to define the spacing")
         assert (wave.planetype == PlaneType.image)
 
         y, x = self.get_coordinates(wave)
@@ -711,8 +712,10 @@ class CircularPhaseMask(AnalyticImagePlaneElement):
         npix = (r<=radius).sum()
         if npix < 50:
             import warnings
-            warnings.warn("Phase mask is very coarsely sampled: only {} pixels. Improve sampling for better precision!".format(npix))
-            _log.warn("Phase mask is very coarsely sampled: only {} pixels. Improve sampling for better precision!".format(npix))
+            errmsg = "Phase mask is very coarsely sampled: only {} pixels. "\
+                     "Improve sampling for better precision!".format(npix)
+            warnings.warn(errmsg)
+            _log.warn(errmsg)
         return self.opd
 
 

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -20,7 +20,7 @@ if accel_math._USE_NUMEXPR:
 _log = logging.getLogger('poppy')
 
 __all__ = ['AnalyticOpticalElement', 'ScalarTransmission', 'InverseTransmission',
-           'BandLimitedCoron', 'BandLimitedCoronagraph', 'IdealFQPM', 'RectangularFieldStop', 'SquareFieldStop',
+           'BandLimitedCoron', 'BandLimitedCoronagraph', 'IdealFQPM', 'CircularPhaseMask', 'RectangularFieldStop', 'SquareFieldStop',
            'AnnularFieldStop', 'HexagonFieldStop',
            'CircularOcculter', 'BarOcculter', 'FQPM_FFT_aligner', 'CircularAperture',
            'HexagonAperture', 'MultiHexagonAperture', 'NgonAperture', 'RectangleAperture',
@@ -659,6 +659,61 @@ class IdealFQPM(AnalyticImagePlaneElement):
         phase = (1 - np.sign(x) * np.sign(y)) * 0.25
 
         return phase * self.central_wavelength.to(u.meter).value
+
+
+class CircularPhaseMask(AnalyticImagePlaneElement):
+    """ Circular phase mask coronagraph, with its retardance
+    set perfectly at one specific wavelength and varying linearly on
+    either side of that.
+
+    Parameters
+    ----------
+    name : string
+        Descriptive name
+    radius : float
+        Radius of the mask
+    wavelength : float
+        Wavelength in meters for which the phase mask was designed
+    retardance : float
+        Optical path delay at that wavelength, specified in waves
+        relative to the reference wavelengt. Default is 0.5.
+
+    """
+
+    @utils.quantity_input(radius=u.arcsec, wavelength=u.meter)
+    def __init__(self, name=None, radius=1*u.arcsec, wavelength=1e-6 * u.meter, retardance=0.5, **kwargs):
+        if name is None:
+            name = "Phase mask r={:.3g}".format(radius)
+        AnalyticImagePlaneElement.__init__(self, name=name, **kwargs)
+        self.wavefront_display_hint = 'phase'  # preferred display for wavefronts at this plane
+        self._default_display_size = 4*radius
+
+        self.central_wavelength = wavelength
+        self.radius = radius
+        self.retardance = retardance
+
+    def get_opd(self, wave):
+        """ Compute the OPD appropriate for a 4QPM for some given pixel spacing
+        corresponding to the supplied Wavefront
+        """
+
+        if not isinstance(wave, Wavefront):  # pragma: no cover
+            raise ValueError("4QPM get_opd must be called with a Wavefront to define the spacing")
+        assert (wave.planetype == PlaneType.image)
+
+        y, x = self.get_coordinates(wave)
+        r = _r(x, y)
+
+        self.opd= np.zeros(wave.shape, dtype=_float())
+        radius = self.radius.to(u.arcsec).value
+
+        self.opd[r <= radius] = self.retardance * self.central_wavelength.to(u.meter).value
+        npix = (r<=radius).sum()
+        if npix < 50:
+            import warnings
+            warnings.warn("Phase mask is very coarsely sampled: only {} pixels. Improve sampling for better precision!".format(npix))
+            _log.warn("Phase mask is very coarsely sampled: only {} pixels. Improve sampling for better precision!".format(npix))
+        return self.opd
 
 
 class RectangularFieldStop(AnalyticImagePlaneElement):

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -91,6 +91,20 @@ def test_SquareFieldStop():
     assert wave.intensity.sum() == 400 # 1/10 of the 1e4 element array
 
 
+def test_CircularPhaseMask():
+    import poppy
+    optic= optics.CircularPhaseMask(radius=1, retardance=0.25, wavelength=3e-6)
+    wave = poppy_core.Wavefront(npix=100, pixelscale=0.05, wavelength=3e-6)
+
+    wave*= optic
+    assert wave.phase[50,0]==0
+    assert wave.phase[50,29]==0
+    np.testing.assert_almost_equal(wave.phase[50,30], np.pi/2)
+    np.testing.assert_almost_equal(wave.phase[50,50], np.pi/2)
+    np.testing.assert_almost_equal(wave.phase[50,69], np.pi/2)
+    assert wave.phase[50,70]==0
+    assert wave.phase[50,80]==0
+
 
 def test_BarOcculter():
     optic= optics.BarOcculter(width=1, rotation=0)


### PR DESCRIPTION
Adds the new feature requested in #272, a CircularPhaseMask class useful for either old-school Roddier & Roddier coronagraphs, or a Zernike wavefront sensor. 