### PR TITLE
update ContinousDM.display_actuators to work after PR #314 display refactoring

### DIFF
--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -120,6 +120,7 @@ from .wfe import *
 from .fresnel import *
 from .physical_wavefront import *
 from .special_prop import *
+from .dms import *
 
 from .instrument import Instrument
 

--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -470,6 +470,7 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
 
     def display_actuators(self, annotate=False, grid=True, what='opd', crosshairs=False, *args, **kwargs):
         """ Display the optical surface, viewed as discrete actuators
+
         Parameters
         ------------
         annotate : bool
@@ -482,23 +483,11 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
             Draw crosshairs on plot to indicate the origin.
         """
 
-        # display in DM coordinates
-        # temporarily set attributes appropriately as if this were a regular OpticalElement
-        self.amplitude = np.ones_like(self.surface)
-        self.opd = self.surface
-        if self.include_actuator_mask:
-            self.amplitude[self.actuator_mask == 0] = 0
-
-        self.pixelscale = self.actuator_spacing / u.pixel
-
-        # then call parent class display
-        returnvalue = optics.OpticalElement.display(self, what=what, crosshairs=crosshairs, **kwargs)
-
-        # now un-set all the temporary attributes, since this is analytic and
-        # these are unneeded
-        del self.pixelscale
-        del self.opd
-        del self.amplitude
+        # call parent class display, setting parameters to display at actuator grid resolution
+        returnvalue = super().display(what=what, crosshairs=crosshairs,
+                npix = self.dm_shape[0],
+                grid_size = self.dm_shape[0]*self.actuator_spacing.to(u.m).value,
+                **kwargs)
 
         if annotate: self.annotate()
         if grid: self.annotate_grid()

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -25,7 +25,7 @@ __all__ = ['AnalyticOpticalElement', 'ScalarTransmission', 'InverseTransmission'
            'CircularOcculter', 'BarOcculter', 'FQPM_FFT_aligner', 'CircularAperture',
            'HexagonAperture', 'MultiHexagonAperture', 'NgonAperture', 'RectangleAperture',
            'SquareAperture', 'SecondaryObscuration', 'AsymmetricSecondaryObscuration',
-           'ThinLens', 'GaussianAperture', 'CompoundAnalyticOptic']
+           'ThinLens', 'GaussianAperture', 'KnifeEdge', 'CompoundAnalyticOptic', 'fixed_sampling_optic']
 
 
 # ------ Generic Analytic elements -----

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -24,7 +24,8 @@ from . import zernike
 from . import utils
 from . import accel_math
 
-__all__ = ['WavefrontError', 'ParameterizedWFE', 'ZernikeWFE', 'SineWaveWFE']
+__all__ = ['WavefrontError', 'ParameterizedWFE', 'ZernikeWFE', 'SineWaveWFE',
+        'StatisticalPSDWFE']
 
 
 def _accept_wavefront_or_meters(f):


### PR DESCRIPTION
The update I just merged in #314 to fix display but #309 caused some trouble for the `ContinousDeformableMirror.display_actuators()` function. Conveniently the fix for this is to substantially simplify `display_actuators` and throw away most of the code in it. :-) This just goes to show that the refactoring in #314 was indeed a good idea. 

An unrelated minor fix that I also included in this PR is to update a few imports and `__all__` lists so a few recently-added classes will now also be in the top `poppy` namespace. E.g. you can now say `poppy.StatisticalPSDWFE` instead of `poppy.wfe.StatisticalPSDWFE`, and `poppy.ContinuousDeformableMirror` instead of `poppy.dms.ContinuousDeformableMirror`.

