### PR TITLE
remove _accept_wavefront_or_meters and units args, and related tests, to fix #312 and #199

### DIFF
--- a/poppy/tests/test_wfe.py
+++ b/poppy/tests/test_wfe.py
@@ -36,24 +36,13 @@ def test_ZernikeAberration():
 
     assert stddev < 1e-16, ("ZernikeAberration disagrees with ThinLens! stddev {}".format(stddev))
 
-def test_wavefront_or_meters_decorator():
-    zernike_lens = wfe.ZernikeWFE(
-        coefficients=[0, 0, 0, NWAVES * WAVELENGTH / (2 * np.sqrt(3))],
-        radius=RADIUS
-    )
-    opd_waves_a = zernike_lens.get_opd(WAVELENGTH)
-    opd_waves_b = zernike_lens.get_opd(poppy_core.Wavefront(wavelength=WAVELENGTH))
-
-    stddev = np.std(opd_waves_a - opd_waves_b)
-    assert stddev < 1e-16, "OPD map disagreement based on form of argument to get_opd!"
 
 def test_zernike_get_opd():
+    wave = poppy_core.Wavefront(wavelength=WAVELENGTH)
     zernike_optic = wfe.ZernikeWFE(coefficients=[NWAVES * WAVELENGTH,], radius=RADIUS)
-    opd_map = zernike_optic.get_opd(WAVELENGTH, units='meters')
+    opd_map = zernike_optic.get_opd(wave)
     assert np.max(opd_map) == NWAVES * WAVELENGTH
 
-    opd_map_waves = zernike_optic.get_opd(WAVELENGTH, units='waves')
-    assert np.max(opd_map_waves) == NWAVES
 
 def test_ParameterizedAberration():
     # verify that we can reproduce the same behavior as ZernikeAberration

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -28,21 +28,17 @@ __all__ = ['WavefrontError', 'ParameterizedWFE', 'ZernikeWFE', 'SineWaveWFE',
         'StatisticalPSDWFE']
 
 
-def _accept_wavefront_or_meters(f):
+def _check_wavefront_arg(f):
     """Decorator that ensures the first positional method argument
-    is a poppy.Wavefront or a floating point number of meters
-    for a wavelength
+    is a poppy.Wavefront or FresnelWavefront
     """
 
     @wraps(f)
     def wrapper(*args, **kwargs):
         if not isinstance(args[1], BaseWavefront):
-            wave = Wavefront(wavelength=args[1])
-            new_args = (args[0],) + (wave,) + (args[2:])
-            return f(*new_args, **kwargs)
+            raise ValueError("The first argument must be a Wavefront or FresnelWavefront object.")
         else:
             return f(*args, **kwargs)
-
     return wrapper
 
 
@@ -61,8 +57,8 @@ class WavefrontError(AnalyticOpticalElement):
         # in general we will want to see phase rather than intensity at this plane
         self.wavefront_display_hint = 'phase'
 
-    @_accept_wavefront_or_meters
-    def get_opd(self, wave, units='meters'):
+    @_check_wavefront_arg
+    def get_opd(self, wave):
         """Construct the optical path difference array for a wavefront error source
         as evaluated across the pupil for an input wavefront `wave`
 
@@ -71,8 +67,6 @@ class WavefrontError(AnalyticOpticalElement):
         wave : Wavefront
             Wavefront object with a `coordinates` method that returns (y, x)
             coordinate arrays in meters in the pupil plane
-        units : 'meters' or 'waves'
-            The units of optical path difference (Default: meters)
         """
         raise NotImplementedError('Not implemented yet')
 
@@ -159,8 +153,8 @@ class ParameterizedWFE(WavefrontError):
         self._default_display_size = radius * 3
         super(ParameterizedWFE, self).__init__(name=name, **kwargs)
 
-    @_accept_wavefront_or_meters
-    def get_opd(self, wave, units='meters'):
+    @_check_wavefront_arg
+    def get_opd(self, wave):
         y, x = self.get_coordinates(wave)
         rho, theta = _wave_y_x_to_rho_theta(y, x, self.radius.to(u.meter).value)
 
@@ -174,12 +168,7 @@ class ParameterizedWFE(WavefrontError):
                 continue  # save the trouble of a multiply-and-add of zeros
             coefficient_in_m = coefficient.to(u.meter).value
             combined_distortion += coefficient_in_m * computed_terms[idx]
-        if units == 'meters':
-            return combined_distortion
-        elif units == 'waves':
-            return combined_distortion / wave.wavelength
-        else:
-            raise ValueError("'units' argument must be 'meters' or 'waves'")
+        return combined_distortion
 
 
 class ZernikeWFE(WavefrontError):
@@ -214,8 +203,8 @@ class ZernikeWFE(WavefrontError):
         kwargs.update({'name': name})
         super(ZernikeWFE, self).__init__(**kwargs)
 
-    @_accept_wavefront_or_meters
-    def get_opd(self, wave, units='meters'):
+    @_check_wavefront_arg
+    def get_opd(self, wave):
         """
         Parameters
         ----------
@@ -223,11 +212,6 @@ class ZernikeWFE(WavefrontError):
             Incoming Wavefront before this optic to set wavelength and
             scale, or a float giving the wavelength in meters
             for a temporary Wavefront used to compute the OPD.
-        units : 'meters' or 'waves'
-            Coefficients are supplied in `ZernikeWFE.coefficients` as
-            meters of OPD, but the resulting OPD can be converted to
-            waves based on the `Wavefront` wavelength or a supplied
-            wavelength value.
         """
 
         # the Zernike optic, being normalized on a circle, is
@@ -267,8 +251,6 @@ class ZernikeWFE(WavefrontError):
                 )
 
         combined_zernikes *= aperture_intensity
-        if units == 'waves':
-            combined_zernikes /= wave.wavelength.to(u.meter).value
         return combined_zernikes
 
 
@@ -303,8 +285,8 @@ class SineWaveWFE(WavefrontError):
         # note, can't call this next one 'amplitude' since that's already a property
         self.sine_amplitude = amplitude
 
-    @_accept_wavefront_or_meters
-    def get_opd(self, wave, units='meters'):
+    @_check_wavefront_arg
+    def get_opd(self, wave):
         """
         Parameters
         ----------
@@ -312,11 +294,6 @@ class SineWaveWFE(WavefrontError):
             Incoming Wavefront before this optic to set wavelength and
             scale, or a float giving the wavelength in meters
             for a temporary Wavefront used to compute the OPD.
-        units : 'meters' or 'waves'
-            Coefficients are supplied as meters of OPD, but the
-            resulting OPD can be converted to
-            waves based on the `Wavefront` wavelength or a supplied
-            wavelength value.
         """
 
         y, x = self.get_coordinates(wave)  # in meters
@@ -324,8 +301,6 @@ class SineWaveWFE(WavefrontError):
         opd = self.sine_amplitude.to(u.meter).value * \
               np.sin(2 * np.pi * (x * self.sine_spatial_freq.to(1 / u.meter).value + self.sine_phase_offset))
 
-        if units == 'waves':
-            opd /= wave.wavelength.to(u.meter).value
         return opd
 
 
@@ -356,7 +331,7 @@ class StatisticalPSDWFE(WavefrontError):
         self.radius = radius
         self.seed = seed
 
-    @_accept_wavefront_or_meters
+    @_check_wavefront_arg
     def get_opd(self, wave, units='meters'):
         """
         Parameters

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -332,7 +332,7 @@ class StatisticalPSDWFE(WavefrontError):
         self.seed = seed
 
     @_check_wavefront_arg
-    def get_opd(self, wave, units='meters'):
+    def get_opd(self, wave):
         """
         Parameters
         ----------

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -340,11 +340,6 @@ class StatisticalPSDWFE(WavefrontError):
             Incoming Wavefront before this optic to set wavelength and
             scale, or a float giving the wavelength in meters
             for a temporary Wavefront used to compute the OPD.
-        units : 'meters' or 'waves'
-            Coefficients are supplied as meters of OPD, but the
-            resulting OPD can be converted to
-            waves based on the `Wavefront` wavelength or a supplied
-            wavelength value.
         """
         y, x = self.get_coordinates(wave)
         rho, theta = _wave_y_x_to_rho_theta(y, x, self.radius.to(u.meter).value)
@@ -358,8 +353,5 @@ class StatisticalPSDWFE(WavefrontError):
 
         phase_screen -= np.mean(phase_screen)  # force zero-mean
         opd = phase_screen / np.std(phase_screen) * self.wfe.to(u.m).value  # normalize to wanted input rms wfe
-
-        if units == 'waves':
-            opd /= wave.wavelength.to(u.meter).value
 
         return opd


### PR DESCRIPTION
This PR would remove the ability of WFE classes' `get_opd` functions to accept both Wavefront objects or raw floating-point wavelength values . That behavior was inconsistent with how anything else worked, caused problems (see #199), wasn't used anywhere else in poppy, and wasn't described in the documentation. So I think we can simply drop it, for an overall simplification. 

I replaced it with a wrapper that just checks the input argument is a wavefront and raises an error if not. This could be moved upstream into optics.py later for use on all the optic classes there, if it proves sufficiently useful. 