### PR TITLE
Update display method in OpticalElement class 

### DIFF
--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2429,17 +2429,19 @@ class OpticalElement(object):
                          colorbar_orientation=colorbar_orientation, title=None, opd_vmax=opd_vmax,
                          nrows=nrows)
             ax2.set_ylabel('')  # suppress redundant label which duplicates the intensity plot's label
+            if title is not None:
+                plt.suptitle(title)
             return ax, ax2
         elif what == 'amplitude':
             plot_array = ampl
-            title = 'Transmissivity'
+            default_title = 'Transmissivity'
             cb_label = 'Fraction'
             cb_values = [0, 0.25, 0.5, 0.75, 1.0]
             cmap = cmap_amp
             norm = norm_amp
         elif what == 'intensity':
             plot_array = ampl ** 2
-            title = "Transmittance"
+            default_title = "Transmittance"
             cb_label = 'Fraction'
             cb_values = [0, 0.25, 0.5, 0.75, 1.0]
             cmap = cmap_amp
@@ -2448,14 +2450,14 @@ class OpticalElement(object):
             warnings.warn("displaying 'phase' has been deprecated. Use what='opd' instead.",
                           category=DeprecationWarning)
             plot_array = opd
-            title = "OPD"
+            default_title = "OPD"
             cb_label = 'waves'
             cb_values = np.array([-1, -0.5, 0, 0.5, 1]) * opd_vmax_m
             cmap = cmap_opd
             norm = norm_opd
         elif what == 'opd':
             plot_array = opd
-            title = "OPD"
+            default_title = "OPD"
             cb_label = 'meters'
             cb_values = np.array([-1, -0.5, 0, 0.5, 1]) * opd_vmax_m
             cmap = cmap_opd
@@ -2472,7 +2474,10 @@ class OpticalElement(object):
         utils.imshow_with_mouseover(plot_array, ax=ax, extent=extent, cmap=cmap, norm=norm,
                                     origin='lower')
         if nrows == 1:
-            plt.title(title + " for " + self.name)
+            if title is None:
+                plt.title(default_title + " for " + self.name)
+            else:
+                plt.title(title)
         plt.ylabel(units)
         ax.xaxis.set_major_locator(matplotlib.ticker.MaxNLocator(nbins=4, integer=True))
         ax.yaxis.set_major_locator(matplotlib.ticker.MaxNLocator(nbins=4, integer=True))

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2475,9 +2475,8 @@ class OpticalElement(object):
                                     origin='lower')
         if nrows == 1:
             if title is None:
-                plt.title(default_title + " for " + self.name)
-            else:
-                plt.title(title)
+                title = default_title + " for " + self.name
+            plt.title(title)
         plt.ylabel(units)
         ax.xaxis.set_major_locator(matplotlib.ticker.MaxNLocator(nbins=4, integer=True))
         ax.yaxis.set_major_locator(matplotlib.ticker.MaxNLocator(nbins=4, integer=True))


### PR DESCRIPTION
This PR is a fix for a reported issue in a STARS ticket.

Issue: "In the file `poppy_core.py`, in `class OpticalElement`, the `display` method has an optional positional argument called `title` which defaults to `None`. Presumably this is so the user can pass in the title to be used in the `display`. However, passing in a title does not work, as the code steps on anything that is provided."

I fixed it so now if `title=None`, the default title structure of "{what your plotting} for {`self.name`}" will remain. But if `title` is not `None`, that input is used for the `title` (or `suptitle` in the case of `what=='both'` since you have 2 subplots)