### PR TITLE
Misc handful of small enhancements 

### DIFF
--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -67,7 +67,7 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
                  actuator_print_through_file=None,
                  actuator_mask_file=None,
                  radius=1.0 * u.meter,
-                 **kwargs,
+                 **kwargs
                  ):
 
         optics.AnalyticOpticalElement.__init__(self, planetype=poppy_core.PlaneType.pupil, **kwargs)
@@ -212,7 +212,7 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
         if np.isscalar(new_surface.value):
             self._surface[:] = new_surface.to(u.meter).value
         else:
-            assert new_surface.shape == self._surface.shape
+            assert new_surface.shape == self._surface.shape, "Supplied surface shape doesn't match DM. Must be {}".format(self._surface.shape)
             self._surface[:] = np.asarray(new_surface.to(u.meter).value, dtype=float)
 
     @utils.quantity_input(new_value=u.meter)
@@ -247,11 +247,17 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
 
     def get_act_coordinates(self, one_d=False):
         """ Y and X coordinates for the actuators
+
         Parameters
         ------------
         one_d : bool
             Return 1-dimensional arrays of coordinates per axis?
             Default is to return 2D arrays with same shape as full array.
+
+        Returns
+        -------
+        y_act, x_act : float ndarrays
+            actuator coordinates, in units of meters
         """
 
         act_space_m = self.actuator_spacing.to(u.meter).value

--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -41,6 +41,12 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
                 on the details of your particular hardware. This parameter does not affect
                 any of the actuator models, only the reflective area for wavefront amplitude.
 
+            Additionally, the standard parameters for shift_x and shift_y can be accepted and
+            will be handled by the **kwargs mechanism. Note, rotation is not yet supported for DMs,
+            and shifts are currently rounded to integer pixels in the sampled wavefront, rather
+            than being applied as floating point values.  Shifts are specified in physical units
+            of meters transverse motion in the DM plane.
+
             Note:  Keeping track of actuator locations and spacing is subtle. This note
             assumes you are familiar with 'counting fenceposts' and off-by-one errors.
             This class follows the convention adopted by Boston Micromachines:
@@ -51,6 +57,7 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
             However, for display purposes etc it is often useful if the displayed pupil extends
             over the full N actuators, so we set the `pupil_diam` attribute to N*actuator_spacing,
             or the reflective radius, whichever is larger.
+
             """
 
     @utils.quantity_input(actuator_spacing=u.meter, radius=u.meter)
@@ -60,18 +67,19 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
                  actuator_print_through_file=None,
                  actuator_mask_file=None,
                  radius=1.0 * u.meter,
+                 **kwargs,
                  ):
 
-        poppy_core.OpticalElement.__init__(self, planetype=poppy_core.PlaneType.pupil)
+        optics.AnalyticOpticalElement.__init__(self, planetype=poppy_core.PlaneType.pupil, **kwargs)
         self._dm_shape = dm_shape  # number of actuators
         self.name = name
         self._surface = np.zeros(dm_shape)  # array for the DM surface OPD, in meters
         self.numacross = dm_shape[0]  # number of actuators across diameter of
-        # the optic's cleared aperture (may be less than full diameter of array)
+            # the optic's cleared aperture (may be less than full diameter of array)
 
         # What is the total reflective area that passes light onwards?
         self.radius_reflective = radius
-        self._aperture = optics.CircularAperture(radius=radius)
+        self._aperture = optics.CircularAperture(radius=radius, **kwargs)
 
         # What is the active area and spacing between actuators?
         if actuator_spacing is None:
@@ -138,9 +146,6 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
             raise RuntimeError("Influence function file must have a SAMPLING keyword giving # pixels per actuator.")
 
         hdulist.close()
-
-        # , self.influence_header = fits.getdata(self.influence_func_file, header=True)
-        # self.influence = influence_func[0].data.copy()
 
     def _get_rescaled_influence_func(self, pixelscale):
         """ Return the influence function, rescaled onto the appropriate pixel scale for
@@ -277,7 +282,26 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
         if self.include_actuator_print_through:
             interpolated_surface += self._get_actuator_print_through(wave)
 
-        # phasor = np.exp(1.j * 2 * np.pi * interpolated_surface/wave.wavelength.value)
+        if hasattr(self, 'shift_x') or hasattr(self, 'shift_y'):
+            # Apply shifts here, if necessary. Doing it this way lets the same shift code apply
+            # across all of the above 3 potential ingredients into the OPD, potentially at some
+            # small cost in accuracy rather than shifting each individuall at a subpixel level.
+
+            # suppress irrelevant scipy warning from ndzoom calls
+            import warnings
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+
+                if (hasattr(self, 'shift_x') and self.shift_x !=0):
+                    pixscale_m = wave.pixelscale.to(u.m/u.pixel).value
+                    shift_x_pix = int(np.round(self.shift_x /pixscale_m))
+                    interpolated_surface = np.roll(interpolated_surface, shift_x_pix, axis=1)
+
+                if (hasattr(self, 'shift_y') and self.shift_y !=0):
+                    pixscale_m = wave.pixelscale.to(u.m/u.pixel).value
+                    shift_y_pix = int(np.round(self.shift_y /pixscale_m))
+                    interpolated_surface = np.roll(interpolated_surface, shift_y_pix, axis=0)
+
         return interpolated_surface
 
     def _get_surface_via_gaussian_influence_functions(self, wave):
@@ -350,7 +374,7 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
         # For now will just regenerate this every time. Slower but strict.
         # TODO - also consider the case where actuators are not spaced integer pixels apart...
         # Eventually that may require more accurate handling here instead of rounding to integer pixels.
-        _, x_wave = wave.coordinates()
+        y_wave, x_wave = wave.coordinates()
         y_act, x_act = self.get_act_coordinates(one_d=True)
         N_act = self.numacross
         x_wave_ind_act = np.argmin(np.abs(x_act.reshape((N_act, 1)) *
@@ -388,6 +412,11 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
         return dm_surface
 
     def get_transmission(self, wave):
+        # Pass through transformations of this optic to the aperture sub-optic, if needed
+        if hasattr(self, 'shift_x'):
+            self._aperture.shift_x = self.shift_x
+        if hasattr(self, 'shift_y'):
+            self._aperture.shift_y = self.shift_y
         return self._aperture.get_transmission(wave)
 
     def display(self, annotate=False, grid=False, what='opd', crosshairs=False, *args, **kwargs):

--- a/poppy/matrixDFT.py
+++ b/poppy/matrixDFT.py
@@ -94,7 +94,7 @@ def matrix_dft(plane, nlamD, npix,
         Is this a forward or inverse transformation? (Default is False,
         implying a forward transformation.)
     centering : {'FFTSTYLE', 'SYMMETRIC', 'ADJUSTABLE'}, optional
-        What type of centering convention should be used for this FFT? 
+        What type of centering convention should be used for this FFT?
 
         * ADJUSTABLE (the default) For an output array with ODD size n,
           the PSF center will be at the center of pixel (n-1)/2. For an output

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -74,9 +74,9 @@ class AnalyticOpticalElement(OpticalElement):
 
     def __str__(self):
         if self.planetype == PlaneType.pupil:
-            return "Pupil plane: %s (Analytic)" % self.name
+            return "Pupil plane: " + self.name
         elif self.planetype == PlaneType.image:
-            return "Image plane: %s (Analytic)" % self.name
+            return "Image plane: " + self.name
         else:
             return "Optic: " + self.name
 

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -1235,8 +1235,12 @@ class MultiHexagonAperture(AnalyticOpticalElement):
 
 
     Note that this routine becomes a bit slow for nrings >4. For repeated computations on
-    the same aperture, it will be faster to create this once, save it to a FITS file using
-    the toFITS() method, and then use that.
+    the same aperture, avoid repeated evaluations of this function. It will be faster to create
+    this aperture, evalute it once, and save the result onto a discrete array, via either
+       (1) saving it to a FITS file using the to_fits() method, and then use that in a
+       FITSOpticalElement, or
+       (2) Use the fixed_sampling_optic function to create an ArrayOpticalElement with
+       a sampled version of this.
 
     """
 
@@ -1296,80 +1300,51 @@ class MultiHexagonAperture(AnalyticOpticalElement):
         """
         ring = self._hex_in_ring(hex_index)
 
+        # handle degenerate case of center segment
+        # to avoid div by 0 in the main code below
+        if ring == 0:
+            return 0, 0
+
         # now count around from the starting point:
         index_in_ring = hex_index - self._n_hexes_inside_ring(ring) + 1  # 1-based
         angle_per_hex = 2 * np.pi / self._n_hexes_in_ring(ring)  # angle in radians
 
         # Now figure out what the radius is:
-        xpos = None
         flattoflat = self.flattoflat.to(u.meter).value
         gap = self.gap.to(u.meter).value
         side = self.side.to(u.meter).value
-        if ring <= 1:
-            radius = (flattoflat + gap) * ring
+
+        radius = (flattoflat + gap) * ring  # JWST 'B' segments, aka corners
+        if np.mod(index_in_ring, ring) == 1:
             angle = angle_per_hex * (index_in_ring - 1)
-        elif ring == 2:
-            if np.mod(index_in_ring, 2) == 1:
-                radius = (flattoflat + gap) * ring  # JWST 'B' segments
-            else:
-                radius = side * 3 + gap * np.sqrt(3.) / 2 * 2  # JWST 'C' segments
-            angle = angle_per_hex * (index_in_ring - 1)
-        elif ring == 3:
-            if np.mod(index_in_ring, ring) == 1:
-                radius = (flattoflat + gap) * ring  # JWST 'B' segments
-                angle = angle_per_hex * (index_in_ring - 1)
-            else:  # C-like segments (in pairs)
-                ypos = 2.5 * (flattoflat + gap)
-                xpos = 1.5 * side + gap * np.sqrt(3) / 4
-                radius = np.sqrt(xpos ** 2 + ypos ** 2)
-                Cangle = np.arctan2(xpos, ypos)
-
-                if np.mod(index_in_ring, 3) == 2:
-                    last_B_angle = ((index_in_ring - 1) // 3) * 3 * angle_per_hex
-                    angle = last_B_angle + Cangle * np.mod(index_in_ring - 1, 3)
-                else:
-                    next_B_angle = (((index_in_ring - 1) // 3) * 3 + 3) * angle_per_hex
-                    angle = next_B_angle - Cangle
-                xpos = None
-        else:  # generalized code!
-            # the above are actuall now redundant given that this exists, but
-            # I'll leave them alone for now.
-            # TODO:jlong: remove redundant code paths?
-            whichside = (index_in_ring - 1) // ring  # which of the sides are we on?
-
-            if np.mod(index_in_ring, ring) == 1:
-                radius = (flattoflat + gap) * ring  # JWST 'B' segments
-                angle = angle_per_hex * (index_in_ring - 1)
-            else:
-                # find position of previous 'B' type segment.
-                radius0 = (flattoflat + gap) * ring  # JWST 'B' segments
-                last_B_angle = ((index_in_ring - 1) // ring) * ring * angle_per_hex
-                ypos0 = radius0 * np.cos(last_B_angle)
-                xpos0 = radius0 * np.sin(last_B_angle)
-
-                da = (flattoflat + gap) * np.cos(30 * np.pi / 180)
-                db = (flattoflat + gap) * np.sin(30 * np.pi / 180)
-
-                if whichside == 0:
-                    dx, dy = da, -db
-                elif whichside == 1:
-                    dx, dy = 0, -(flattoflat + gap)
-                elif whichside == 2:
-                    dx, dy = -da, -db
-                elif whichside == 3:
-                    dx, dy = -da, db
-                elif whichside == 4:
-                    dx, dy = 0, (flattoflat + gap)
-                elif whichside == 5:
-                    dx, dy = da, db
-
-                xpos = xpos0 + dx * np.mod(index_in_ring - 1, ring)
-                ypos = ypos0 + dy * np.mod(index_in_ring - 1, ring)
-
-        # now clock clockwise around the ring (for rings <=3 only)
-        if xpos is None:
             ypos = radius * np.cos(angle)
             xpos = radius * np.sin(angle)
+        else:
+            # find position of previous 'B' type segment.
+            last_B_angle = ((index_in_ring - 1) // ring) * ring * angle_per_hex
+            ypos0 = radius * np.cos(last_B_angle)
+            xpos0 = radius * np.sin(last_B_angle)
+
+            # count around from that corner
+            da = (flattoflat + gap) * np.cos(30 * np.pi / 180)
+            db = (flattoflat + gap) * np.sin(30 * np.pi / 180)
+
+            whichside = (index_in_ring - 1) // ring  # which of the sides are we on?
+            if whichside == 0:
+                dx, dy = da, -db
+            elif whichside == 1:
+                dx, dy = 0, -(flattoflat + gap)
+            elif whichside == 2:
+                dx, dy = -da, -db
+            elif whichside == 3:
+                dx, dy = -da, db
+            elif whichside == 4:
+                dx, dy = 0, (flattoflat + gap)
+            elif whichside == 5:
+                dx, dy = da, db
+
+            xpos = xpos0 + dx * np.mod(index_in_ring - 1, ring)
+            ypos = ypos0 + dy * np.mod(index_in_ring - 1, ring)
 
         return ypos, xpos
 
@@ -1963,7 +1938,7 @@ def fixed_sampling_optic(optic, wavefront):
         A version ofthe input optic with fixed arrays for OPD and transmission.
 
     """
-    from poppy_core import ArrayOpticalElement
+    from .poppy_core import ArrayOpticalElement
     npix = wavefront.shape[0]
     grid_size = npix*u.pixel*wavefront.pixelscale
     sampled_opd = optic.sample(what='opd', npix=npix, grid_size=grid_size)
@@ -1971,5 +1946,5 @@ def fixed_sampling_optic(optic, wavefront):
 
     return ArrayOpticalElement(opd=sampled_opd,
                                transmission=sampled_trans,
-                               pixelscale=wf.pixelscale,
+                               pixelscale=wavefront.pixelscale,
                                name=optic.name)

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2170,6 +2170,17 @@ class CompoundOpticalSystem(OpticalSystem):
         else:
             return wavefront
 
+    @property
+    def planes(self):
+        """ A merged list containing all the planes in all the included optical systems """
+        out = []
+        [out.extend(osys.planes) for osys in self.optsyslist]
+        return out
+
+    @planes.setter
+    def planes(self, value):
+        # needed for compatibility with superclass init
+        pass
 
 # ------ core Optical Element Classes ------
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -600,6 +600,7 @@ class BaseWavefront(ABC):
         display_what = getattr(optic, 'wavefront_display_hint', 'best')
         display_vmax = getattr(optic, 'wavefront_display_vmax_hint', None)
         display_vmin = getattr(optic, 'wavefront_display_vmin_hint', None)
+        display_crop = getattr(optic, 'wavefront_display_imagecrop', None)
         display_nrows = getattr(self, '_display_hint_expected_nplanes', default_nplanes)
 
         ax = self.display(what=display_what,
@@ -607,6 +608,7 @@ class BaseWavefront(ABC):
                           nrows=display_nrows,
                           colorbar=False,
                           vmax=display_vmax, vmin=display_vmin,
+                          imagecrop=display_crop,
                           **kwargs)
         if hasattr(optic, 'display_annotate'):
             optic.display_annotate(optic, ax)  # atypical calling convention needed empirically
@@ -942,7 +944,7 @@ class Wavefront(BaseWavefront):
             self.planetype = PlaneType.image
             self.pixelscale = (self.wavelength / self.diam * u.radian / self.oversample).to(u.arcsec) / u.pixel
             self.fov = self.wavefront.shape[0] * u.pixel * self.pixelscale
-            self.history.append('   FFT {},  to IMAGE plane  scale={}'.format(self.wavefront.shape, self.pixelscale))
+            self.history.append('   FFT {},  to IMAGE plane  scale={:.4f}'.format(self.wavefront.shape, self.pixelscale))
 
         elif self.planetype == PlaneType.image and optic.planetype == PlaneType.pupil:
             fft_forward = False
@@ -950,7 +952,7 @@ class Wavefront(BaseWavefront):
             # (pre-)update state:
             self.planetype = PlaneType.pupil
             self.pixelscale = self.diam * self.oversample / (self.wavefront.shape[0] * u.pixel)
-            self.history.append('   FFT {},  to PUPIL scale={}'.format(self.wavefront.shape, self.pixelscale))
+            self.history.append('   FFT {},  to PUPIL scale={:.4f}'.format(self.wavefront.shape, self.pixelscale))
 
         # do FFT
         if conf.enable_flux_tests: _log.debug("\tPre-FFT total intensity: " + str(self.total_intensity))
@@ -2150,7 +2152,7 @@ class CompoundOpticalSystem(OpticalSystem):
                 loghistory(wavefront, "CompoundOpticalSystem: Converted wavefront to Fraunhofer type")
 
             # Propagate
-            loghistory(wavefront, "CompoundOpticalSystem: Propagating through system {}: {}".format(i, optsys.name))
+            loghistory(wavefront, "CompoundOpticalSystem: Propagating through system {}: {}".format(i+1, optsys.name))
             retval = optsys.propagate(wavefront,
                                       normalize=normalize,
                                       return_intermediates=return_intermediates,
@@ -3077,7 +3079,7 @@ class Detector(OpticalElement):
         return (int(fpix), int(fpix)) if np.isscalar(fpix) else fpix.astype(int)[0:2]
 
     def __str__(self):
-        return "Detector plane: {} ({}x{} pixels, {})".format(self.name, self.shape[1], self.shape[0], self.pixelscale)
+        return "Detector plane: {} ({}x{} pixels, {:.3f})".format(self.name, self.shape[1], self.shape[0], self.pixelscale)
 
     @staticmethod
     def _handle_pixelscale_units_flexibly(pixelscale, fov_pixels):

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -594,3 +594,6 @@ def test_CompoundOpticalSystem():
     np.testing.assert_allclose(psf_simple[0].data, psf_compound[0].data,
                                err_msg="PSFs do not match between equivalent simple and compound optical systems")
 
+
+    # check the planes
+    assert len(cosys.planes) == len(osys1.planes)+len(osys2.planes)

--- a/poppy/tests/test_misc.py
+++ b/poppy/tests/test_misc.py
@@ -21,7 +21,7 @@ def test_airy_1d(display=False):
         plt.axvline(1.028/2, color='k', ls=':')
         plt.axhline(0.5, color='k', ls=':')
         plt.ylabel('Intensity relative to peak')
-        plt.xlabel('Separation in $\lambda/D$')
+        plt.xlabel('Separation in $\\lambda/D$')
         for rad in airy_zeros:
             plt.axvline(rad, color='red', ls='--')
 
@@ -60,13 +60,13 @@ def test_airy_2d(display=False):
         plt.legend(loc='upper right')
         plt.axvline(0.251643, color='red', ls='--')
         plt.ylabel('Intensity relative to peak')
-        plt.xlabel('Separation in $\lambda/D$')
+        plt.xlabel('Separation in $\\lambda/D$')
  
         ax=plt.subplot(212)
         plt.plot(r, cut-fn1d)
         ax.set_ylim(-1e-8, 1e-8)
         plt.ylabel('Difference')
-        plt.xlabel('Separation in $\lambda/D$')
+        plt.xlabel('Separation in $\\lambda/D$')
 
     #print fn1d[0], cut[0]
     #print np.abs(fn1d-cut) #< 1e-9
@@ -109,7 +109,7 @@ def test_sinc2_2d(display=False):
 
         plt.legend(loc='upper right')
         plt.ylabel('Intensity relative to peak')
-        plt.xlabel('Separation in $\lambda/D$')
+        plt.xlabel('Separation in $\\lambda/D$')
  
         #plt.plot(r, cut-fn1d)
         #ax.set_ylim(-1e-8, 1e-8)

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -635,3 +635,11 @@ def test_ThinLens(display=False):
         "ThinLens shouldn't be affected by null optical elements! Introducing extra image planes "
         "made the output PSFs differ beyond numerical tolerances."
     )
+
+def test_fixed_sampling_optic():
+    optic= optics.HexagonAperture(side=1)
+    wave = poppy_core.Wavefront(npix=100, diam=10.0, wavelength=1e-6) # 10x10 meter square
+
+    array_optic= optics.fixed_sampling_optic(optic, wave)
+
+    assert np.allclose(array_optic.amplitude, optic.get_transmission(wave)), 'mismatch between original and fixed sampling version'


### PR DESCRIPTION
_(Not a super well organized PR; a couple unrelated things in here. To make a long story short, I meant to just PR in the fix to 303, but a couple other recent commits also got swept up in that, and I decided I might as well just go with it rather than redo and split up into multiple PRs)._ 

1. Simplifies the code inside `MultiHexagonAperture`, fixing #303. 
2.  Implements `shift_x` and `shift_y` options for the `ContinuousDeformableMirror` class. Same syntax as for any other optical element, just a different implementation for compatibility with how that class works. 
3. Adds a new function `fixed_sampling_optic` which takes any AnalyticOpticalElement and returns an equivalent ArrayOpticalElement with fixed sampling. This is useful for instance for taking a computationally-slow optic such as MultiHexagonAperture and saving a discretized version for future faster use.
4. Implement `.planes` attribute for CompoundOpticalSystem, which acts as a view to the concatenation of the planes of all the subsidiary optical systems
5. Various small display or docs improvements.  