### PR TITLE
better default parameters for OpticalSystem.input_wavefront 

### DIFF
--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1116,7 +1116,7 @@ class FresnelOpticalSystem(OpticalSystem):
         return inwave
 
     @utils.quantity_input(wavelength=u.meter)
-    def propagate_mono(self, wavelength=2e-6 * u.meter,
+    def propagate_mono(self, wavelength=1e-6 * u.meter,
                            normalize='first',
                            retain_intermediates=False,
                            retain_final=False,

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -215,7 +215,7 @@ class AnalyticOpticalElement(OpticalElement):
             return output_array
 
     @utils.quantity_input(wavelength=u.meter)
-    def display(self, nrows=1, row=1, wavelength=2e-6 * u.meter, npix=512, grid_size=None,
+    def display(self, nrows=1, row=1, wavelength=1e-6 * u.meter, npix=512, grid_size=None,
                 what='intensity', **kwargs):
         """Display an Analytic optic by first computing it onto a grid...
 
@@ -283,7 +283,7 @@ class AnalyticOpticalElement(OpticalElement):
         return returnvalue
 
     @utils.quantity_input(wavelength=u.meter)
-    def to_fits(self, outname=None, what='amplitude', wavelength=2e-6 * u.meter, npix=512, **kwargs):
+    def to_fits(self, outname=None, what='amplitude', wavelength=1e-6 * u.meter, npix=512, **kwargs):
         """ Save an analytic optic computed onto a grid to a FITS file
 
         The FITS file is returned to the calling function, and may optionally be
@@ -1717,7 +1717,7 @@ class ThinLens(CircularAperture):
     """
 
     @utils.quantity_input(reference_wavelength=u.meter)
-    def __init__(self, name='Thin lens', nwaves=4.0, reference_wavelength=2e-6 * u.meter,
+    def __init__(self, name='Thin lens', nwaves=4.0, reference_wavelength=1e-6 * u.meter,
                  radius=1.0*u.meter, **kwargs):
         self.reference_wavelength = reference_wavelength
         self.nwaves = nwaves

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -710,7 +710,7 @@ class CircularPhaseMask(AnalyticImagePlaneElement):
 
         self.opd[r <= radius] = self.retardance * self.central_wavelength.to(u.meter).value
         npix = (r<=radius).sum()
-        if npix < 50:
+        if npix < 50:  # pragma: no cover
             import warnings
             errmsg = "Phase mask is very coarsely sampled: only {} pixels. "\
                      "Improve sampling for better precision!".format(npix)

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2349,9 +2349,9 @@ class FITSOpticalElement(OpticalElement):
                     _log.info("The supplied pupil OPD is a datacube but no slice was specified. "
                               "Defaulting to use slice 0.")
                     opd_index = 0
-                self.opd_slice_index = opd_index
-                self.opd = self.opd[self.opd_slice_index, :, :]
-                _log.debug(" Datacube detected, using slice ={0}".format(self.opd_slice_index))
+                self.opd_slice = opd_index
+                self.opd = self.opd[self.opd_slice, :, :]
+                _log.debug(" Datacube detected, using slice ={0}".format(self.opd_slice))
 
             if transmission is None:
                 _log.info("No info supplied on amplitude transmission; assuming uniform throughput = 1")

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -119,7 +119,7 @@ class Wavefront(object):
     """
 
     @utils.quantity_input(wavelength=u.meter, diam=u.meter, pixelscale=u.arcsec / u.pixel)
-    def __init__(self, wavelength=2e-6 * u.meter, npix=1024, dtype=None, diam=8.0 * u.meter,
+    def __init__(self, wavelength=1e-6 * u.meter, npix=1024, dtype=None, diam=8.0 * u.meter,
                  oversample=2, pixelscale=None):
 
         self._last_transform_type = None  # later used to track MFT vs FFT pixel coord centering in coordinates()
@@ -1410,7 +1410,7 @@ class OpticalSystem(object):
 
     @utils.quantity_input(wavelength=u.meter)
     def propagate_mono(self,
-                       wavelength=2e-6 * u.meter,
+                       wavelength=1e-6 * u.meter,
                        normalize='first',
                        retain_intermediates=False,
                        retain_final=False,

--- a/poppy/special_prop.py
+++ b/poppy/special_prop.py
@@ -90,7 +90,7 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
                                                     name='Oversampled Occulter Plane')
 
     @utils.quantity_input(wavelength=u.meter)
-    def propagate_mono(self, wavelength=2e-6 * u.meter,
+    def propagate_mono(self, wavelength=1e-6 * u.meter,
                        normalize='first',
                        retain_final=False,
                        retain_intermediates=False,

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     scipy = None
 
+import poppy
 from .. import poppy_core
 from .. import optics
 
@@ -393,6 +394,55 @@ def test_return_complex():
     assert len(psf[1])==1 #make sure only one element was returned
     #test that the wavefront returned is the final wavefront:
     assert np.allclose(psf[1][0].intensity,psf[0][0].data)
+
+### Tests for OpticalElements defined in poppy_core###
+
+def test_ArrayOpticalElement():
+    import poppy
+    y,x = np.indices((10,10)) # arbitrary something to stick in an optical element
+
+    ar = poppy.ArrayOpticalElement(opd=x, transmission=y, pixelscale=1*u.meter/u.pixel)
+
+    assert np.allclose(ar.opd, x), "Couldn't set OPD"
+    assert np.allclose(ar.amplitude, y), "Couldn't set amplitude transmission"
+    assert ar.pixelscale == 1*u.meter/u.pixel
+
+def test_FITSOpticalElement(tempdir='./'):
+    circ_fits = poppy.CircularAperture().to_fits(grid_size=3, npix=10)
+    fn = tempdir+"circle.fits"
+    circ_fits.writeto(fn, overwrite=True)
+
+    # Test passing aperture via file on disk
+    foe = poppy.FITSOpticalElement(transmission=fn)
+    assert foe.amplitude_file == fn
+    assert np.allclose(foe.amplitude, circ_fits[0].data)
+
+    # Test passing OPD via FITS object, along with unit conversion
+    circ_fits[0].header['BUNIT'] = 'micron' # need unit for OPD
+    foe = poppy.FITSOpticalElement(opd=circ_fits)
+    assert foe.opd_file == 'supplied as fits.HDUList object'
+    assert np.allclose(foe.opd, circ_fits[0].data*1e-6)
+
+    # make a cube
+    rect_mask = poppy.RectangleAperture().sample(grid_size=3, npix=10)
+    circ_mask = circ_fits[0].data
+    circ_fits[0].data = np.stack([circ_mask, rect_mask])
+    circ_fits[0].header['BUNIT'] = 'nm' # need unit for OPD
+    fn2 = tempdir+"cube.fits"
+    circ_fits.writeto(fn2, overwrite=True)
+
+    # Test passing OPD as cube, with slice default, units of nanometers
+    foe = poppy.FITSOpticalElement(opd=fn2)
+    assert foe.opd_file == fn2
+    assert foe.opd_slice == 0
+    assert np.allclose(foe.opd, circ_mask*1e-9)
+
+    # Same cube but now we ask for the next slice
+    foe = poppy.FITSOpticalElement(opd=(fn2, 1))
+    assert foe.opd_file == fn2
+    assert foe.opd_slice == 1
+    assert np.allclose(foe.opd, rect_mask*1e-9)
+
 
 ### Detector class unit test ###
 

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 from astropy.io import fits
+import astropy.units as u
 import pytest
 try:
     import scipy
@@ -59,22 +60,24 @@ def test_input_wavefront_size():
     # is applied during an FFT propagation; by default there's no effect
     # in the unpadded array.
     for oversamp in (1,2,4):
-        osys = poppy_core.OpticalSystem("test", oversample=oversamp)
+        osys = poppy_core.OpticalSystem("test", oversample=oversamp, pupil_diameter = 1*u.meter)
         #pupil = optics.CircularAperture(radius=1)
         wf = osys.input_wavefront()
         expected_shape = (1024,1024) if (wf.ispadded == False) else (1024*oversamp, 1024*oversamp)
         assert wf.shape == expected_shape, 'Wavefront is not the expected size: is {} expects {}'.format(wf.shape,  expected_shape)
 
 
-    # test setting the size based on the npix parameter, with null optical system
+    # test setting the size based on the npix parameter, with no optical system planes
+    # (so it gets the diameter from the optical system object)
     for size in [512, 1024, 2001]:
-        osys = poppy_core.OpticalSystem("test", oversample=1, npix=size)
+        osys = poppy_core.OpticalSystem("test", oversample=1, npix=size, pupil_diameter = 1*u.meter)
         #pupil = optics.CircularAperture(radius=1)
         wf = osys.input_wavefront()
         expected_shape = (size,size)
         assert wf.shape == expected_shape, 'Wavefront is not the expected size: is {} expects {}'.format(wf.shape,  expected_shape)
 
     # test setting the size based on the npix parameter, with a non-null optical system
+    # (so it infers the system diameter from the first optic's diameter)
     for size in [512, 1024, 2001]:
         osys = poppy_core.OpticalSystem("test", oversample=1, npix=size)
         osys.add_pupil(optics.CircularAperture(radius=1))

--- a/poppy/tests/test_errorhandling.py
+++ b/poppy/tests/test_errorhandling.py
@@ -101,3 +101,8 @@ if _HAVE_PYTEST:
             zernike.zernike(2,4)
         assert _exception_message_starts_with(excinfo, "Zernike index m must be >= index n")
 
+
+    def test_lack_of_input_wavefront_specification():
+        with pytest.raises(RuntimeError) as excinfo:
+            poppy_core.OpticalSystem().calc_psf()
+        assert _exception_message_starts_with(excinfo, "You must define an entrance pupil diameter")


### PR DESCRIPTION
This PR fixes #246:
>Currently, the logic in input_wavefront for determining the sampling of the wavefront array is to first look at the pupil size and number of pixels for the first plane in the optical system, and only if those are None does it look to the attributes of the OpticalSystem instance itself. This violates the principle of least astonishment. If the user has specifically set npix or pupil_diam on the OpticalSystem, that should be the first place that is checked when creating an wavefront, and should override whatever the first OpticalElement has.

The result is that input wavefront sizes are determined as following. 
1. If `npix` or `pupil_diameter` are defined on the OpticalSystem as a whole, those values take precedence.
2. Otherwise check if the first OpticalElement in the system defines the sampling number of pixels (by having a `.shape`) and/or has a `.pupil_diam` attribute. 
3. If none of the above, default to `npix=1024` for the pixel grid, or raise an error if nothing defines the size of array to sample.

As noted in #246, this also has the benefit of making OpticalSystem consistent with FresnelOpticalSystem in terms of how the wavefront sampling is defined. 

Relatedly but distinct, I also went ahead and updated the default wavelength to 1 micron everywhere, rather than a mix of 1 and 2 microns. 