### PR TITLE
Add FITSOpticalElement support for wavelength-independent phase maps

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -6,17 +6,17 @@ POPPY Class Listing
 ============================
 
 The key classes for POPPY are `~poppy.OpticalSystem` and the various `~poppy.OpticalElement` classes (of which there are many). There is also a `~poppy.Wavefront` class that is used internally, but users will rarely
-need to instantiate that directly. Results are returned as FITS files, specifically astropy.io.fits.HDUList objects. 
+need to instantiate that directly. Results are returned as FITS files, specifically astropy.io.fits.HDUList objects.
 
 `~poppy.OpticalSystem` is in essence a container for `~poppy.OpticalElement` instances, which handles creating input wavefronts, propagating them through the individual optics, and then combining the
 results into a broadband output point spread function.
 
 
-The `~poppy.Instrument` class provides a framework for developing high-level models of astronomical instruments. 
-An `~poppy.OpticalSystem` does not include any information about spectral bandpasses, filters, or light source properties, 
-it just propagates whatever specified list of wavelengths and weights it's provided with.  The 
+The `~poppy.Instrument` class provides a framework for developing high-level models of astronomical instruments.
+An `~poppy.OpticalSystem` does not include any information about spectral bandpasses, filters, or light source properties,
+it just propagates whatever specified list of wavelengths and weights it's provided with.  The
 `~poppy.Instrument` class provides the machinery for handling filters and sources to generate weighted source spectra, as
-well as support for configurable instruments with selectable mechanisms, and system-level impacts on PSFs such as pointing jitter. 
+well as support for configurable instruments with selectable mechanisms, and system-level impacts on PSFs such as pointing jitter.
 
 Note that the `~poppy.Instrument` class should not be used directly but rather is subclassed to implement the details of your particular instrument. See its class documentation for more details.
 
@@ -25,11 +25,11 @@ Optical Systems
 -----------------
 
  *  `~poppy.OpticalSystem` is the fundamental optical system class, that propagates `~poppy.Wavefront` objects between optics using Fourier transforms.
- *  `~poppy.SemiAnalyticCoronagraph` implements the semi-analytic coronagraphic propagation algorithm of Soummer et al. 
+ *  `~poppy.SemiAnalyticCoronagraph` implements the semi-analytic coronagraphic propagation algorithm of Soummer et al.
  *  `~poppy.MatrixFTCoronagraph` enables efficient propagation calculations for Lyot coronagraphs with diaphragm-type focal plane masks, relevant to the WFIRST coronagraph and described by Zimmerman et al. (2016).
 
 
- 
+
 Optical Elements
 -----------------
 
@@ -61,7 +61,7 @@ Optical Elements
      * `~poppy.IdealFQPM`
 
  * `~poppy.InverseTransmission` allows any optic, whether analytic or discrete, to be flipped in sign, a la the Babinet principle.
- * `~poppy.Rotation` represents a rotation of the axes of the wavefront, for instance to change coordinate systems between two optics that are 
+ * `~poppy.Rotation` represents a rotation of the axes of the wavefront, for instance to change coordinate systems between two optics that are
    rotated with respect to one another. The axis of rotation must be the axis of optical propagation.
  * `_poppy.CoordinateInversion` represents a flip in orientation of the X or Y axis, or both at once.
 

--- a/docs/fitsheaders.rst
+++ b/docs/fitsheaders.rst
@@ -6,7 +6,7 @@ POPPY FITS Header Keywords Definitions
 
 * `WAVELEN`: Wavelength in meters
 * `DIFFLMT`:  Diffraction limit lambda/D in *arcsecond*
-* `OVERSAMP`: Oversampling factor for FFTs in computation of PSF 
+* `OVERSAMP`: Oversampling factor for FFTs in computation of PSF
 * `DET_SAMP`: Oversampling factor for MFT to detector plane
 * `PIXELSCL` : Scale in *arcsecond/pixel*  or *meter/pixel* (after oversampling)
 * `PIXUNIT` : units of the pixels in the header, typically either *arcsecond* or *meter*
@@ -18,4 +18,4 @@ POPPY FITS Header Keywords Definitions
 * `DIFFLMT`: Scale in arcsec/pix (after oversampling)
 * `DIAM`: Pupil diameter in meters (not incl padding)
 * `NWAVES`: Number of wavelengths used in calculation
-* `BUNIT`:        units of OPD error. Default is 'meters'. can be 'meter', 'meters', 'micron(s)', 'nanometer(s)', or their SI abbreviations.
+* `BUNIT`: units of OPD error. Default is 'meters'. Can be 'meter', 'meters', 'micron(s)', 'nanometer(s)', or their SI abbreviations. Can also be 'radian' or 'radians', which makes POPPY treat the phase pattern as wavelength-independent (i.e. Pancharatnam-Berry phase).

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2418,9 +2418,9 @@ class OpticalElement(object):
             halfsize = 1.0
         extent = [-halfsize, halfsize, -halfsize, halfsize]
 
-
-        ampl = self.get_transmission(wavelength)
-        opd = self.get_opd(wavelength)
+        temp_wavefront = Wavefront(wavelength)
+        ampl = self.get_transmission(temp_wavefront)
+        opd = self.get_opd(temp_wavefront)
         opd[np.where(ampl == 0)] = np.nan
 
         if what == 'both':

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2634,7 +2634,7 @@ class FITSOpticalElement(OpticalElement):
         self.amplitude_file = None
         self.amplitude_header = None
         self.opd_header = None
-        self._opd_is_phase_map = False
+        self._opd_in_radians = False
         self.planetype = planetype
 
         _log.debug("Trans: " + str(transmission))
@@ -2754,14 +2754,14 @@ class FITSOpticalElement(OpticalElement):
             elif opdunits in ('nanometer', 'nm'):
                 self.opd *= 1e-9
             elif opdunits == 'radian':
-                self._opd_is_phase_map = True
+                self._opd_in_radians = True
             else:
                 raise ValueError(
                     "Got opdunits (or BUNIT header keyword) {}. Valid options "
                     "are meter, micron, nanometer, or radian.".format(repr(opdunits))
                 )
 
-            if self.opd_header is not None and not self._opd_is_phase_map:
+            if self.opd_header is not None and not self._opd_in_radians:
                 self.opd_header['BUNIT'] = 'meter'
 
             if len(self.opd.shape) != 2 or self.opd.shape[0] != self.opd.shape[1]:
@@ -2929,7 +2929,7 @@ class FITSOpticalElement(OpticalElement):
             wavelength = wave.wavelength
         else:
             wavelength = wave
-        if self._opd_is_phase_map:
+        if self._opd_in_radians:
             return self.opd * wavelength.to(u.m) / (2 * np.pi)
         return self.opd
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2418,9 +2418,9 @@ class OpticalElement(object):
             halfsize = 1.0
         extent = [-halfsize, halfsize, -halfsize, halfsize]
 
-
-        ampl = self.get_transmission(wavelength)
-        opd = self.get_opd(wavelength)
+        temp_wavefront = Wavefront(wavelength)
+        ampl = self.get_transmission(temp_wavefront)
+        opd = self.get_opd(temp_wavefront)
         opd[np.where(self.amplitude == 0)] = np.nan
 
         if what == 'both':

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2349,9 +2349,9 @@ class OpticalElement(object):
         else:
             return self.phasor
 
-    @utils.quantity_input(opd_vmax=u.meter)
+    @utils.quantity_input(opd_vmax=u.meter, wavelength=u.meter)
     def display(self, nrows=1, row=1, what='intensity', crosshairs=False, ax=None, colorbar=True,
-                colorbar_orientation=None, title=None, opd_vmax=0.5e-6 * u.meter):
+                colorbar_orientation=None, title=None, opd_vmax=0.5e-6 * u.meter, wavelength=1e-6 * u.meter):
         """Display plots showing an optic's transmission and OPD.
 
         Parameters
@@ -2374,6 +2374,9 @@ class OpticalElement(object):
             Max absolute value for OPD image display, in meters.
         title : string
             Plot label
+        wavelength : float, default 1 micron
+            For optics with wavelength-dependent behavior, evaluate at this
+            wavelength for display.
         """
         if colorbar_orientation is None:
             colorbar_orientation = "horizontal" if nrows == 1 else 'vertical'
@@ -2415,8 +2418,9 @@ class OpticalElement(object):
             halfsize = 1.0
         extent = [-halfsize, halfsize, -halfsize, halfsize]
 
-        ampl = self.amplitude
-        opd = self.opd.copy()
+
+        ampl = self.get_transmission(wavelength)
+        opd = self.get_opd(wavelength)
         opd[np.where(self.amplitude == 0)] = np.nan
 
         if what == 'both':

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2418,9 +2418,9 @@ class OpticalElement(object):
             halfsize = 1.0
         extent = [-halfsize, halfsize, -halfsize, halfsize]
 
-        temp_wavefront = Wavefront(wavelength)
-        ampl = self.get_transmission(temp_wavefront)
-        opd = self.get_opd(temp_wavefront)
+
+        ampl = self.get_transmission(wavelength)
+        opd = self.get_opd(wavelength)
         opd[np.where(self.amplitude == 0)] = np.nan
 
         if what == 'both':

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2421,7 +2421,7 @@ class OpticalElement(object):
 
         ampl = self.get_transmission(wavelength)
         opd = self.get_opd(wavelength)
-        opd[np.where(self.amplitude == 0)] = np.nan
+        opd[np.where(ampl == 0)] = np.nan
 
         if what == 'both':
             # recursion!
@@ -2934,7 +2934,7 @@ class FITSOpticalElement(OpticalElement):
         else:
             wavelength = wave
         if self._opd_in_radians:
-            return self.opd * wavelength.to(u.m) / (2 * np.pi)
+            return self.opd * wavelength.to(u.m).value / (2 * np.pi)
         return self.opd
 
 

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -525,7 +525,7 @@ def test_OPD_in_waves_for_FITSOpticalElement():
     lens_as_fits[0].header['BUNIT'] = 'radian'
     lens_as_fits[0].data *= 2 * np.pi / reference_wavelength.to(u.m).value
     thin_lens_wl_indep = poppy.FITSOpticalElement(opd=lens_as_fits, opdunits='radian')
-    central_pixels = []
+    # We expect identical peak flux for all wavelengths, so check at 0.5x and 2x
     for prefactor in (0.5, 1.0, 2.0):
         osys = poppy.OpticalSystem(oversample=1, npix=npix)
         osys.add_pupil(pupil)

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -516,7 +516,7 @@ def test_OPD_in_waves_for_FITSOpticalElement():
     # has lower flux than at 2 um (it should be the 'hole' of the donut)
     psf_1um = osys.calc_psf(reference_wavelength)
     center_pixel_value = psf_1um[0].data[1,1]
-    psf_2um = osys.calc_psf(reference_wavelength)
+    psf_2um = osys.calc_psf(2 * reference_wavelength)
     assert psf_2um[0].data[1,1] > psf_1um[0].data[1,1]
     # Now, use the single_wave_1um_lens optic to make a
     # wavelength-independent 1 wave defocus

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -515,9 +515,9 @@ def test_OPD_in_waves_for_FITSOpticalElement():
     osys.add_detector(0.01 * u.arcsec / u.pixel, fov_pixels=3)
     # We have applied 1 wave of defocus at 1 um, so verify the center
     # has lower flux than at 2 um (it should be the 'hole' of the donut)
-    psf_1um = osys.calc_psf(reference_wavelength)
+    psf_1um = osys.calc_psf(reference_wavelength.to(u.m).value)
     center_pixel_value = psf_1um[0].data[1,1]
-    psf_2um = osys.calc_psf(2 * reference_wavelength)
+    psf_2um = osys.calc_psf(2 * reference_wavelength.to(u.m).value)
     assert psf_2um[0].data[1,1] > psf_1um[0].data[1,1]
     # Now, use the single_wave_1um_lens optic to make a
     # wavelength-independent 1 wave defocus
@@ -531,7 +531,7 @@ def test_OPD_in_waves_for_FITSOpticalElement():
         osys.add_pupil(pupil)
         osys.add_pupil(thin_lens_wl_indep)
         osys.add_detector(prefactor * 0.01 * u.arcsec / u.pixel, fov_pixels=3)
-        psf = osys.calc_psf(wavelength=prefactor * u.um)
+        psf = osys.calc_psf(wavelength=(prefactor * reference_wavelength).to(u.m).value)
         assert np.isclose(center_pixel_value, psf[0].data[1,1])
 
 ### Detector class unit test ###

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -515,9 +515,9 @@ def test_OPD_in_waves_for_FITSOpticalElement():
     osys.add_detector(0.01 * u.arcsec / u.pixel, fov_pixels=3)
     # We have applied 1 wave of defocus at 1 um, so verify the center
     # has lower flux than at 2 um (it should be the 'hole' of the donut)
-    psf_1um = osys.calc_psf(reference_wavelength.to(u.m).value)
+    psf_1um = osys.calc_psf(reference_wavelength)
     center_pixel_value = psf_1um[0].data[1,1]
-    psf_2um = osys.calc_psf(2 * reference_wavelength.to(u.m).value)
+    psf_2um = osys.calc_psf(2 * reference_wavelength)
     assert psf_2um[0].data[1,1] > psf_1um[0].data[1,1]
     # Now, use the single_wave_1um_lens optic to make a
     # wavelength-independent 1 wave defocus
@@ -531,7 +531,7 @@ def test_OPD_in_waves_for_FITSOpticalElement():
         osys.add_pupil(pupil)
         osys.add_pupil(thin_lens_wl_indep)
         osys.add_detector(prefactor * 0.01 * u.arcsec / u.pixel, fov_pixels=3)
-        psf = osys.calc_psf(wavelength=(prefactor * reference_wavelength).to(u.m).value)
+        psf = osys.calc_psf(wavelength=prefactor * u.um)
         assert np.isclose(center_pixel_value, psf[0].data[1,1])
 
 ### Detector class unit test ###

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -107,11 +107,11 @@ def test_input_wavefront_size():
 def test_CircularAperture_Airy(display=False):
     """ Compare analytic 2d Airy function with the results of a POPPY
     numerical calculation of the PSF for a circular aperture.
-   
+
     Note that we expect very close but not precisely perfect agreement due to
     the quantization of the POPPY PSF relative to a perfect geometric circle.
     """
-   
+
     from ..misc import airy_2d
     # Analytic PSF for 1 meter diameter aperture
     analytic = airy_2d(diameter=1)
@@ -391,7 +391,7 @@ def test_unit_conversions():
 
 def test_return_complex():
     osys =poppy_core.OpticalSystem()
-    osys.add_pupil(optics.CircularAperture(radius=3))  
+    osys.add_pupil(optics.CircularAperture(radius=3))
     osys.add_detector(pixelscale=0.010, fov_arcsec=5.0)
     psf = osys.calc_psf(2e-6,return_final=True)
     assert len(psf[1])==1 #make sure only one element was returned
@@ -497,6 +497,43 @@ def test_FITSOpticalElement(tempdir='./'):
     assert foe.opd_file == fn2
     assert foe.opd_slice == 1
     assert np.allclose(foe.opd, rect_mask*1e-9)
+
+def test_OPD_in_waves_for_FITSOpticalElement():
+    pupil_radius = 1 * u.m
+    pupil = poppy.CircularAperture(radius=pupil_radius)
+    reference_wavelength = 1 * u.um
+    single_wave_1um_lens = poppy.ThinLens(
+        name='Defocus',
+        nwaves=1,
+        reference_wavelength=reference_wavelength,
+        radius=pupil_radius
+    )
+    osys = poppy.OpticalSystem(oversample=1, npix=1024)
+    osys.add_pupil(pupil)
+    osys.add_pupil(single_wave_1um_lens)
+    osys.add_detector(0.01 * u.arcsec / u.pixel, fov_pixels=3)
+    # We have applied 1 wave of defocus at 1 um, so verify the center
+    # has lower flux than at 2 um (it should be the 'hole' of the donut)
+    psf_1um = osys.calc_psf(reference_wavelength)
+    center_pixel_value = psf_1um[0].data[1,1]
+    psf_2um = osys.calc_psf(reference_wavelength)
+    assert psf_2um[0].data[1,1] > psf_1um[0].data[1,1]
+    # Now, use the single_wave_1um_lens optic to make a
+    # wavelength-independent 1 wave defocus
+    lens_as_fits = single_wave_1um_lens.to_fits(what='opd', npix=1536)
+    lens_as_fits[0].header['BUNIT'] = 'radian'
+    lens_as_fits[0].data *= 2 * np.pi / reference_wavelength.to(u.m).value
+    thin_lens_wl_indep = poppy.FITSOpticalElement(opd=lens_as_fits, opdunits='radian')
+    central_pixels = []
+    for prefactor in (0.5, 1.0, 2.0):
+        osys = poppy.OpticalSystem(oversample=1, npix=1024)
+        osys.add_pupil(pupil)
+        osys.add_pupil(thin_lens_wl_indep)
+        osys.add_detector(prefactor * 0.01 * u.arcsec / u.pixel, fov_pixels=3)
+        psf = osys.calc_psf(wavelength=prefactor * u.um)
+        central_pixels.append(psf[0].data[1,1])
+        yc, xc = psf[0].data.shape[0] // 2, psf[0].data.shape[1] // 2
+    assert np.allclose(center_pixel_value, central_pixels)
 
 
 ### Detector class unit test ###


### PR DESCRIPTION
Certain optics impart a phase which is (approximately) wavelength independent, using a phenomenon sometimes called Pancharatnam-Berry phase [1,2]. This adds support for such optics in FITSOpticalElement with a new `BUNIT` keyword value, `'radian'`, which causes POPPY to treat the phase map as the same number of radians regardless of wavelength.

(This is currently implemented by scaling the phase map to OPD, only to re-scale back to phase in `get_phasor`. This seemed like the best way to preserve backwards-compatibility.)

Fixes #305 

[1] Pancharatnam, S., “Generalized Theory of Interference, and Its Applications. Part I. Coherent Pencils,” Proc. In- dian. Acad. Sci. Sect. A 44, 247 (1956).

[2] Berry, M., “The Adiabatic Phase and Pancharatnams Phase for Polarized Light,” J. Mod. Opt. 34, 1401–1407 (1987).