### PR TITLE
Use RectBivariateSpline instead of zoom for detector-plane resampling

### DIFF
--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1057,7 +1057,7 @@ class FresnelOpticalSystem(BaseOpticalSystem):
         self.distances = []  # distance along the optical axis to each successive optic
 
     @u.quantity_input(distance=u.m)
-    def add_optic(self, optic=None, distance=0.0 * u.m):
+    def add_optic(self, optic=None, distance=0.0 * u.m, index=None):
         """ Add an optic to the optical system
 
         Parameters
@@ -1066,9 +1066,19 @@ class FresnelOpticalSystem(BaseOpticalSystem):
             Some optic
         distance : astropy.Quantity of dimension length
             separation distance of this optic relative to the prior optic in the system.
+        index : int
+            Index at which to insert the new optical element
+
         """
-        self.planes.append(optic)
-        self.distances.append(distance.to(u.m))
+        if index is None:
+            # Optic is appended to the end of the system
+            self.planes.append(optic)
+            self.distances.append(distance.to(u.m))
+        else:
+            # Insert the optic into the middle of the beam train somewhere
+            self.planes.insert(index, optic)
+            self.distances.insert(index, distance.to(u.m))
+
         if self.verbose:
             _log.info("Added optic: {0} after separation: {1:.2e} ".format(self.planes[-1].name, distance))
 

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -971,6 +971,7 @@ class FresnelWavefront(BaseWavefront):
         if np.abs(pixscale_ratio - 1.0) < 1e-3:
             _log.debug("Wavefront is already at desired pixel scale "
                        "{:.4g}.  No resampling needed.".format(self.pixelscale))
+            self.wavefront = utils.pad_or_crop_to_shape(self.wavefront, detector.shape)
             return
 
         super(FresnelWavefront, self)._resample_wavefront_pixelscale(detector)

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -67,7 +67,7 @@ class QuadPhase(poppy.optics.AnalyticOpticalElement):
         k = 2 * np.pi / wave.wavelength.to(u.m).value
         if (z == np.inf) | (z == -np.inf):
             lens_phasor = 1 + 0j
-            _log.debug("lens_phasor:"+str(lens_phasor))
+            _log.debug("lens_phasor:" + str(lens_phasor))
             return lens_phasor
         if accel_math._USE_NUMEXPR:
             rsqd = ne.evaluate("(x ** 2 + y ** 2)")
@@ -435,7 +435,7 @@ class FresnelWavefront(BaseWavefront):
             pixel_scale_x, pixel_scale_y = pixelscale_mpix, pixelscale_mpix
 
         if accel_math._USE_NUMEXPR:
-            return ne.evaluate("pixel_scale_y * y"),  ne.evaluate("pixel_scale_x * x")
+            return ne.evaluate("pixel_scale_y * y"), ne.evaluate("pixel_scale_x * x")
         else:
             return pixel_scale_y * y, pixel_scale_x * x
 
@@ -586,7 +586,7 @@ class FresnelWavefront(BaseWavefront):
             self.planetype = PlaneType.image  # needed for back compatibility when using image plane optics
         elif optic.planetype == PlaneType.detector:
             self._resample_wavefront_pixelscale(optic)
-            self.location = 'at detector '+optic.name
+            self.location = 'at detector ' + optic.name
         else:
             self.location = 'before ' + optic.name
 
@@ -629,7 +629,7 @@ class FresnelWavefront(BaseWavefront):
         x, y = self.coordinates()  # meters
         meter_per_pix = self.pixelscale.to(u.m / u.pix).value
         rhosqr = accel_math._fftshift((x / (meter_per_pix ** 2 * self.n)) ** 2 + (
-                                  y / (meter_per_pix ** 2 * self.n)) ** 2)
+            y / (meter_per_pix ** 2 * self.n)) ** 2)
         # Transfer Function of diffraction propagation eq. 22, eq. 87
         wavelen_m = self.wavelength.to(u.m).value
 
@@ -968,7 +968,7 @@ class FresnelWavefront(BaseWavefront):
 
         pixscale_ratio = (self.pixelscale / detector.pixelscale).decompose().value
 
-        if np.abs(pixscale_ratio-1.0) < 1e-3:
+        if np.abs(pixscale_ratio - 1.0) < 1e-3:
             _log.debug("Wavefront is already at desired pixel scale "
                        "{:.4g}.  No resampling needed.".format(self.pixelscale))
             return
@@ -999,9 +999,9 @@ class FresnelWavefront(BaseWavefront):
             raise NotImplementedError("Conversion from image planes to Fresnel is not yet implemented.")
 
         if wf.ispadded:
-            beam_radius = wf.wavefront.shape[0]/wf.oversample/2 * wf.pixelscale*u.pixel
+            beam_radius = wf.wavefront.shape[0] / wf.oversample / 2 * wf.pixelscale * u.pixel
         else:
-            beam_radius = wf.wavefront.shape[0]/2 * wf.pixelscale * u.pixel
+            beam_radius = wf.wavefront.shape[0] / 2 * wf.pixelscale * u.pixel
         new_wf = FresnelWavefront(beam_radius=beam_radius,
                                   npix=wf.shape[0],
                                   oversample=wf.oversample,
@@ -1084,8 +1084,9 @@ class FresnelOpticalSystem(BaseOpticalSystem):
 
         return optic
 
-    @u.quantity_input(distance=u.m, pixelscale=u.micron/u.pixel)
-    def add_detector(self, pixelscale=10*u.micron/u.pixel, fov_pixels=10*u.pixel, distance=0.0 * u.m):
+    @u.quantity_input(distance=u.m, pixelscale=u.micron / u.pixel)
+    def add_detector(self, pixelscale=10 * u.micron / u.pixel, fov_pixels=10 * u.pixel,
+                     distance=0.0 * u.m):
         """ Add a detector to the optical system
 
         Parameters
@@ -1158,8 +1159,8 @@ class FresnelOpticalSystem(BaseOpticalSystem):
                 wavefront.normalize()
                 wavefront *= np.sqrt(2)
             elif normalize.lower() == 'exit_pupil':  # normalize the last pupil in the system to 1
-                last_pupil_plane_index = np.where(np.asarray([p.planetype is PlaneType.pupil for p in self.planes]))[
-                                             0].max() + 1
+                last_pupil_plane_index = np.where(
+                    np.asarray([p.planetype is PlaneType.pupil for p in self.planes]))[0].max() + 1
                 if wavefront.current_plane_index == last_pupil_plane_index:
                     wavefront.normalize()
                     _log.debug(

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -702,14 +702,15 @@ class BaseWavefront(ABC):
 
         # Input and output axes for interpolation.  The interpolated wavefront will be evaluated
         # directly onto the detector axis, so don't need to crop afterwards.
-        x_in = make_axis(crop_shape[0], self.pixelscale)
-        y_in = make_axis(crop_shape[1], self.pixelscale)
-        x_out = make_axis(detector.shape[0], detector.pixelscale)
-        y_out = make_axis(detector.shape[1], detector.pixelscale)
+        x_in = make_axis(crop_shape[0], self.pixelscale.to(u.m/u.pix).value)
+        y_in = make_axis(crop_shape[1], self.pixelscale.to(u.m/u.pix).value)
+        x_out = make_axis(detector.shape[0], detector.pixelscale.to(u.m/u.pix).value)
+        y_out = make_axis(detector.shape[1], detector.pixelscale.to(u.m/u.pix).value)
 
         def interpolator(arr):
             """
-            Bind arguments to scipy's RectBivariateSpline function.  For data on a regular 2D grid, RectBivariateSpline is more efficient than interp2d.
+            Bind arguments to scipy's RectBivariateSpline function.
+            For data on a regular 2D grid, RectBivariateSpline is more efficient than interp2d.
             """
             return scipy.interpolate.RectBivariateSpline(
                 x_in, y_in, arr, kx=detector.interp_order, ky=detector.interp_order)

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -199,7 +199,7 @@ class BaseWavefront(ABC):
 
     def __iadd__(self, wave):
         """Add another wavefront to this one"""
-        if not isinstance(wave, Wavefront):
+        if not isinstance(wave, BaseWavefront):
             raise ValueError('Wavefronts can only be summed with other Wavefronts')
 
         if not self.wavefront.shape[0] == wave.wavefront.shape[0]:


### PR DESCRIPTION
The current implementation of detector-plane resampling for Fresnel propagations uses `scipy.ndimage.zoom`, which appears to result in incorrect amplitude scaling and PSF centering.  This PR replaces this with an alternative implementation which uses `scipy.interpolate.interp2d`, which is better-behaved in both of these aspects.