### PR TITLE
Refactoring to enable chaining of optical systems, and mixed Fresnel/Fraunhofer

### DIFF
--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -8,7 +8,8 @@ and point spread function formation, particularly in the context of astronomical
 POPPY was developed as part of a simulation package for JWST, but is more broadly applicable to many kinds of
 imaging simulations.
 
-Developed by Marshall Perrin and colleagues at STScI, 2010-2017, for use simulating the James Webb Space Telescope.
+Developed by Marshall Perrin and colleagues at STScI, for use simulating the James Webb Space Telescope
+and other NASA missions.
 
 Documentation can be found online at https://poppy-optics.readthedocs.io/
 """

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1139,50 +1139,6 @@ class FresnelOpticalSystem(OpticalSystem):
         inwave._display_hint_expected_nplanes = len(self)     # For displaying a multi-step calculation nicely
         return inwave
 
-#    @utils.quantity_input(wavelength=u.meter)
-#    def propagate_mono(self, wavelength=1e-6 * u.meter,
-#                           normalize='first',
-#                           retain_intermediates=False,
-#                           retain_final=False,
-#                           display_intermediates=False):
-#        """Propagate a monochromatic wavefront through the optical system, via Fresnel calculations.
-#        Called from within `calc_psf`.
-#        Returns a tuple with a `fits.HDUList` object and a list of intermediate `Wavefront`s (empty if
-#        `retain_intermediates=False`).
-#
-#        Parameters
-#        ----------
-#        wavelength : float
-#            Wavelength in meters
-#        normalize : string, {'first', 'last'}
-#            how to normalize the wavefront?
-#            * 'first' = set total flux = 1 after the first optic, presumably a pupil
-#            * 'last' = set total flux = 1 after the entire optical system.
-#            * 'first=2' = set total flux = 2 after the first optic (used for debugging only)
-#        display_intermediates : bool
-#            Should intermediate steps in the calculation be displayed on screen? Default: False.
-#        retain_intermediates : bool
-#            Should intermediate steps in the calculation be retained? Default: False.
-#            If True, the second return value of the method will be a list of `poppy.Wavefront` objects
-#            representing intermediate optical planes from the calculation.
-#        retain_final : bool
-#            Should the final complex wavefront be retained? Default: False.
-#            If True, the second return value of the method will be a single element list
-#            (for consistency with retain intermediates) containing a `poppy.Wavefront` object
-#            representing the final optical plane from the calculation.
-#            Overridden by retain_intermediates.
-#        Returns
-#        -------
-#        final_wf : fits.HDUList
-#            The final result of the monochromatic propagation as a FITS HDUList
-#        intermediate_wfs : list
-#            A list of `poppy.Wavefront` objects representing the wavefront at intermediate optical planes.
-#            The 0th item is "before first optical plane", 1st is "after first plane and before second plane", and so on.
-#            (n.b. This will be empty if `retain_intermediates` is False and singular if retain_final is True.)
-#        """
-#        if poppy.conf.enable_speed_tests:
-#            t_start = time.time()
-
     def propagate_through(self,
                           wavefront,
                           normalize='none',
@@ -1250,7 +1206,6 @@ class FresnelOpticalSystem(OpticalSystem):
             return wavefront, intermediate_wfs
         else:
             return wavefront
-
 
     def describe(self):
         """ Print out a string table describing all planes in an optical system"""

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -978,9 +978,10 @@ class FresnelWavefront(BaseWavefront):
     def from_wavefront(cls, wavefront):
         """Convert a Fraunhofer type wavefront object to a Fresnel one
 
-		Note, this function implicitly assumes this wavefront is at a
-		pupil plane, so the Fraunhofer wavefront can have pixelscale
-		in meters/pix rather than arcsec/pix.
+        Note, for now this function only works if the input wavefront is at a
+        pupil plane, so the Fraunhofer wavefront has pixelscale
+        in meters/pix rather than arcsec/pix. Conversion from
+        image planes may be added later.
 
         Parameters
         ----------
@@ -990,6 +991,11 @@ class FresnelWavefront(BaseWavefront):
         """
         # Generate a Fresnel wavefront with the same sampling
         wf = wavefront
+
+        if wf.planetype==PlaneType.image:
+            raise NotImplementedError("Conversion from image planes to Fresnel is not yet implemented.")
+
+
         if wf.ispadded:
             beam_radius = wf.wavefront.shape[0]/wf.oversample/2 *wf.pixelscale*u.pixel
         else:

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -5,7 +5,7 @@ import logging
 import time
 
 import poppy
-from poppy.poppy_core import PlaneType, OpticalSystem, Wavefront, BaseWavefront
+from poppy.poppy_core import PlaneType, Wavefront, BaseWavefront, BaseOpticalSystem
 from . import utils
 from . import accel_math
 if accel_math._USE_NUMEXPR:
@@ -1017,29 +1017,8 @@ class FresnelWavefront(BaseWavefront):
 
         return new_wf
 
-        if wf.ispadded:
-            beam_radius = wf.wavefront.shape[0]/wf.oversample/2 *wf.pixelscale*u.pixel
-        else:
-            beam_radius = wf.wavefront.shape[0]/2 *wf.pixelscale*u.pixel
-        new_wf = FresnelWavefront(beam_radius=beam_radius,
-                                  npix=wf.shape[0],
-                                  oversample=wf.oversample,
-                                  wavelength=wf.wavelength)
-        # Deal with metadata
-        new_wf.history = wf.history.copy()
-        new_wf.history.append("Converted to Fresnel propagation")
-        new_wf.history.append("  Fresnel array pixel scale = {:.4g}, oversample = {}".format(new_wf.pixelscale, new_wf.oversample))
-        # Copy over the contents of the array
-        new_wf.wavefront = utils.pad_to_size(wf.wavefront, new_wf.shape)
-        # Copy over misc internal info
-        if hasattr(wf, '_display_hint_expected_nplanes'):
-            new_wf._display_hint_expected_nplanes = wf._display_hint_expected_nplanes
-        new_wf.current_plane_index = wf.current_plane_index
-        new_wf.location = wf.location
 
-        return new_wf
-
-class FresnelOpticalSystem(OpticalSystem):
+class FresnelOpticalSystem(BaseOpticalSystem):
     """ Class representing a series of optical elements,
     through which light can be propagated using the Fresnel formalism.
 
@@ -1073,12 +1052,6 @@ class FresnelOpticalSystem(OpticalSystem):
         self.npix = npix
 
         self.distances = []  # distance along the optical axis to each successive optic
-
-    def add_pupil(self, *args, **kwargs):
-        raise NotImplementedError('Use add_optic for Fresnel instead')
-
-    def add_image(self, *args, **kwargs):
-        raise NotImplementedError('Use add_optic for Fresnel instead')
 
     @u.quantity_input(distance=u.m)
     def add_optic(self, optic=None, distance=0.0 * u.m):

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1125,16 +1125,18 @@ class FresnelOpticalSystem(OpticalSystem):
         inwave._display_hint_expected_nplanes = len(self)     # For displaying a multi-step calculation nicely
         return inwave
 
-    def propagate_through(self,
-                          wavefront,
-                          normalize='none',
-                          return_intermediates=False,
-                          display_intermediates=False):
+    def propagate(self,
+                  wavefront,
+                  normalize='none',
+                  return_intermediates=False,
+                  display_intermediates=False):
+        """ Core low-level routine for propagating a wavefront through an optical system
 
+        See docstring of OpticalSystem.propagate for details
 
+        """
         intermediate_wfs = []
 
-        # note: 0 is 'before first optical plane; 1 = 'after first plane and before second plane' and so on
         for optic, distance in zip(self.planes, self.distances):
             # The actual propagation:
             wavefront.propagate_to(optic, distance)
@@ -1169,16 +1171,8 @@ class FresnelOpticalSystem(OpticalSystem):
             if display_intermediates:
                 if poppy.conf.enable_speed_tests:
                     t0 = time.time()
-                title = None if wavefront.current_plane_index > 1 else "propagating $\lambda=${}".format(wavefront.wavelength.to(u.micron))
-                display_what = getattr(optic, 'wavefront_display_hint', 'best')
-                display_vmax = getattr(optic, 'wavefront_display_vmax_hint', None)
-                display_vmin = getattr(optic, 'wavefront_display_vmin_hint', None)
-                display_nrows = getattr(wavefront, '_display_hint_expected_nplanes', len(self))
 
-                ax = wavefront.display(what=display_what,
-                                       row=None,
-                                       nrows=display_nrows,
-                                       colorbar=False, vmax=display_vmax, vmin=display_vmin)
+                ax = wavefront._display_after_optic(optic)
 
                 if poppy.conf.enable_speed_tests:
                     t1 = time.time()

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -722,7 +722,7 @@ class Instrument(object):
             old_no_sam = None
         # Trigger config validation to update any optical planes
         # (specifically auto-selected pupils based on filter selection)
-        wavelengths, _ = self._get_weights()
+        wavelengths, _ = self._get_weights(nlambda=1)
         self._validate_config(wavelengths=wavelengths)
         optsys = self._get_optical_system()
         optsys.display(what='both')

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -592,10 +592,6 @@ class Instrument(object):
 
         return optsys
 
-    def _getOpticalSystem(self, *args, **kwargs):
-        warnings.warn("_getOpticalSystem is deprecated; use _get_optical_system instead", DeprecationWarning)
-        return self._get_optical_system(*args, **kwargs)
-
     def _check_for_aliasing(self, wavelengths):
         """ Check for spatial frequency aliasing and warn if the
         user is requesting a FOV which is larger than supported based on

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -11,7 +11,7 @@ from . import utils
 from . import conf
 from . import accel_math
 from .version import version
-from .poppy_core import OpticalElement, Wavefront, PlaneType, _RADIANStoARCSEC
+from .poppy_core import OpticalElement, Wavefront, BaseWavefront, PlaneType, _RADIANStoARCSEC
 from .accel_math import _exp, _r, _float, _complex
 
 if accel_math._USE_NUMEXPR:
@@ -104,7 +104,7 @@ class AnalyticOpticalElement(OpticalElement):
             either a scalar wavelength or a Wavefront object
 
         """
-        if isinstance(wave, Wavefront):
+        if isinstance(wave, BaseWavefront):
             wavelength = wave.wavelength
         else:
             wavelength = wave
@@ -499,7 +499,7 @@ class BandLimitedCoronagraph(AnalyticImagePlaneElement):
         for pointing this out.
 
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("BLC get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype == PlaneType.image)
 
@@ -651,7 +651,7 @@ class IdealFQPM(AnalyticImagePlaneElement):
         corresponding to the supplied Wavefront
         """
 
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("4QPM get_opd must be called with a Wavefront to define the spacing")
         assert (wave.planetype == PlaneType.image)
 
@@ -698,7 +698,7 @@ class CircularPhaseMask(AnalyticImagePlaneElement):
         corresponding to the supplied Wavefront
         """
 
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("get_opd must be called with a Wavefront to define the spacing")
         assert (wave.planetype == PlaneType.image)
 
@@ -741,7 +741,7 @@ class RectangularFieldStop(AnalyticImagePlaneElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the field stop.
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("IdealFieldStop get_transmission must be called with a Wavefront "
                              "to define the spacing")
         assert (wave.planetype == PlaneType.image)
@@ -833,7 +833,7 @@ class HexagonFieldStop(AnalyticImagePlaneElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("HexagonFieldStop get_transmission must be called with a Wavefront "
                              "to define the spacing")
         assert (wave.planetype == PlaneType.image)
@@ -889,7 +889,7 @@ class AnnularFieldStop(AnalyticImagePlaneElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the field stop.
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype == PlaneType.image)
 
@@ -952,7 +952,7 @@ class BarOcculter(AnalyticImagePlaneElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype == PlaneType.image)
 
@@ -1002,7 +1002,7 @@ class FQPM_FFT_aligner(AnalyticOpticalElement):
         the 4 central pixels, not on the central pixel itself.
         """
 
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("FQPM get_opd must be called with a Wavefront to define the spacing")
         assert wave.planetype != PlaneType.image, "This optic does not work on image planes"
 
@@ -1051,7 +1051,7 @@ class ParityTestAperture(AnalyticOpticalElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("CircularAperture get_opd must be called with a Wavefront "
                              "to define the spacing")
         assert (wave.planetype != PlaneType.image)
@@ -1111,7 +1111,7 @@ class CircularAperture(AnalyticOpticalElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the aperture.
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("CircularAperture get_transmission must be called with a Wavefront "
                              "to define the spacing")
         assert (wave.planetype != PlaneType.image)
@@ -1177,7 +1177,7 @@ class HexagonAperture(AnalyticOpticalElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("HexagonAperture get_transmission must be called with a Wavefront "
                              "to define the spacing")
         assert (wave.planetype != PlaneType.image)
@@ -1377,7 +1377,7 @@ class MultiHexagonAperture(AnalyticOpticalElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
-        if not isinstance(wave, Wavefront):
+        if not isinstance(wave, BaseWavefront):
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != PlaneType.image)
 
@@ -1447,7 +1447,7 @@ class NgonAperture(AnalyticOpticalElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != PlaneType.image)
         y, x = self.get_coordinates(wave)
@@ -1497,7 +1497,7 @@ class RectangleAperture(AnalyticOpticalElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the occulter.
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != PlaneType.image)
 
@@ -1588,7 +1588,7 @@ class SecondaryObscuration(AnalyticOpticalElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the obscuration
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != PlaneType.image)
 
@@ -1662,7 +1662,7 @@ class AsymmetricSecondaryObscuration(SecondaryObscuration):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the obscuration
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         assert (wave.planetype != PlaneType.image)
 
@@ -1793,7 +1793,7 @@ class GaussianAperture(AnalyticOpticalElement):
     def get_transmission(self, wave):
         """ Compute the transmission inside/outside of the aperture.
         """
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         y, x = self.get_coordinates(wave)
 
@@ -1823,7 +1823,7 @@ class KnifeEdge(AnalyticOpticalElement):
         AnalyticOpticalElement.__init__(self, name=name, rotation=rotation, **kwargs)
 
     def get_transmission(self, wave):
-        if not isinstance(wave, Wavefront):  # pragma: no cover
+        if not isinstance(wave, BaseWavefront):  # pragma: no cover
             raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
         y, x = self.get_coordinates(wave)
         return x < 0

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -129,14 +129,14 @@ class BaseWavefront(ABC):
             dtype = _complex()
         self.wavefront = np.ones((npix, npix), dtype=dtype)  # the actual complex wavefront array
         self.ispadded = False  # is the wavefront padded for oversampling?
-        self.history = []  # List of strings giving a descriptive history of actions
-                           # performed on the wavefront. Saved to FITS headers.
+        self.history = []   # List of strings giving a descriptive history of actions
+                            # performed on the wavefront. Saved to FITS headers.
         self.history.append("Created wavefront: wavelength={0}, diam={1}".format(self.wavelength, self.diam))
         self.history.append(" using array size %s" % (self.wavefront.shape,))
-        self.location = 'Entrance Pupil' # Descriptive string for where a wavefront is instantaneously located.
-                                         # Used mostly for titling displayed plots.
+        self.location = 'Entrance Pupil'    # Descriptive string for where a wavefront is instantaneously located.
+                                            # Used mostly for titling displayed plots.
 
-        self.current_plane_index = 0 # For tracking stages in a calculation
+        self.current_plane_index = 0  # For tracking stages in a calculation
 
         accel_math.update_math_settings()                   # ensure optimal propagation based on user settings
 
@@ -179,7 +179,8 @@ class BaseWavefront(ABC):
         phasor = optic.get_phasor(self)
 
         if not np.isscalar(phasor) and phasor.size > 1:
-            assert self.wavefront.shape == phasor.shape, "Phasor shape {} does not match wavefront shape {}".format(phasor.shape, self.wavefront.shape)
+            assert self.wavefront.shape == phasor.shape, "Phasor shape {} does not match wavefront shape {}".format(
+                phasor.shape, self.wavefront.shape)
 
         self.wavefront *= phasor
         msg = "  Multiplied WF by phasor for " + str(optic)
@@ -666,15 +667,15 @@ class BaseWavefront(ABC):
 
         pixscale_ratio = (self.pixelscale / detector.pixelscale).decompose().value
         _log.info("Resampling wavefront to detector with {} pixels and {}. Zoom factor is {:.5f}".format(
-            detector.shape, detector.pixelscale, pixscale_ratio ))
+            detector.shape, detector.pixelscale, pixscale_ratio))
 
         _log.debug("Wavefront pixel scale:        {:.3f}".format(self.pixelscale.to(detector.pixelscale.unit)))
         _log.debug("Desired detector pixel scale: {:.3f}".format(detector.pixelscale))
         _log.debug("Wavefront FOV:        {} pixels, {:.3f}".format(self.shape,
-                                                                self.shape[0]*u.pixel*self.pixelscale.to(
+                                                                    self.shape[0]*u.pixel*self.pixelscale.to(
                                                                     detector.pixelscale.unit)))
         _log.debug("Desired detector FOV: {} pixels, {:.3f}".format(detector.shape,
-                                                                detector.shape[0]*u.pixel*detector.pixelscale))
+                                                                    detector.shape[0]*u.pixel*detector.pixelscale))
 
         # TODO the following works but is not optimal for performance
         # We should consider cropping out an appropriate subregion prior to performing the zoom.
@@ -860,7 +861,8 @@ class Wavefront(BaseWavefront):
         Transformations between pupil and detector planes use MFT or inverse MFT.
         Transformations between pupil and other (non-detector) image planes use FFT or inverse FFT, unless
         explicitly tagged to use MFT via a propagation hint.
-        Transformations from any frame through a rotation or coordinate transform plane simply transform the wavefront accordingly.
+        Transformations from any frame through a rotation or coordinate transform plane simply transform the
+        wavefront accordingly.
 
         Parameters
         -----------
@@ -886,11 +888,11 @@ class Wavefront(BaseWavefront):
         elif optic.planetype == PlaneType.inversion:  # invert coordinates
             self.invert(axis=optic.axis)
             self.location = 'after ' + optic.name
-        elif ((optic.planetype == PlaneType.detector or getattr(optic, 'propagation_hint', None)=='MFT')
+        elif ((optic.planetype == PlaneType.detector or getattr(optic, 'propagation_hint', None) == 'MFT')
                 and self.planetype == PlaneType.pupil):  # from pupil to detector in image plane: use MFT
             self._propagate_mft(optic)
             self.location = 'before ' + optic.name
-        elif (optic.planetype == PlaneType.pupil and self.planetype == PlaneType.image and \
+        elif (optic.planetype == PlaneType.pupil and self.planetype == PlaneType.image and
                 self._last_transform_type == 'MFT'):
             # inverse MFT detector to pupil
             # n.b. transforming PlaneType.pupil -> PlaneType.detector results in self.planetype == PlaneType.image
@@ -922,7 +924,7 @@ class Wavefront(BaseWavefront):
                 _log.debug("    Padded WF array for oversampling by %dx" % self.oversample)
             self.history.append("    Padded WF array for oversampling by %dx" % self.oversample)
 
-       # Set up for computation - figure out direction & normalization
+        # Set up for computation - figure out direction & normalization
         if self.planetype == PlaneType.pupil and optic.planetype == PlaneType.image:
             fft_forward = True
 
@@ -971,7 +973,7 @@ class Wavefront(BaseWavefront):
 
         assert self.planetype == PlaneType.pupil
         assert (det.planetype == PlaneType.detector or
-                getattr(det, 'propagation_hint', None)=='MFT')
+                getattr(det, 'propagation_hint', None) == 'MFT')
 
         if self.ispadded:
             # pupil plane is padded - trim that out since it's not needed
@@ -1187,7 +1189,6 @@ class Wavefront(BaseWavefront):
         else:
             raise RuntimeError("Unknown plane type (should be pupil or image!)")
 
-
     @classmethod
     def from_fresnel_wavefront(cls, fresnel_wavefront, verbose=False):
         """Convert a Fresnel type wavefront object to a Fraunhofer one
@@ -1204,7 +1205,7 @@ class Wavefront(BaseWavefront):
         """
         # Generate a Fraunhofer wavefront with the same sampling
         wf = fresnel_wavefront
-        beam_diam = (wf.wavefront.shape[0]//wf.oversample) *wf.pixelscale*u.pixel
+        beam_diam = (wf.wavefront.shape[0]//wf.oversample) * wf.pixelscale*u.pixel
         new_wf = Wavefront(diam=beam_diam,
                            npix=wf.shape[0]//wf.oversample,
                            oversample=wf.oversample,
@@ -1226,6 +1227,7 @@ class Wavefront(BaseWavefront):
         return new_wf
 
 # ------ core Optical System classes -------
+
 
 class BaseOpticalSystem(ABC):
     """ Abstract Base class for optical systems
@@ -1442,7 +1444,7 @@ class BaseOpticalSystem(ABC):
         # loop over wavelengths
         if self.verbose:
             _log.info("Calculating PSF with %d wavelengths" % (len(wavelength)))
-        outFITS = None
+        outfits = None
         intermediate_wfs = None
         if save_intermediates or return_intermediates:
             _log.info("User requested saving intermediate wavefronts in call to poppy.calc_psf")
@@ -1460,25 +1462,23 @@ class BaseOpticalSystem(ABC):
         if conf.use_multiprocessing and len(wavelength) > 1:  # ######## Parallellized computation ############
             # Avoid a Mac OS incompatibility that can lead to hard-to-reproduce crashes.
             # see issues #23 and #176
-            import sys
-            import platform
 
             if _USE_FFTW:
                 _log.warning('IMPORTANT WARNING: Python multiprocessing and fftw3 do not appear to play well together. '
-                                'This may crash intermittently')
+                             'This may crash intermittently')
                 _log.warning('   We suggest you set poppy.conf.use_fftw to False if you want to use multiprocessing().')
             if display:
                 _log.warning('Display during calculations is not supported for multiprocessing mode. '
-                                'Please set poppy.conf.use_multiprocessing = False if you want to use display=True.')
+                             'Please set poppy.conf.use_multiprocessing = False if you want to use display=True.')
                 _log.warning('(Plot the returned PSF with poppy.utils.display_psf.)')
 
             if return_intermediates:
                 _log.warning('Memory usage warning: When preserving intermediate  planes in multiprocessing mode, '
-                                'memory usage scales with the number of planes times number of wavelengths. Disable '
-                                'use_multiprocessing if you are running out of memory.')
+                             'memory usage scales with the number of planes times number of wavelengths. Disable '
+                             'use_multiprocessing if you are running out of memory.')
             if save_intermediates:
                 _log.warning('Saving intermediate steps does not take advantage of multiprocess parallelism. '
-                                'Set save_intermediates=False for improved speed.')
+                             'Set save_intermediates=False for improved speed.')
 
             # do *NOT* just blindly try to create as many processes as one has CPUs, or one per wavelength either
             # This is a memory-intensive task so that can end up swapping to disk and thrashing IO
@@ -1501,8 +1501,8 @@ class BaseOpticalSystem(ABC):
             pool.close()
 
             # Sum all the results up into one array, using the weights
-            outFITS, intermediate_wfs = results[0]
-            outFITS[0].data *= normwts[0]
+            outfits, intermediate_wfs = results[0]
+            outfits[0].data *= normwts[0]
             for idx, wavefront in enumerate(intermediate_wfs):
                 intermediate_wfs[idx] *= normwts[0]
             _log.info("got results for wavelength channel {} / {} ({:g} meters)".format(
@@ -1512,10 +1512,10 @@ class BaseOpticalSystem(ABC):
                 wave_weight = normwts[i]
                 _log.info("got results for wavelength channel {} / {} ({:g} meters)".format(
                     i, len(tuple(wavelength)), wavelength[i]))
-                outFITS[0].data += mono_psf[0].data * wave_weight
+                outfits[0].data += mono_psf[0].data * wave_weight
                 for idx, wavefront in enumerate(mono_intermediate_wfs):
                     intermediate_wfs[idx] += wavefront * wave_weight
-            outFITS[0].header.add_history("Multiwavelength PSF calc using {} processes completed.".format(nproc))
+            outfits[0].header.add_history("Multiwavelength PSF calc using {} processes completed.".format(nproc))
 
         else:  # ######### single-threaded computations (may still use multi cores if FFTW enabled ######
             if display:
@@ -1529,16 +1529,16 @@ class BaseOpticalSystem(ABC):
                     normalize=normalize
                 )
 
-                if outFITS is None:
+                if outfits is None:
                     # for the first wavelength processed, set up the arrays where we accumulate the output
-                    outFITS = mono_psf
-                    outFITS[0].data *= wave_weight
+                    outfits = mono_psf
+                    outfits[0].data *= wave_weight
                     intermediate_wfs = mono_intermediate_wfs
                     for wavefront in intermediate_wfs:
                         wavefront *= wave_weight  # modifies Wavefront in-place
                 else:
                     # for subsequent wavelengths, scale and add the data to the existing arrays
-                    outFITS[0].data += mono_psf[0].data * wave_weight
+                    outfits[0].data += mono_psf[0].data * wave_weight
                     for idx, wavefront in enumerate(mono_intermediate_wfs):
                         intermediate_wfs[idx] += wavefront * wave_weight
 
@@ -1547,16 +1547,16 @@ class BaseOpticalSystem(ABC):
             if display and not display_intermediates:
                 cmap = getattr(matplotlib.cm, conf.cmap_sequential)
                 cmap.set_bad('0.3')
-                halffov_x = outFITS[0].header['PIXELSCL'] * outFITS[0].data.shape[1] / 2
-                halffov_y = outFITS[0].header['PIXELSCL'] * outFITS[0].data.shape[0] / 2
+                halffov_x = outfits[0].header['PIXELSCL'] * outfits[0].data.shape[1] / 2
+                halffov_y = outfits[0].header['PIXELSCL'] * outfits[0].data.shape[0] / 2
                 extent = [-halffov_x, halffov_x, -halffov_y, halffov_y]
                 unit = "arcsec"
-                vmax = outFITS[0].data.max()
+                vmax = outfits[0].data.max()
                 vmin = vmax / 1e4
                 norm = matplotlib.colors.LogNorm(vmin=vmin, vmax=vmax)  # vmin=1e-8,vmax=1e-1)
                 plt.xlabel(unit)
 
-                utils.imshow_with_mouseover(outFITS[0].data, extent=extent, norm=norm, cmap=cmap,
+                utils.imshow_with_mouseover(outfits[0].data, extent=extent, norm=norm, cmap=cmap,
                                             origin='lower')
 
         if save_intermediates:
@@ -1570,7 +1570,7 @@ class BaseOpticalSystem(ABC):
         tstop = time.time()
         tdelta = tstop - tstart
         _log.info("  Calculation completed in {0:.3f} s".format(tdelta))
-        outFITS[0].header.add_history("Calculation completed in {0:.3f} seconds".format(tdelta))
+        outfits[0].header.add_history("Calculation completed in {0:.3f} seconds".format(tdelta))
 
         if _USE_FFTW and conf.autosave_fftw_wisdom:
             utils.fftw_save_wisdom()
@@ -1579,23 +1579,24 @@ class BaseOpticalSystem(ABC):
         waves = np.asarray(wavelength)
         wts = np.asarray(weight)
         mnwave = (waves * wts).sum() / wts.sum()
-        outFITS[0].header['WAVELEN'] = (mnwave, 'Weighted mean wavelength in meters')
-        outFITS[0].header['NWAVES'] = (waves.size, 'Number of wavelengths used in calculation')
+        outfits[0].header['WAVELEN'] = (mnwave, 'Weighted mean wavelength in meters')
+        outfits[0].header['NWAVES'] = (waves.size, 'Number of wavelengths used in calculation')
         for i in range(waves.size):
-            outFITS[0].header['WAVE' + str(i)] = (waves[i], "Wavelength " + str(i))
-            outFITS[0].header['WGHT' + str(i)] = (wts[i], "Wavelength weight " + str(i))
+            outfits[0].header['WAVE' + str(i)] = (waves[i], "Wavelength " + str(i))
+            outfits[0].header['WGHT' + str(i)] = (wts[i], "Wavelength weight " + str(i))
         ffttype = "pyFFTW" if _USE_FFTW else "numpy.fft"
-        outFITS[0].header['FFTTYPE'] = (ffttype, 'Algorithm for FFTs: numpy or fftw')
-        outFITS[0].header['NORMALIZ'] = (normalize, 'PSF normalization method')
+        outfits[0].header['FFTTYPE'] = (ffttype, 'Algorithm for FFTs: numpy or fftw')
+        outfits[0].header['NORMALIZ'] = (normalize, 'PSF normalization method')
 
         if self.verbose:
             _log.info("PSF Calculation completed.")
 
         if return_intermediates | return_final:
-            return outFITS, intermediate_wfs
+            return outfits, intermediate_wfs
 
         else:
-            return outFITS
+            return outfits
+
     @utils.quantity_input(wavelength=u.meter)
     def propagate_mono(self,
                        wavelength=1e-6 * u.meter,
@@ -1679,7 +1680,6 @@ class BaseOpticalSystem(ABC):
         for i, plane in enumerate(planes_to_display):
             _log.info("Displaying plane {0:s} in row {1:d} of {2:d}".format(plane.name, i + 1, nplanes))
             plane.display(nrows=nplanes, row=i + 1, **kwargs)
-
 
 
 class OpticalSystem(BaseOpticalSystem):
@@ -1898,14 +1898,14 @@ class OpticalSystem(BaseOpticalSystem):
         if len(self.planes) > 0:
             if npix is None:
                 if self.planes[0].shape is not None:
-                    npix=self.planes[0].shape[0]
+                    npix = self.planes[0].shape[0]
             if diam is None:
                 if hasattr(self.planes[0], 'pupil_diam') and self.planes[0].pupil_diam is not None:
                     diam = self.planes[0].pupil_diam
 
         if npix is None:
             _log.info("You did not define npix either on the OpticalSystem or its first optic; defaulting to 1024 pixels.")
-            npix=1024
+            npix = 1024
         if diam is None:
             raise RuntimeError("You must define an entrance pupil diameter either on the OpticalSystem or its first optic.")
 
@@ -1944,9 +1944,9 @@ class OpticalSystem(BaseOpticalSystem):
             offset_y = sign_y * self.source_offset_r * np.cos(angle)
             inwave.tilt(Xangle=offset_x, Yangle=offset_y)
             _log.debug("Tilted input wavefront by theta_X=%f, theta_Y=%f arcsec. (signs=%d, %d; theta offset=%f) " % (
-            offset_x, offset_y, sign_x, sign_y, rotation_angle))
+                       offset_x, offset_y, sign_x, sign_y, rotation_angle))
 
-        inwave._display_hint_expected_nplanes = len(self) # For display of intermediate steps nicely
+        inwave._display_hint_expected_nplanes = len(self)  # For display of intermediate steps nicely
         return inwave
 
     def propagate(self,
@@ -2076,7 +2076,7 @@ class CompoundOpticalSystem(OpticalSystem):
         # validate the input optical systems make sense
         if optsyslist is None:
             raise ValueError("Missing required optsyslist argument to CompoundOpticalSystem")
-        elif len(optsyslist)==0:
+        elif len(optsyslist) == 0:
             raise ValueError("The provided optsyslist argument is an empty list. Must contain at least 1 optical system.")
         for item in optsyslist:
             if not isinstance(item, BaseOpticalSystem):
@@ -2084,7 +2084,7 @@ class CompoundOpticalSystem(OpticalSystem):
 
         if name is None:
             name = "CompoundOpticalSystem containing {} systems".format(len(optsyslist))
-        super(CompoundOpticalSystem,self).__init__(name=name,  **kwargs)
+        super(CompoundOpticalSystem, self).__init__(name=name,  **kwargs)
 
         self.optsyslist = optsyslist
 
@@ -2094,7 +2094,7 @@ class CompoundOpticalSystem(OpticalSystem):
 
     def __len__(self):
         # The length of a compound optical system is the sum of the lengths of the individual systems
-        return np.sum(  [len(optsys) for optsys in self.optsyslist])
+        return np.sum([len(optsys) for optsys in self.optsyslist])
 
     @utils.quantity_input(wavelength=u.meter)
     def input_wavefront(self, wavelength=1e-6 * u.meter):
@@ -2128,11 +2128,10 @@ class CompoundOpticalSystem(OpticalSystem):
             _log.debug(msg)
             wavefront.history.append(msg)
 
-
         for i, optsys in enumerate(self.optsyslist):
             # If necessary, convert wavefront type.
             if (isinstance(optsys, FresnelOpticalSystem) and
-                not isinstance(wavefront, FresnelWavefront)):
+               not isinstance(wavefront, FresnelWavefront)):
                 wavefront = FresnelWavefront.from_wavefront(wavefront)
                 loghistory(wavefront, "CompoundOpticalSystem: Converted wavefront to Fresnel type")
             elif (not isinstance(optsys, FresnelOpticalSystem) and
@@ -2160,8 +2159,9 @@ class CompoundOpticalSystem(OpticalSystem):
             return wavefront
 
 
-
 # ------ core Optical Element Classes ------
+
+
 class OpticalElement(object):
     """ Base class for all optical elements, whether from FITS files or analytic functions.
 
@@ -2270,7 +2270,8 @@ class OpticalElement(object):
         float_tolerance = 0.001  # how big of a relative scale mismatch before resampling?
         if self.pixelscale is not None and hasattr(wave, 'pixelscale') and abs(
                 wave.pixelscale - self.pixelscale) / self.pixelscale >= float_tolerance:
-            _log.debug("Non-matching pixel scales for wavefront and optic. Need to interpolate. Pixelscales: wave {}, optic {}".format(wave.pixelscale, self.pixelscale))
+            _log.debug("Non-matching pixel scales for wavefront and optic. Need to interpolate. "
+                       "Pixelscales: wave {}, optic {}".format(wave.pixelscale, self.pixelscale))
             if hasattr(self, '_resampled_scale') and abs(
                     self._resampled_scale - wave.pixelscale) / self._resampled_scale >= float_tolerance:
                 # we already did this same resampling, so just re-use it!
@@ -2284,7 +2285,7 @@ class OpticalElement(object):
                 resampled_amplitude = scipy.ndimage.interpolation.zoom(self.amplitude, zoom,
                                                                        output=self.amplitude.dtype,
                                                                        order=self.interp_order)
-                _log.debug("resampled optic to match wavefront via spline interpolation by a"+
+                _log.debug("resampled optic to match wavefront via spline interpolation by a" +
                            " zoom factor of {:.3g}".format(zoom))
                 _log.debug("resampled optic shape: {}   wavefront shape: {}".format(resampled_amplitude.shape,
                                                                                     wave.shape))
@@ -2296,8 +2297,9 @@ class OpticalElement(object):
                 border_y = np.abs(ly - ly_w) // 2
                 if (self.pixelscale * self.amplitude.shape[0] < wave.pixelscale * wave.amplitude.shape[0]) or (
                         self.pixelscale * self.amplitude.shape[1] < wave.pixelscale * wave.amplitude.shape[0]):
-                    _log.warning("After resampling, optic phasor shape " + str(np.shape(resampled_opd)) + " is smaller than input wavefront " + str(
-                        (lx_w, ly_w)) + "; will zero-pad the rescaled array.")
+                    _log.warning("After resampling, optic phasor shape " + str(np.shape(resampled_opd)) +
+                                 " is smaller than input wavefront " + str(
+                                 (lx_w, ly_w)) + "; will zero-pad the rescaled array.")
                     self._resampled_opd = np.zeros([lx_w, ly_w])
                     self._resampled_amplitude = np.zeros([lx_w, ly_w])
 
@@ -2764,11 +2766,11 @@ class FITSOpticalElement(OpticalElement):
             if rotation is not None and len(self.amplitude.shape) == 2:
                 # do rotation with interpolation, but try to clean up some of the artifacts afterwards.
                 # this is imperfect at best, of course...
-                self.amplitude = scipy.ndimage.interpolation.rotate(self.amplitude, -rotation, #negative = CCW
+                self.amplitude = scipy.ndimage.interpolation.rotate(self.amplitude, -rotation,  # negative = CCW
                                                                     reshape=False).clip(min=0, max=1.0)
                 wnoise = np.where((self.amplitude < 1e-3) & (self.amplitude > 0))
                 self.amplitude[wnoise] = 0
-                self.opd = scipy.ndimage.interpolation.rotate(self.opd, -rotation, reshape=False) # negative = CCW
+                self.opd = scipy.ndimage.interpolation.rotate(self.opd, -rotation, reshape=False)  # negative = CCW
                 _log.info("  Rotated optic by %f degrees counter clockwise." % rotation)
                 self._rotation = rotation
 
@@ -2843,7 +2845,6 @@ class FITSOpticalElement(OpticalElement):
             else:  # pupil or any other types of plane
                 self.pixelscale *= u.meter / u.pixel
 
-
             # ---- transformation: shift ----
             # if a shift is specified and we're NOT a null (scalar) optic, then do the shift
             # This has to happen after the pixelscale has been determined, for the shift_x/shift_y path.
@@ -2865,8 +2866,8 @@ class FITSOpticalElement(OpticalElement):
                         raise ValueError("You have asked for an implausibly large shift. Remember, "
                                          "shifts should be specified as decimal values between -0.5 and 0.5, "
                                          "a fraction of the total optic diameter. ")
-                    rolly = int(np.round(self.amplitude.shape[0] * shift[1]))  # remember Y,X order for shape,
-                                                                               # but X,Y order for shift
+                    rolly = int(np.round(self.amplitude.shape[0] * shift[1]))   # remember Y,X order for shape,
+                                                                                # but X,Y order for shift
                     rollx = int(np.round(self.amplitude.shape[1] * shift[0]))
                     _log.info("Requested optic shift of ({:6.3f}, {:6.3f}) fraction of pupil ".format(*shift))
                     _log.info("Actual shift applied   = (%6.3f, %6.3f) " % (
@@ -2875,7 +2876,6 @@ class FITSOpticalElement(OpticalElement):
 
                 self.amplitude = scipy.ndimage.shift(self.amplitude, (rolly, rollx))
                 self.opd = scipy.ndimage.shift(self.opd, (rolly, rollx))
-
 
     @property
     def pupil_diam(self):

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -452,7 +452,7 @@ class BaseWavefront(object):
         norm_phase = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)
 
         def wrap_lines_title(title):
-            # Helper fn to add line breaks in plot titles, 
+            # Helper fn to add line breaks in plot titles,
             # tweaked to put in particular places for aesthetics
             for prep in ['after', 'before']:
                 if prep in title:
@@ -799,9 +799,6 @@ class BaseWavefront(object):
         # - number of pixels on a side in focal plane array.
 
         # Try to transform to whatever the intrinsic scale of the next pupil is.
-        # If it has a 
-
-        # try to transform to whatever the intrinsic scale of the next pupil is.
         # but if this ends up being a scalar (meaning it is an AnalyticOptic) then
         # just go back to our own prior shape and pixel scale.
         if pupil_npix is None:
@@ -1110,7 +1107,7 @@ class BaseWavefront(object):
         new_wf.history.append("  Fraunhofer array pixel scale = {:.4g}, oversample = {}".format(new_wf.pixelscale, new_wf.oversample))
         # Copy over the contents of the array
         new_wf.wavefront = utils.pad_or_crop_to_shape(wf.wavefront, new_wf.shape)
-        # Copy over misc internal info 
+        # Copy over misc internal info
         if hasattr(wf, '_display_hint_expected_nplanes'):
             new_wf._display_hint_expected_nplanes = wf._display_hint_expected_nplanes
 

--- a/poppy/special_prop.py
+++ b/poppy/special_prop.py
@@ -89,12 +89,15 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
                                                     fov_arcsec=self.occulter_box * 2,
                                                     name='Oversampled Occulter Plane')
 
-    def propagate_through(self,
-                          wavefront,
-                          normalize='none',
-                          return_intermediates=False,
-                          display_intermediates=False):
-        """ Experimental work-in-progress refactoring of propagate_mono
+    def propagate(self,
+                  wavefront,
+                  normalize='none',
+                  return_intermediates=False,
+                  display_intermediates=False):
+        """ Core low-level routine for propagating a wavefront through an optical system
+
+        See docstring of OpticalSystem.propagate for details
+
         """
 
         if self.verbose:
@@ -127,24 +130,8 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
 
             if return_intermediates:  # save intermediate wavefront, summed for polychromatic if needed
                 intermediate_wfs.append(wavefront.copy())
-
             if display_intermediates:
-                if hasattr(optic, 'wavefront_display_hint'):
-                    display_what = optic.wavefront_display_hint
-                else:
-                    display_what = 'best'
-                if hasattr(optic, 'wavefront_display_vmax_hint'):
-                    display_vmax = optic.wavefront_display_vmax_hint
-                else:
-                    display_vmax = None
-                if hasattr(optic, 'wavefront_display_vmin_hint'):
-                    display_vmin = optic.wavefront_display_vmin_hint
-                else:
-                    display_vmin = None
-
-                wavefront.display(what=display_what, nrows=nrows, row=None,
-                                  colorbar=False, vmax=display_vmax, vmin=display_vmin)
-
+                wavefront._display_after_optic(optic, default_nplanes=nrows)
 
         # SAMC step 2: propagate to detector via MFT at high res.
 
@@ -157,7 +144,7 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
             intermediate_wfs.append(wavefront_cor.copy())
 
         if display_intermediates:  # Display prior to the occulter
-            wavefront_cor.display(what='best', nrows=nrows, row=None, colorbar=False)
+            wavefront_cor._display_after_optic(self.occulter_highres, default_nplanes=nrows)
 
         # Multiply that by M(r) =  1 - the occulting plane mask function
         wavefront_cor *= self.mask_function
@@ -166,7 +153,8 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
             intermediate_wfs.append(wavefront_cor.copy())
 
         if display_intermediates:  # Display after the occulter (EXTRA PLANE)
-            wavefront_cor.display(what='intensity', nrows=nrows, row=None, colorbar=False)
+            wavefront_cor._display_after_optic(self.occulter_highres, default_nplanes=nrows,
+                                               what='intensity')
 
         # SAMC step 3:
         # calculate the MFT from that small region back to the full Lyot plane, and
@@ -195,23 +183,8 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
 
             if return_intermediates:  # save intermediate wavefront, summed for polychromatic if needed
                 intermediate_wfs.append(wavefront.copy())
-
             if display_intermediates:
-                if hasattr(optic, 'wavefront_display_hint'):
-                    display_what = optic.wavefront_display_hint
-                else:
-                    display_what = 'best'
-                if hasattr(optic, 'wavefront_display_vmax_hint'):
-                    display_vmax = optic.wavefront_display_vmax_hint
-                else:
-                    display_vmax = None
-                if hasattr(optic, 'wavefront_display_vmin_hint'):
-                    display_vmin = optic.wavefront_display_vmin_hint
-                else:
-                    display_vmin = None
-
-                wavefront.display(what=display_what, nrows=nrows, row=None,
-                                  colorbar=False, vmax=display_vmax, vmin=display_vmin)
+                wavefront._display_after_optic(optic, default_nplanes=nrows)
 
         # ------- differences from regular propagation end here --------------
 

--- a/poppy/special_prop.py
+++ b/poppy/special_prop.py
@@ -88,49 +88,6 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
         self.occulter_highres = poppy_core.Detector(self.detector.pixelscale / self.oversample,
                                                     fov_arcsec=self.occulter_box * 2,
                                                     name='Oversampled Occulter Plane')
-#
-#    @utils.quantity_input(wavelength=u.meter)
-#    def propagate_mono(self, wavelength=1e-6 * u.meter,
-#                       normalize='first',
-#                       retain_final=False,
-#                       retain_intermediates=False,
-#                       display_intermediates=False):
-#        """Propagate a monochromatic wavefront through the optical system. Called from within `calc_psf`.
-#        Returns a tuple with a `fits.HDUList` object and a list of intermediate `Wavefront`s (empty if
-#        `retain_intermediates=False`).
-#
-#        *** This is a modified/custom version of the code in OpticalSystem.propagate_mono() ***
-#
-#        Parameters
-#        ----------
-#        wavelength : float
-#            Wavelength in meters
-#        normalize : string, {'first', 'last'}
-#            how to normalize the wavefront?
-#            * 'first' = set total flux = 1 after the first optic, presumably a pupil
-#            * 'last' = set total flux = 1 after the entire optical system.
-#        display_intermediates : bool
-#            Should intermediate steps in the calculation be displayed on screen? Default: False.
-#        retain_intermediates : bool
-#            Should intermediate steps in the calculation be retained? Default: False.
-#            If True, the second return value of the method will be a list of `poppy.Wavefront` objects
-#            representing intermediate optical planes from the calculation.
-#        retain_final : bool
-#            Should the final complex wavefront be retained? Default: False.
-#            If True, the second return value of the method will be a single element list
-#            (for consistency with retain intermediates) containing a `poppy.Wavefront` object
-#            representing the final optical plane from the calculation.
-#            Overridden by retain_intermediates.
-#        Returns
-#        -------
-#        final_wf : fits.HDUList
-#            The final result of the monochromatic propagation as a FITS HDUList
-#        intermediate_wfs : list
-#            A list of `poppy.Wavefront` objects representing the wavefront at intermediate optical planes.
-#            The 0th item is "before first plane", 1st is "after first plane and before second plane", and so on.
-#            (n.b. This will be empty if `retain_intermediates` is False and singular if retain_final is True.)
-#        """
-#        
 
     def propagate_through(self,
                           wavefront,

--- a/poppy/special_prop.py
+++ b/poppy/special_prop.py
@@ -88,54 +88,61 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
         self.occulter_highres = poppy_core.Detector(self.detector.pixelscale / self.oversample,
                                                     fov_arcsec=self.occulter_box * 2,
                                                     name='Oversampled Occulter Plane')
+#
+#    @utils.quantity_input(wavelength=u.meter)
+#    def propagate_mono(self, wavelength=1e-6 * u.meter,
+#                       normalize='first',
+#                       retain_final=False,
+#                       retain_intermediates=False,
+#                       display_intermediates=False):
+#        """Propagate a monochromatic wavefront through the optical system. Called from within `calc_psf`.
+#        Returns a tuple with a `fits.HDUList` object and a list of intermediate `Wavefront`s (empty if
+#        `retain_intermediates=False`).
+#
+#        *** This is a modified/custom version of the code in OpticalSystem.propagate_mono() ***
+#
+#        Parameters
+#        ----------
+#        wavelength : float
+#            Wavelength in meters
+#        normalize : string, {'first', 'last'}
+#            how to normalize the wavefront?
+#            * 'first' = set total flux = 1 after the first optic, presumably a pupil
+#            * 'last' = set total flux = 1 after the entire optical system.
+#        display_intermediates : bool
+#            Should intermediate steps in the calculation be displayed on screen? Default: False.
+#        retain_intermediates : bool
+#            Should intermediate steps in the calculation be retained? Default: False.
+#            If True, the second return value of the method will be a list of `poppy.Wavefront` objects
+#            representing intermediate optical planes from the calculation.
+#        retain_final : bool
+#            Should the final complex wavefront be retained? Default: False.
+#            If True, the second return value of the method will be a single element list
+#            (for consistency with retain intermediates) containing a `poppy.Wavefront` object
+#            representing the final optical plane from the calculation.
+#            Overridden by retain_intermediates.
+#        Returns
+#        -------
+#        final_wf : fits.HDUList
+#            The final result of the monochromatic propagation as a FITS HDUList
+#        intermediate_wfs : list
+#            A list of `poppy.Wavefront` objects representing the wavefront at intermediate optical planes.
+#            The 0th item is "before first plane", 1st is "after first plane and before second plane", and so on.
+#            (n.b. This will be empty if `retain_intermediates` is False and singular if retain_final is True.)
+#        """
+#        
 
-    @utils.quantity_input(wavelength=u.meter)
-    def propagate_mono(self, wavelength=1e-6 * u.meter,
-                       normalize='first',
-                       retain_final=False,
-                       retain_intermediates=False,
-                       display_intermediates=False):
-        """Propagate a monochromatic wavefront through the optical system. Called from within `calc_psf`.
-        Returns a tuple with a `fits.HDUList` object and a list of intermediate `Wavefront`s (empty if
-        `retain_intermediates=False`).
-
-        *** This is a modified/custom version of the code in OpticalSystem.propagate_mono() ***
-
-        Parameters
-        ----------
-        wavelength : float
-            Wavelength in meters
-        normalize : string, {'first', 'last'}
-            how to normalize the wavefront?
-            * 'first' = set total flux = 1 after the first optic, presumably a pupil
-            * 'last' = set total flux = 1 after the entire optical system.
-        display_intermediates : bool
-            Should intermediate steps in the calculation be displayed on screen? Default: False.
-        retain_intermediates : bool
-            Should intermediate steps in the calculation be retained? Default: False.
-            If True, the second return value of the method will be a list of `poppy.Wavefront` objects
-            representing intermediate optical planes from the calculation.
-        retain_final : bool
-            Should the final complex wavefront be retained? Default: False.
-            If True, the second return value of the method will be a single element list
-            (for consistency with retain intermediates) containing a `poppy.Wavefront` object
-            representing the final optical plane from the calculation.
-            Overridden by retain_intermediates.
-        Returns
-        -------
-        final_wf : fits.HDUList
-            The final result of the monochromatic propagation as a FITS HDUList
-        intermediate_wfs : list
-            A list of `poppy.Wavefront` objects representing the wavefront at intermediate optical planes.
-            The 0th item is "before first plane", 1st is "after first plane and before second plane", and so on.
-            (n.b. This will be empty if `retain_intermediates` is False and singular if retain_final is True.)
+    def propagate_through(self,
+                          wavefront,
+                          normalize='none',
+                          return_intermediates=False,
+                          display_intermediates=False):
+        """ Experimental work-in-progress refactoring of propagate_mono
         """
-        if conf.enable_speed_tests:
-            t_start = time.time()
+
         if self.verbose:
             _log.info(" Propagating wavelength = {0:g} meters using "
-                      "Fast Semi-Analytic Coronagraph method".format(wavelength))
-        wavefront = self.input_wavefront(wavelength)
+                      "Fast Semi-Analytic Coronagraph method".format(wavefront.wavelength))
 
         intermediate_wfs = []
 
@@ -143,7 +150,6 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
         wavefront.history.append(" for Coronagraphy (See Soummer et al. 2007).")
 
         # note: 0 is 'before first optical plane; 1 = 'after first plane and before second plane' and so on
-        current_plane_index = 0
 
         # ------- differences from regular propagation begin here --------------
 
@@ -156,13 +162,13 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
             # The actual propagation:
             wavefront.propagate_to(optic)
             wavefront *= optic
-            current_plane_index += 1
+
 
             # Normalize if appropriate:
-            if normalize.lower() == 'first' and current_plane_index == 1:  # set entrance plane to 1.
+            if normalize.lower() == 'first' and wavefront.current_plane_index == 1:  # set entrance plane to 1.
                 wavefront.normalize()
 
-            if retain_intermediates:  # save intermediate wavefront, summed for polychromatic if needed
+            if return_intermediates:  # save intermediate wavefront, summed for polychromatic if needed
                 intermediate_wfs.append(wavefront.copy())
 
             if display_intermediates:
@@ -179,12 +185,9 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
                 else:
                     display_vmin = None
 
-                wavefront.display(what=display_what, nrows=nrows, row=current_plane_index,
+                wavefront.display(what=display_what, nrows=nrows, row=None,
                                   colorbar=False, vmax=display_vmax, vmin=display_vmin)
 
-                # nrows = 6
-                # wavefront.display(what='best',nrows=nrows,row=1, colorbar=False,
-                # title="propagating $\lambda=$ {:.3f}".format(wavelength.to(u.micron)))
 
         # SAMC step 2: propagate to detector via MFT at high res.
 
@@ -193,21 +196,20 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
         # calculate the MFT to the N_B x N_B occulting region.
         wavefront_cor = wavefront.copy()
         wavefront_cor.propagate_to(self.occulter_highres)  # This will be an MFT propagation
-        current_plane_index += 1
-        if retain_intermediates:
+        if return_intermediates:
             intermediate_wfs.append(wavefront_cor.copy())
 
         if display_intermediates:  # Display prior to the occulter
-            wavefront_cor.display(what='best', nrows=nrows, row=current_plane_index, colorbar=False)
+            wavefront_cor.display(what='best', nrows=nrows, row=None, colorbar=False)
 
         # Multiply that by M(r) =  1 - the occulting plane mask function
         wavefront_cor *= self.mask_function
-        current_plane_index += 1
-        if retain_intermediates:
+        wavefront_cor.current_plane_index += 1
+        if return_intermediates:
             intermediate_wfs.append(wavefront_cor.copy())
 
         if display_intermediates:  # Display after the occulter (EXTRA PLANE)
-            wavefront_cor.display(what='intensity', nrows=nrows, row=current_plane_index, colorbar=False)
+            wavefront_cor.display(what='intensity', nrows=nrows, row=None, colorbar=False)
 
         # SAMC step 3:
         # calculate the MFT from that small region back to the full Lyot plane, and
@@ -215,27 +217,26 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
 
         wavefront_lyot = wavefront_cor.copy()
         wavefront_lyot.propagate_to(self.lyotplane)
-        current_plane_index += 1
-        if retain_intermediates:
+        if return_intermediates:
             intermediate_wfs.append(wavefront_lyot.copy())
 
         # combine that with the original pupil function
         wavefront_combined = wavefront + (-1) * wavefront_lyot
         wavefront_combined.location = 'recombined Lyot pupil'
+        wavefront_combined.current_plane_index = wavefront_lyot.current_plane_index
 
         wavefront = wavefront_combined
 
         if display_intermediates:  # Display back at Lyot (EXTRA PLANE)
-            wavefront.display(what='intensity', nrows=nrows, row=current_plane_index, colorbar=False)
+            wavefront.display(what='intensity', nrows=nrows, row=None, colorbar=False)
 
         # SAMC step 4: propagate through the rest of the optical system
         for optic in self.planes[self.fpm_index + 1:]:
             # The actual propagation:
             wavefront.propagate_to(optic)
             wavefront *= optic
-            current_plane_index += 1
 
-            if retain_intermediates:  # save intermediate wavefront, summed for polychromatic if needed
+            if return_intermediates:  # save intermediate wavefront, summed for polychromatic if needed
                 intermediate_wfs.append(wavefront.copy())
 
             if display_intermediates:
@@ -252,7 +253,7 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
                 else:
                     display_vmin = None
 
-                wavefront.display(what=display_what, nrows=nrows, row=current_plane_index,
+                wavefront.display(what=display_what, nrows=nrows, row=None,
                                   colorbar=False, vmax=display_vmax, vmin=display_vmin)
 
         # ------- differences from regular propagation end here --------------
@@ -261,14 +262,11 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
         if normalize.lower() == 'last':
             wavefront.normalize()
 
-        if conf.enable_speed_tests:
-            t_stop = time.time()
-            _log.debug("\tTIME %f s\tfor propagating one wavelength" % (t_stop - t_start))
+        if return_intermediates:
+            return wavefront, intermediate_wfs
+        else:
+            return wavefront
 
-        if (not retain_intermediates) & retain_final:  # return the full complex wavefront of the last plane.
-            intermediate_wfs = [wavefront]
-
-        return wavefront.as_fits(), intermediate_wfs
 
 
 class MatrixFTCoronagraph(poppy_core.OpticalSystem):
@@ -436,7 +434,7 @@ class MatrixFTCoronagraph(poppy_core.OpticalSystem):
                 wavefront.display(
                     what='best',
                     nrows=len(self.planes),
-                    row=current_plane_index,
+                    row=wavefront.current_plane_index,
                     colorbar=False,
                     title=title
                 )

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -506,3 +506,36 @@ def test_Detector_pixelscale_units():
         assert _exception_message_starts_with(excinfo, "Argument 'fov_pixels' to function"), \
             "Error message not as expected"
 
+
+# Tests for CompoundOpticalSystem
+
+
+def test_CompoundOpticalSystem():
+    """ Verify basic functionality of concatenating optical systems
+    """
+    opt1 = poppy.SquareAperture()
+    opt2 = poppy.CircularAperture(radius=0.55)
+
+    # a single optical system
+    osys = poppy.OpticalSystem()
+    osys.add_pupil(opt1)
+    osys.add_pupil(opt2)
+    osys.add_detector(pixelscale=0.1, fov_pixels=128)
+
+    # two systems, joined into a CompoundOpticalSystem
+    osys1 = poppy.OpticalSystem()
+    osys1.add_pupil(opt1)
+
+    osys2 = poppy.OpticalSystem()
+    osys2.add_pupil(opt2)
+    osys2.add_detector(pixelscale=0.1, fov_pixels=128)
+
+    cosys = poppy.CompoundOpticalSystem([osys1, osys2])
+
+    # PSF calculations
+    psf_simple = osys.calc_psf()
+    psf_compound = cosys.calc_psf()
+
+    np.testing.assert_allclose(psf_simple[0].data, psf_compound[0].data,
+                               err_msg="PSFs do not match between equivalent simple and compound optical systems")
+

--- a/poppy/tests/test_errorhandling.py
+++ b/poppy/tests/test_errorhandling.py
@@ -106,3 +106,29 @@ if _HAVE_PYTEST:
         with pytest.raises(RuntimeError) as excinfo:
             poppy_core.OpticalSystem().calc_psf()
         assert _exception_message_starts_with(excinfo, "You must define an entrance pupil diameter")
+
+
+    def test_compound_osys_errors():
+
+        """ Test that it rejects incompatible inputs"""
+        import poppy
+
+        inputs_and_errors = ( (None, "Missing required optsyslist argument"),
+                              ([], "The provided optsyslist argument is an empty list"),
+                              ([poppy.CircularAperture()], "All items in the optical system list must be OpticalSystem instances"))
+
+        for test_input, expected_error in inputs_and_errors:
+            with pytest.raises(ValueError) as excinfo:
+                poppy.CompoundOpticalSystem(test_input)
+            assert _exception_message_starts_with(excinfo, expected_error)
+
+
+        osys = poppy.OpticalSystem()
+        osys.add_pupil(poppy.CircularAperture())
+
+        cosys = poppy.CompoundOpticalSystem([osys])
+
+        with pytest.raises(RuntimeError) as excinfo:
+            cosys.add_pupil(poppy.SquareAperture())
+        assert _exception_message_starts_with(excinfo, "Adding individual optical elements is disallowed")
+

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -622,6 +622,23 @@ def test_CompoundOpticalSystem_hybrid(npix=128):
     opt1 = poppy.SquareAperture()
     opt2 = poppy.CircularAperture(radius=0.55)
 
+    ###### Simple test case to exercise the conversion functions, with only trivial propagation
+    osys1 = poppy.OpticalSystem()
+    osys1.add_pupil(opt1)
+    osys2 = poppy.FresnelOpticalSystem()
+    osys2.add_optic(poppy.ScalarTransmission())
+    osys3 = poppy.OpticalSystem()
+    osys3.add_pupil(poppy.ScalarTransmission())
+    osys3.add_detector(fov_pixels=64, pixelscale=0.01)
+    cosys = poppy.CompoundOpticalSystem([osys1, osys2, osys3])
+    psf, ints = cosys.calc_psf( return_intermediates=True)
+    assert len(ints) == 4, "Unexpected number of intermediate  wavefronts"
+    assert isinstance(ints[0], poppy.Wavefront), "Unexpected output type"
+    assert isinstance(ints[1], poppy.FresnelWavefront), "Unexpected output type"
+    assert isinstance(ints[2], poppy.Wavefront), "Unexpected output type"
+
+    ###### Harder case involving more complex actual propagations
+
     #===== a single Fresnel optical system =====
     osys = poppy.FresnelOpticalSystem(beam_ratio=0.25, npix=128, pupil_diameter=2*u.m)
     osys.add_optic(opt1)

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -601,3 +601,55 @@ def test_CompoundOpticalSystem_fresnel(npix=128, display=False):
     assert np.allclose(psf[0].data, psf2[0].data), "Results from simple and compound Fresnel systems differ unexpectedly."
 
     return psf, psf2
+
+def test_CompoundOpticalSystem_hybrid(npix=128):
+    """ Test that the CompoundOpticalSystem container works for hybrid Fresnel+Fraunhofer systems
+
+    Defining "works correctly" here is a bit arbitrary given the different physical assumptions.
+    For the purpose of this test we consider a VERY simple case, mostly a Fresnel system. We split
+    out the first optic and put that in a Fraunhofer system. We then test that a compound hybrid
+    system yields the same results as the original fully-Fresnel system.
+
+    Parameters
+    ----------
+    npix : int
+        Number of pixels for the pupil sampling. Kept small by default to
+        reduce test run time.
+    """
+
+    import poppy
+
+    opt1 = poppy.SquareAperture()
+    opt2 = poppy.CircularAperture(radius=0.55)
+
+    #===== a single Fresnel optical system =====
+    osys = poppy.FresnelOpticalSystem(beam_ratio=0.25, npix=128, pupil_diameter=2*u.m)
+    osys.add_optic(opt1)
+    osys.add_optic(opt2, distance=10*u.cm)
+    osys.add_optic(poppy.QuadraticLens(1.0*u.m))
+    osys.add_optic(poppy.Detector(pixelscale=0.125*u.micron/u.pixel, fov_pixels=512), distance=1*u.m)
+
+    #===== two systems, joined into a CompoundOpticalSystem =====
+    # First part is Fraunhofer then second is Fresnel
+    osys1 = poppy.OpticalSystem(npix=128, oversample=4, name="FIRST PART, FRAUNHOFER")
+    # Note for strict consistency we need to apply a half pixel shift to optics in the Fraunhofer part;
+    # this accomodates the differences between different types of image centering.
+    pixscl = osys.input_wavefront().pixelscale
+    halfpixshift = (pixscl*0.5*u.pixel).to(u.m).value
+    opt1shifted = poppy.SquareAperture(shift_x = halfpixshift, shift_y = halfpixshift)
+    osys1.add_pupil(opt1shifted)
+
+    osys2 = poppy.FresnelOpticalSystem(name='SECOND PART, FRESNEL')
+    osys2.add_optic(opt2, distance=10*u.cm)
+    osys2.add_optic(poppy.QuadraticLens(1.0*u.m))
+    osys2.add_optic(poppy.Detector(pixelscale=0.125*u.micron/u.pixel, fov_pixels=512), distance=1*u.m)
+
+    cosys = poppy.CompoundOpticalSystem([osys1, osys2])
+
+    #===== PSF calculations =====
+    psf_simple = osys.calc_psf(return_intermediates=False)
+    poppy.poppy_core._log.info("******=========calculation divider============******")
+    psf_compound = cosys.calc_psf(return_intermediates=False)
+
+    np.testing.assert_allclose(psf_simple[0].data, psf_compound[0].data,
+                               err_msg="PSFs do not match between equivalent simple and compound/hybrid optical systems")

--- a/poppy/tests/test_instrument.py
+++ b/poppy/tests/test_instrument.py
@@ -29,7 +29,7 @@ def test_instrument_source_weight_dict(weights_dict=WEIGHTS_DICT):
         "Number of wavelengths in PSF header does not match number requested"
 
     # Check weighted sum
-    osys = inst._getOpticalSystem(fov_pixels=FOV_PIXELS,
+    osys = inst._get_optical_system(fov_pixels=FOV_PIXELS,
                                   detector_oversample=2, fft_oversample=2)
     output = np.zeros((2 * FOV_PIXELS, 2 * FOV_PIXELS))
     for wavelength, weight in zip(weights_dict['wavelengths'], weights_dict['weights']):
@@ -51,7 +51,7 @@ def test_instrument_source_weight_array(wavelengths=WAVELENGTHS_ARRAY, weights=W
         "Number of wavelengths in PSF header does not match number requested"
 
     # Check weighted sum
-    osys = inst._getOpticalSystem(fov_pixels=FOV_PIXELS,
+    osys = inst._get_optical_system(fov_pixels=FOV_PIXELS,
                                   detector_oversample=2, fft_oversample=2)
     output = np.zeros((2 * FOV_PIXELS, 2 * FOV_PIXELS))
     for wavelength, weight in zip(wavelengths, weights):
@@ -174,7 +174,7 @@ def test_instrument_calc_datacube():
                     "Spectral axis of datacube does not match number requested"
 
     # Check individual planes
-    osys = inst._getOpticalSystem(fov_pixels=FOV_PIXELS,
+    osys = inst._get_optical_system(fov_pixels=FOV_PIXELS,
                                   detector_oversample=2, fft_oversample=2)
     for i, wavelength in enumerate(WAVELENGTHS_ARRAY):
 

--- a/poppy/tests/test_special_prop.py
+++ b/poppy/tests/test_special_prop.py
@@ -51,6 +51,9 @@ def test_SAMC(fft_oversample=4, samc_oversample=8, npix=512,
         plt.figure()
     t_start_sam = time.time()
     psf_sam = sam_osys.calc_psf(display_intermediates=display)
+    # also compute a version with the intermediate planes returned
+    psf_sam_copy, intermediates= sam_osys.calc_psf(display_intermediates=display,
+                    return_intermediates=True)
     t_stop_sam = time.time()
 
     print("SAMC calculation: {} s".format(t_stop_sam - t_start_sam))
@@ -85,4 +88,8 @@ def test_SAMC(fft_oversample=4, samc_oversample=8, npix=512,
     assert totdiff < thresh, "Total pixel value absolute difference summed overimages ({}) exceeds threshold ({}).".format(totdiff, thresh)
 
 
+    # Check there are the expected number of intermediate planes, which for this
+    # kind of propagation has some extras:
+    assert len(intermediates) == len(osys)+2, "Unexpected number of returned optical planes"
 
+    assert np.allclose(psf_sam[0].data, psf_sam_copy[0].data), "Didn't get same results with & without return_intermediates"

--- a/poppy/tests/test_special_prop.py
+++ b/poppy/tests/test_special_prop.py
@@ -55,12 +55,15 @@ def test_SAMC(fft_oversample=4, samc_oversample=8, npix=512,
 
     print("SAMC calculation: {} s".format(t_stop_sam - t_start_sam))
     if display:
+        plt.suptitle("Calculation using SAMC method")
         plt.figure()
 
     t_start_fft = time.time()
     psf_fft = osys.calc_psf(display_intermediates=display)
     t_stop_fft = time.time()
     print("Basic FFT calculation: {} s".format(t_stop_fft - t_start_fft))
+    if display:
+        plt.suptitle("Calculation using Basic FFT method")
 
     # The pixel by pixel difference should be small:
     maxdiff = np.abs(psf_fft[0].data - psf_sam[0].data).max()

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -195,12 +195,10 @@ def display_psf(HDUlist_or_filename, ext=0, vmin=1e-7, vmax=1e-1,
 
     if isinstance(pixelscale, str):
         pixelscale = hdulist[ext].header[pixelscale]
-        halffov_x = pixelscale * psf_array_shape[1] / 2.0
-        halffov_y = pixelscale * psf_array_shape[0] / 2.0
     else:
         pixelscale = float(pixelscale)
-        halffov_x = pixelscale * psf_array_shape[1] / 2.0
-        halffov_y = pixelscale * psf_array_shape[0] / 2.0
+    halffov_x = pixelscale * psf_array_shape[1] / 2.0
+    halffov_y = pixelscale * psf_array_shape[0] / 2.0
 
     unit = "arcsec"
     extent = [-halffov_x, halffov_x, -halffov_y, halffov_y]
@@ -1141,6 +1139,9 @@ def pad_or_crop_to_shape(array, target_shape):
     pad_to_oversample, pad_to_size
 
     """
+
+    if array.shape == target_shape:
+        return array
 
     lx, ly = array.shape
     lx_w, ly_w = target_shape

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -199,6 +199,10 @@ class ZernikeWFE(WavefrontError):
     @utils.quantity_input(coefficients=u.meter, radius=u.meter)
     def __init__(self, name="Zernike WFE", coefficients=None, radius=None,
             aperture_stop=False, **kwargs):
+
+        if radius is None:
+            raise ValueError("You must specify a radius for the unit circle "
+                             "over which the Zernike polynomials are normalized")
         self.radius = radius
         self.aperture_stop=aperture_stop
         self.coefficients = coefficients


### PR DESCRIPTION
A relatively substantial refactoring of some core propagation functions. See #280 for more on the motivating use case: passing the outputs of one propagation into the start of another propagation. For instance, this could be used to perform a mixed calculation using Fresnel in some parts and Fraunhofer in others. 

This PR implements this via the following. 

- Refactors most of the core OpticalSystem propagation logic from `propagate_mono` into a new function, tentatively called `propagate_through`, which is a linear operator acting on Wavefront objects. The old `propagate_mono` now becomes a wrapper that creates an input wavefront and passes it through that new function, then handles the output formatting. This preserves the old API and functionality for all existing code, while adding the desired new functionality.
- Refactors `Wavefront` and `FresnelWavefront` to both be children of a parent abstract base class, `BaseWavefront`. This is cleaner than before, in which `FresnelWavefront` was a child of `Wavefront` but with different semantics. This also makes it easier to test which kind of wavefront you're dealing with - i.e. before `isinstance(Wavefront)` would be true for both kinds, now it's only true for pure `Wavefront` instances but not `FresnelWavefront` instances.
- Implements  new functions for casting back and forth between those two kinds of wavefronts. 
- Implements a new class `CompoundOpticalSystem` to easily chain multiple optical systems. It's the same kind of container and iterator idea as for `CompoundAnalyticOptic`, but applied to optical systems using the above. 
- Some supporting changes to wavefront display during calculations, to let it work as desired inside a chained calculation (i.e. the display of a later optical system adds more rows of wavefront plots rather than overwriting the first set of plots)

There are also some less-directly-related changes included in this PR: 
- Improves support for Detectors, in particular for resampling a wavefront to match the detector sampling even if the wavefront is already at the right plane so there's not strictly any propagation needed. 
- A variety of minor edits, comment cleanups, and semi-unrelated fixes made in the course of all the above, while trying to get this working for HiCAT multi-DM sims. 

Apologies in advance but this PR is going to be a pain to read. I recommend reading the part in `poppy_core` and ignoring everything else to start. Note, Github seems to want to hide that by default because it's a large diff, so be sure to click to expand it. 