### PR TITLE
Implement gray subpixel sampling for circular apertures

### DIFF
--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -1,13 +1,14 @@
-
-import numpy as np
-
-
 #  Functions for reasonably exact geometry on discrete arrays
 #  These codes allow you to calculate circles and other such
 #  shapes discretized onto arrays with proper handling of areas
 #  at subpixel precision. (or at least reasonably proper; no
 #  guarantees for utter mathematical exactness at machine precision.)
 
+import numpy as np
+
+from . import accel_math
+if accel_math._USE_NUMEXPR:
+    import numexpr as ne
 
 # original code in pixwt.c by Marc Buie
 #    See http://www.boulder.swri.edu/~buie/idl/downloads/custom/32bit/pixwt.c
@@ -29,7 +30,10 @@ def _arc(x, y0, y1, r):
     is traversed clockwise then the area is negative, otherwise it is
     positive.
     """
-    return 0.5 * r**2 * (np.arctan(y1/x) - np.arctan(y0/x))
+    if accel_math._USE_NUMEXPR:
+        return ne.evaluate("0.5 * r**2 * (arctan(y1/x) - arctan(y0/x))")
+    else:
+        return 0.5 * r**2 * (np.arctan(y1/x) - np.arctan(y0/x))
 
 def _chord(x, y0, y1):
     """

--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -13,9 +13,8 @@ import numpy as np
 # 
 # ported to pixwt.pro (IDL) by Doug Loucks, Lowell Observatory, 1992 Sep
 #
-# subsequently ported to python by Michael Fitzgerald,
-# LLNL, fitzgerald15@llnl.gov, 2007-10-16
-#
+# subsequently ported to python by Michael Fitzgerald, 2007-10-16
+# LLNL / UCLA
 
 def _arc(x, y0, y1, r):
     """
@@ -167,6 +166,7 @@ def filled_circle_aa(shape, xcenter, ycenter, radius, xarray=None, yarray=None, 
     xarray, yarray : 2d ndarrays
         X and Y coordinates corresponding to the center of each pixel
         in the main array. If not present, integer pixel indices are assumed.
+        WARNING - code currently is buggy with pixel scales != 1
     fillvalue : float
         Value to add into the array, for pixels that are entirely within the radius.
         This is *added* to each pixel at the specified coordinates. Default is 1
@@ -175,7 +175,6 @@ def filled_circle_aa(shape, xcenter, ycenter, radius, xarray=None, yarray=None, 
     cliprange : array_like
         if clip is True, give values to use in the clip function.
     """
-
 
 
 
@@ -189,11 +188,15 @@ def filled_circle_aa(shape, xcenter, ycenter, radius, xarray=None, yarray=None, 
     array[r < radius ]  = fillvalue
 
     pixscale = np.abs(xarray[0,1] - xarray[0,0])
+    area_per_pix = pixscale**2
+
+    if np.abs(pixscale -1.0) > 0.01:
+        _log.warning('filled_circle_aa is not reliable for pixel scale <1')
     border = np.where( np.abs(r-radius) < pixscale)
 
     weights = pixwt(xcenter, ycenter, radius, xarray[border], yarray[border])
 
-    array[border] = weights
+    array[border] = weights *fillvalue/area_per_pix
 
 
     if clip:

--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -1,0 +1,202 @@
+
+import numpy as np
+
+
+#  Functions for reasonably exact geometry on discrete arrays
+#  These codes allow you to calculate circles and other such
+#  shapes discretized onto arrays with proper handling of areas
+#  at subpixel precision. (or at least reasonably proper; no 
+#  guarantees for utter mathematical exactness at machine precision.)
+
+
+# original code in pixwt.c by Marc Buie
+# 
+# ported to pixwt.pro (IDL) by Doug Loucks, Lowell Observatory, 1992 Sep
+#
+# subsequently ported to python by Michael Fitzgerald,
+# LLNL, fitzgerald15@llnl.gov, 2007-10-16
+#
+
+def _arc(x, y0, y1, r):
+    """
+    Compute the area within an arc of a circle.  The arc is defined by
+    the two points (x,y0) and (x,y1) in the following manner: The
+    circle is of radius r and is positioned at the origin.  The origin
+    and each individual point define a line which intersects the
+    circle at some point.  The angle between these two points on the
+    circle measured from y0 to y1 defines the sides of a wedge of the
+    circle.  The area returned is the area of this wedge.  If the area
+    is traversed clockwise then the area is negative, otherwise it is
+    positive.
+    """
+    return 0.5 * r**2 * (np.arctan(y1/x) - np.arctan(y0/x))
+
+def _chord(x, y0, y1):
+    """
+    Compute the area of a triangle defined by the origin and two
+    points, (x,y0) and (x,y1).  This is a signed area.  If y1 > y0
+    then the area will be positive, otherwise it will be negative.
+    """
+    return 0.5 * x * (y1 - y0)
+
+def _oneside(x, y0, y1, r):
+    """
+    Compute the area of intersection between a triangle and a circle.
+    The circle is centered at the origin and has a radius of r.  The
+    triangle has verticies at the origin and at (x,y0) and (x,y1).
+    This is a signed area.  The path is traversed from y0 to y1.  If
+    this path takes you clockwise the area will be negative.
+    """
+
+    if np.all((x==0)): return x
+
+    sx = x.shape
+    ans = np.zeros(sx, dtype=np.float)
+    yh = np.zeros(sx, dtype=np.float)
+    to = (abs(x) >= r)
+    ti = (abs(x) < r)
+    if np.any(to):
+        ans[to] = _arc(x[to], y0[to], y1[to], r)
+    if not np.any(ti):
+        return ans
+
+    yh[ti] = np.sqrt(r**2 - x[ti]**2)
+
+    i = ((y0 <= -yh) & ti)
+    if np.any(i):
+
+        j = ((y1 <= -yh) & i)
+        if np.any(j):
+            ans[j] = _arc(x[j], y0[j], y1[j], r)
+
+        j = ((y1 > -yh) & (y1 <= yh) & i)
+        if np.any(j):
+            ans[j] = _arc(x[j], y0[j], -yh[j], r) + \
+                     _chord(x[j], -yh[j], y1[j])
+
+        j = ((y1 > yh) & i)
+        if np.any(j):
+            ans[j] = _arc(x[j], y0[j], -yh[j], r) + \
+                     _chord(x[j], -yh[j], yh[j]) + \
+                     _arc(x[j], yh[j], y1[j], r)
+
+    i = ((y0 > -yh) & (y0 < yh) & ti)
+    if np.any(i):
+
+        j = ((y1 <= -yh) & i)
+        if np.any(j):
+            ans[j] = _chord(x[j], y0[j], -yh[j]) + \
+                     _arc(x[j], -yh[j], y1[j], r)
+
+        j = ((y1 > -yh) & (y1 <= yh) & i)
+        if np.any(j):
+            ans[j] = _chord(x[j], y0[j], y1[j])
+
+        j = ((y1 > yh) & i)
+        if np.any(j):
+            ans[j] = _chord(x[j], y0[j], yh[j]) + \
+                     _arc(x[j], yh[j], y1[j], r)
+        
+    i = ((y0 >= yh) & ti)
+    if np.any(i):
+
+        j = ((y1 <= -yh) & i)
+        if np.any(j):
+            ans[j] = _arc(x[j], y0[j], yh[j], r) + \
+                     _chord(x[j], yh[j], -yh[j]) + \
+                     _arc(x[j], -yh[j], y1[j], r)
+
+        j = ((y1 > -yh) & (y1 <= yh) & i)
+        if np.any(j):
+            ans[j] = _arc(x[j], y0[j], yh[j], r) + \
+                     _chord(x[j], yh[j], y1[j])
+
+        j = ((y1 > yh) & i)
+        if np.any(j):
+            ans[j] = _arc(x[j], y0[j], y1[j], r)
+    return ans
+
+def _intarea(xc, yc, r, x0, x1, y0, y1):
+    """
+    Compute the area of overlap of a circle and a rectangle.
+      xc, yc  :  Center of the circle.
+      r       :  Radius of the circle.
+      x0, y0  :  Corner of the rectangle.
+      x1, y1  :  Opposite corner of the rectangle.
+    """
+    x0 = x0 - xc
+    y0 = y0 - yc
+    x1 = x1 - xc
+    y1 = y1 - yc
+    return _oneside(x1, y0, y1, r) + _oneside(y1, -x1, -x0, r) + \
+           _oneside(-x0, -y1, -y0, r) + _oneside(-y0, x0, x1, r)
+
+def pixwt(xc, yc, r, x, y):
+    """
+    Compute the fraction of a unit pixel that is interior to a circle.
+    The circle has a radius r and is centered at (xc, yc).  The center
+    of the unit pixel (length of sides = 1) is at (x, y).
+
+    Divides the circle and rectangle into a series of sectors and
+    triangles.  Determines which of nine possible cases for the
+    overlap applies and sums the areas of the corresponding sectors
+    and triangles.
+
+    area = pixwt( xc, yc, r, x, y )
+
+    xc, yc : Center of the circle, numeric scalars
+    r      : Radius of the circle, numeric scalars
+    x, y   : Center of the unit pixel, numeric scalar or vector
+    """
+    return _intarea(xc, yc, r, x-0.5, x+0.5, y-0.5, y+0.5)
+
+
+
+def filled_circle_aa(shape, xcenter, ycenter, radius, xarray=None, yarray=None, fillvalue=1, clip=True, cliprange=(0,1)):
+    """Draw a filled circle with subpixel antialiasing into an array.
+
+    Parameters
+    -------------
+    shape : 2d ndarray
+        shape of array to return
+    xcenter, ycenter : floats
+        (X, Y) coordinates for the center of the circle (in the coordinate
+        system specified by the xarray and yarray parameters, if those are given)
+    radius : float
+        Radius of the circle
+    xarray, yarray : 2d ndarrays
+        X and Y coordinates corresponding to the center of each pixel
+        in the main array. If not present, integer pixel indices are assumed.
+    fillvalue : float
+        Value to add into the array, for pixels that are entirely within the radius.
+        This is *added* to each pixel at the specified coordinates. Default is 1
+    clip : bool
+        Clip the output array values to between the values given by the cliprange parameter.
+    cliprange : array_like
+        if clip is True, give values to use in the clip function.
+    """
+
+
+
+
+    array = np.zeros(shape)
+
+    if xarray is None or yarray is None:
+        yarray, xarray = np.indices(shape)
+
+
+    r = np.sqrt( (xarray-xcenter)**2 + (yarray-ycenter)**2)
+    array[r < radius ]  = fillvalue
+
+    pixscale = np.abs(xarray[0,1] - xarray[0,0])
+    border = np.where( np.abs(r-radius) < pixscale)
+
+    weights = pixwt(xcenter, ycenter, radius, xarray[border], yarray[border])
+
+    array[border] = weights
+
+
+    if clip:
+        assert len(cliprange) == 2
+        np.clip(array, *cliprange)
+    return array

--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -10,6 +10,7 @@ import numpy as np
 
 
 # original code in pixwt.c by Marc Buie
+#    See http://www.boulder.swri.edu/~buie/idl/downloads/custom/32bit/pixwt.c
 # 
 # ported to pixwt.pro (IDL) by Doug Loucks, Lowell Observatory, 1992 Sep
 #
@@ -49,6 +50,9 @@ def _oneside(x, y0, y1, r):
 
     if np.all((x==0)): return x
 
+    if np.isscalar(x): x = np.asarray(x)
+    if np.isscalar(y0): y0 = np.asarray(y0)
+    if np.isscalar(y1): y1 = np.asarray(y1)
     sx = x.shape
     ans = np.zeros(sx, dtype=np.float)
     yh = np.zeros(sx, dtype=np.float)
@@ -143,15 +147,16 @@ def pixwt(xc, yc, r, x, y):
 
     area = pixwt( xc, yc, r, x, y )
 
-    xc, yc : Center of the circle, numeric scalars
-    r      : Radius of the circle, numeric scalars
-    x, y   : Center of the unit pixel, numeric scalar or vector
+    xc, yc : Center of the circle, numpy scalars
+    r      : Radius of the circle, numpy scalars
+    x, y   : Center of the unit pixel, numpy scalar or vector
     """
     return _intarea(xc, yc, r, x-0.5, x+0.5, y-0.5, y+0.5)
 
 
 
-def filled_circle_aa(shape, xcenter, ycenter, radius, xarray=None, yarray=None, fillvalue=1, clip=True, cliprange=(0,1)):
+def filled_circle_aa(shape, xcenter, ycenter, radius, xarray=None, yarray=None, 
+        fillvalue=1, clip=True, cliprange=(0,1)):
     """Draw a filled circle with subpixel antialiasing into an array.
 
     Parameters
@@ -201,5 +206,6 @@ def filled_circle_aa(shape, xcenter, ycenter, radius, xarray=None, yarray=None, 
 
     if clip:
         assert len(cliprange) == 2
-        np.clip(array, *cliprange)
-    return array
+        return np.asarray(array).clip(*cliprange)
+    else:
+        return array

--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -5,13 +5,13 @@ import numpy as np
 #  Functions for reasonably exact geometry on discrete arrays
 #  These codes allow you to calculate circles and other such
 #  shapes discretized onto arrays with proper handling of areas
-#  at subpixel precision. (or at least reasonably proper; no 
+#  at subpixel precision. (or at least reasonably proper; no
 #  guarantees for utter mathematical exactness at machine precision.)
 
 
 # original code in pixwt.c by Marc Buie
 #    See http://www.boulder.swri.edu/~buie/idl/downloads/custom/32bit/pixwt.c
-# 
+#
 # ported to pixwt.pro (IDL) by Doug Loucks, Lowell Observatory, 1992 Sep
 #
 # subsequently ported to python by Michael Fitzgerald, 2007-10-16
@@ -99,7 +99,7 @@ def _oneside(x, y0, y1, r):
         if np.any(j):
             ans[j] = _chord(x[j], y0[j], yh[j]) + \
                      _arc(x[j], yh[j], y1[j], r)
-        
+
     i = ((y0 >= yh) & ti)
     if np.any(i):
 
@@ -155,7 +155,7 @@ def pixwt(xc, yc, r, x, y):
 
 
 
-def filled_circle_aa(shape, xcenter, ycenter, radius, xarray=None, yarray=None, 
+def filled_circle_aa(shape, xcenter, ycenter, radius, xarray=None, yarray=None,
         fillvalue=1, clip=True, cliprange=(0,1)):
     """Draw a filled circle with subpixel antialiasing into an array.
 

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -1048,6 +1048,8 @@ class CircularAperture(AnalyticOpticalElement):
         if name is None:
             name = "Circle, radius={}".format(radius)
         super(CircularAperture, self).__init__(name=name, planetype=planetype, **kwargs)
+        if radius <= 0*u.meter:
+            raise ValueError("radius must be a positive nonzero number.")
         self.radius = radius
         # for creating input wavefronts - let's pad a bit:
         self.pupil_diam = pad_factor * 2 * self.radius
@@ -1063,7 +1065,7 @@ class CircularAperture(AnalyticOpticalElement):
 
         y, x = self.get_coordinates(wave)
         radius = self.radius.to(u.meter).value
-        pixscale = wave.pixelscale.to(u.meter).value
+        pixscale = wave.pixelscale.to(u.meter/u.pixel).value
         self.transmission = geometry.filled_circle_aa(wave.shape, 0, 0, radius/pixscale, x/pixscale, y/pixscale)
         return self.transmission
 

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -1640,9 +1640,6 @@ class ThinLens(CircularAperture):
         r = np.sqrt(x ** 2 + y ** 2)
         r_norm = r / self.radius.to(u.meter).value
 
-        # the thin lens is explicitly also a circular aperture:
-        aperture_intensity = CircularAperture.get_transmission(self, wave)
-        # we use the aperture instensity here to mask the OPD we return
 
         # don't forget the factor of 0.5 to make the scaling factor apply as peak-to-valley
         # rather than center-to-peak
@@ -1650,6 +1647,12 @@ class ThinLens(CircularAperture):
                            (0.5 * self.nwaves * self.reference_wavelength.to(u.meter).value))
         # add negative sign here to get desired sign convention
         opd = -defocus_zernike * aperture_intensity
+
+        # the thin lens is explicitly also a circular aperture:
+        # we use the aperture instensity here to mask the OPD we return
+        aperture_intensity = CircularAperture.get_transmission(self, wave)
+        opd[aperture_intensity==0] = 0
+
         return opd
 
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1151,10 +1151,14 @@ class Wavefront(BaseWavefront):
         else:
             pixel_scale_x, pixel_scale_y = pixelscale_mpix, pixelscale_mpix
 
-        y -= (shape[0] - 1) / 2.0
-        x -= (shape[1] - 1) / 2.0
-
-        return pixel_scale_y * y, pixel_scale_x * x
+        if accel_math._USE_NUMEXPR:
+            ny, nx = shape
+            return (ne.evaluate("pixel_scale_y * (y - (ny-1)/2)"),
+                    ne.evaluate("pixel_scale_x * (x - (nx-1)/2)") )
+        else:
+            y -= (shape[0] - 1) / 2.0
+            x -= (shape[1] - 1) / 2.0
+            return pixel_scale_y * y, pixel_scale_x * x
 
     @staticmethod
     def image_coordinates(shape, pixelscale, last_transform_type, image_centered):

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -156,6 +156,8 @@ class BaseWavefront(ABC):
         sqrt_ti = np.sqrt(self.total_intensity)
         if sqrt_ti == 0:
             _log.warning("Total intensity is zero when trying to normalize the wavefront. Cannot normalize.")
+        elif not np.isfinite(sqrt_ti):
+            _log.warning("Total intensity is NaN or Inf when trying to normalize the wavefront. Cannot normalize.")
         else:
             self.wavefront /= sqrt_ti
 
@@ -2509,7 +2511,7 @@ class OpticalElement(object):
 
         # Evaluate the wavefront at the desired sampling and pixel scale.
         ampl = self.get_transmission(temp_wavefront)
-        opd = self.get_opd(temp_wavefront)
+        opd = self.get_opd(temp_wavefront).copy()
         opd[np.where(ampl == 0)] = np.nan
 
         # define a helper function for the actual plotting - we do it this way so

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -524,7 +524,8 @@ def test_OPD_in_waves_for_FITSOpticalElement():
     lens_as_fits = single_wave_1um_lens.to_fits(what='opd', npix=3 * npix // 2)
     lens_as_fits[0].header['BUNIT'] = 'radian'
     lens_as_fits[0].data *= 2 * np.pi / reference_wavelength.to(u.m).value
-    thin_lens_wl_indep = poppy.FITSOpticalElement(opd=lens_as_fits, opdunits='radian')
+    lens_as_fits_trans = single_wave_1um_lens.to_fits(what='amplitude', npix=3 * npix // 2)
+    thin_lens_wl_indep = poppy.FITSOpticalElement(opd=lens_as_fits, transmission=lens_as_fits_trans, opdunits='radian')
     # We expect identical peak flux for all wavelengths, so check at 0.5x and 2x
     for prefactor in (0.5, 1.0, 2.0):
         osys = poppy.OpticalSystem(oversample=1, npix=npix)

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -130,7 +130,7 @@ def test_Circular_Aperture_PTP_long(display=False, npix=512, display_proper=Fals
     # and obviously the case based on the x axis of the figure.
 
     gw = fresnel.FresnelWavefront(beam_radius=0.5*u.m,wavelength=2200e-9,npix=npix,oversample=4)
-    gw *= optics.CircularAperture(radius=0.5,oversample=gw.oversample)
+    gw *= optics.CircularAperture(radius=0.5,oversample=gw.oversample, gray_pixel=False)
 
     gw.propagate_fresnel(z)
     inten = gw.intensity
@@ -394,7 +394,7 @@ def test_fresnel_FITS_Optical_element(tmpdir, display=False, verbose=False):
     npix = 128
 
     conv_lens = fresnel.QuadraticLens(1.0 * u.m)
-    circular_aperture = optics.CircularAperture(radius=radius)
+    circular_aperture = optics.CircularAperture(radius=radius, gray_pixel=False)
 
     # To test two different versions of the FITS handling, we will repeat this test twice:
     # once with the FITS element crafted to precisely match the pixel scale of the

--- a/poppy/tests/test_geometry.py
+++ b/poppy/tests/test_geometry.py
@@ -1,4 +1,4 @@
-#  
+#
 #  Test functions for subpixel geometry code
 #
 
@@ -33,11 +33,11 @@ def test_clipping():
 # Test effect of shifting the center of the image by integer pixels
 
 # Test effect of shifting the center of the image by fractional pixels
-    # cross correlation of shifted & unshifted to demonstrate 1/2 pixel shifts? 
+    # cross correlation of shifted & unshifted to demonstrate 1/2 pixel shifts?
 
 # Test using subpixel scaling of incput X and Y arrays
 
-# Test the specific case at fault here. 
+# Test the specific case at fault here.
 
 
 

--- a/poppy/tests/test_geometry.py
+++ b/poppy/tests/test_geometry.py
@@ -1,0 +1,95 @@
+#  
+#  Test functions for subpixel geometry code
+#
+
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+import astropy.io.fits as fits
+
+from .. import poppy_core
+from .. import optics
+from .. import geometry
+
+# Test routines for antialiased fractional circle
+
+def test_area_minimal_circle():
+    """ Test that A = pi * r**2, where r==1 """
+    res = geometry.filled_circle_aa((2,2), 0.5, 0.5, 1)
+    assert np.abs(res.sum() -np.pi) < 1e-7
+
+
+def test_clipping():
+
+    res = geometry.filled_circle_aa((20,20), 10.5, 10.5, 1, clip=True,cliprange=(0,1))
+
+    assert res.min() >= 0.0
+    assert res.max() <= 1.0
+
+
+# Come up with some representative plausible test cases for whcih we know the answers
+
+
+# Test effect of shifting the center of the image by integer pixels
+
+# Test effect of shifting the center of the image by fractional pixels
+    # cross correlation of shifted & unshifted to demonstrate 1/2 pixel shifts? 
+
+# Test using subpixel scaling of incput X and Y arrays
+
+# Test the specific case at fault here. 
+
+
+
+
+
+
+
+def test_pixwt():
+    """
+    Test subpixel circular aperture (pixwt function)
+    via comparison to values calculated from IDL pixwt.pro
+    """
+
+    def check_pixwt_result( args, expected=1, tolerance=1e-5):
+        assert np.abs(geometry.pixwt(*args)-expected).max() < tolerance
+
+    # radius 1 circle
+    check_pixwt_result((0,0,1,0,0), expected=1.0)
+    check_pixwt_result((0,0,1,1,1), expected=0.07878669)
+
+    # check with array args
+    xa = np.asarray([0,0,1,1,2,-1])
+    ya = np.asarray([0,1,1,0,0,-1])
+    exp = np.asarray([ 1.0000000, 0.45661139, 0.078786805, 0.45661139, 8.9406967e-08, 0.078786790 ])
+    check_pixwt_result((0,0,1,xa,ya), expected=exp)
+
+
+    # radius 10 circle
+    check_pixwt_result((0,0,10,0,9), expected=1.0)
+    check_pixwt_result((0,0,10,0,10), expected=0.49584007)
+    check_pixwt_result((0,0,10,0,11), expected=0)
+
+    check_pixwt_result((0,0,10,1,10), expected=0.44564247)
+    check_pixwt_result((0,0,10,2,10), expected=0.29352379)
+
+    # offset origin
+    check_pixwt_result((0,1,10,0,11), expected=0.49584007)
+    check_pixwt_result((20,1,10,20,11), expected=0.49584007)
+
+
+def test_filled_aa_circle(plot=True):
+    """ Test the function that computes a filled, anti-aliased circle
+
+
+    """
+
+    # test some specific values in comparison to the pixwt function
+
+    # brute force run pixwt on some array
+    y,x = np.indices((100,100))
+    res_1 = geometry.pixwt(50,50,40,x,y)
+
+
+    res_2 = geometry.filled_circle_aa( (100,100), 50, 50, 40, 1)
+    assert np.max(np.abs(res_1,res_2) < 1e-5)

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -205,17 +205,26 @@ def test_AnnularFieldStop():
 
     wave*= optic
     # Just check a handful of points that it goes from 0 to 1 back to 0
-    assert wave.intensity[50,50] == 0
-    assert wave.intensity[55,50] == 0
-    assert wave.intensity[60,50] == 1
-    assert wave.intensity[69,50] == 1
-    assert wave.intensity[75,50] == 0
-    assert wave.intensity[95,50] == 0
+    np.testing.assert_almost_equal( wave.intensity[50,50], 0)
+    np.testing.assert_almost_equal( wave.intensity[55,50], 0)
+    np.testing.assert_almost_equal( wave.intensity[60,50], 1)
+    np.testing.assert_almost_equal( wave.intensity[68,50], 1)
+    np.testing.assert_almost_equal( wave.intensity[75,50], 0)
+    np.testing.assert_almost_equal( wave.intensity[95,50], 0)
     # and check the area is approximately right
     expected_area = np.pi*(optic.radius_outer**2 - optic.radius_inner**2) * 100
     expected_area = expected_area.to(u.arcsec**2).value
+
+    # updated criteria for dealing with gray pixels
+    # sum of pixels should be close to this, and just a bit less than it
     area = wave.intensity.sum()
-    assert np.abs(expected_area-area) < 0.01*expected_area
+    assert expected_area-area < 0.05*expected_area
+    assert expected_area-area >0
+    # if we count the number of pixels that are significantly nonzero
+    # it should be a bit above the desired area
+    area_upper_bound = (wave.intensity > 0.01).sum()
+    assert area_upper_bound > expected_area
+    assert area_upper_bound < expected_area*1.1
 
 
 def test_BandLimitedOcculter(halfsize = 5) :

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -36,7 +36,7 @@ def test_InverseTransmission():
         assert( np.all(  np.abs(optic.get_phasor(wave) - (1-inverted.get_phasor(wave))) < 1e-10 ))
 
     # vary 2d shape
-    for radius in np.arange(10, dtype=float)/10:
+    for radius in np.arange(1, 11, dtype=float)/10:
 
         optic = optics.CircularAperture(radius=radius)
         inverted = optics.InverseTransmission(optic)

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -600,7 +600,6 @@ def test_GaussianAperture(display=False):
 def test_ThinLens(display=False):
     pupil_radius = 1
 
-    #pupil = optics.CircularAperture(radius=pupil_radius)
     # let's add < 1 wave here so we don't have to worry about wrapping
     lens = optics.ThinLens(nwaves=0.5, reference_wavelength=1e-6, radius=pupil_radius)
     # n.b. npix is 99 so that there are an integer number of pixels per meter (hence multiple of 3)
@@ -608,22 +607,21 @@ def test_ThinLens(display=False):
     # Otherwise the strict test against half a wave min max doesn't work
     # because we're missing some (tiny but nonzero) part of the aperture
     wave = poppy_core.Wavefront(npix=99, diam=3.0, wavelength=1e-6)
-    #wave *= pupil
     wave *= lens
 
     # Now test the values at some precisely chosen pixels
     y, x = wave.coordinates()
     at_radius = np.where((x==1) & (y==0))
-    assert np.allclose(wave.phase[at_radius], np.pi/2), "Didn't get 1/2 wave OPD at edge of optic"
+    assert np.allclose(wave.phase[at_radius], -np.pi/2), "Didn't get -1/2 wave OPD at edge of optic"
     assert len(at_radius[0]) > 0, "Array indices messed up - need to have a pixel at exactly (1,0)"
 
     at_radius = np.where((x==0) & (y==1))
-    assert np.allclose(wave.phase[at_radius], np.pi/2), "Didn't get 1/2 wave OPD at edge of optic"
+    assert np.allclose(wave.phase[at_radius], -np.pi/2), "Didn't get -1/2 wave OPD at edge of optic"
     assert len(at_radius[0]) > 0, "Array indices messed up - need to have a pixel at exactly (0,1)"
 
 
     at_center = np.where((x==0) & (y==0))
-    assert np.allclose(wave.phase[at_center], -np.pi/2), "Didn't get -1/2 wave OPD at center of optic"
+    assert np.allclose(wave.phase[at_center], np.pi/2), "Didn't get 1/2 wave OPD at center of optic"
     assert len(at_radius[0]) > 0, "Array indices messed up - need to have a pixel at exactly (0,0)"
 
     # TODO test intermediate pixel values between center and edge?

--- a/poppy/tests/test_special_prop.py
+++ b/poppy/tests/test_special_prop.py
@@ -84,9 +84,9 @@ def test_SAMC(fft_oversample=4, samc_oversample=8, npix=512,
     else:
         raise NotImplementedError("Don't know what threshold to use for oversample="+str(oversample))
 
-    totdiff = np.abs(psf_sam[0].data.sum() - psf_fft[0].data.sum())
-    assert totdiff < thresh, "Total pixel value absolute difference summed overimages ({}) exceeds threshold ({}).".format(totdiff, thresh)
-
+    expected_total = 0.005615
+    assert np.abs(psf_sam[0].data.sum()-expected_total) < thresh, "Summed total of PSF intensity did not match expectations"
+    assert np.abs(psf_sam[0].data.sum()-expected_total)/expected_total < 0.003, "Summed total of PSF intensity was more than 0.3% away from expectation"
 
     # Check there are the expected number of intermediate planes, which for this
     # kind of propagation has some extras:

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -209,7 +209,7 @@ class ZernikeWFE(WavefrontError):
         self.radius = radius
         self.aperture_stop = aperture_stop
         self.coefficients = coefficients
-        self.circular_aperture = CircularAperture(radius=self.radius, **kwargs)
+        self.circular_aperture = CircularAperture(radius=self.radius, gray_pixel=False, **kwargs)
         self._default_display_size = radius * 3
         kwargs.update({'name': name})
         super(ZernikeWFE, self).__init__(**kwargs)

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -266,7 +266,7 @@ class ZernikeWFE(WavefrontError):
                     noll_normalize=True
                 )
 
-        combined_zernikes *= aperture_intensity
+        combined_zernikes[aperture_intensity==0] = 0
         if units == 'waves':
             combined_zernikes /= wave.wavelength.to(u.meter).value
         return combined_zernikes


### PR DESCRIPTION
This branch implements nearly exact sub pixel sampling for circular apertures. This is a fairly subtle effect for well-sampled arrays, but can make a difference in high-precision calculations. And it's an increasingly large effect for small pixel samplings, for instance here's a circle sampled over just 16 pixels: 

![Unknown](https://user-images.githubusercontent.com/1151745/58299587-a30f1680-7dad-11e9-8fbe-1d56c08c75bf.png)

The algorithm used is _not_ just a simple N*N subsampling, but rather an implementation of precise geometric calculations of circular arcs through square pixels. Python code originally by Mike Fitzgerald (UCLA), based on older C and IDL code, and provided by him to me some time ago for this use. This sub pixel calculation is applied in the `CircularAperture`, `AnnularFieldStop`, `CircularOcculter` classes's `get_transmission()` functions. It thus can also apply on derived classes such as `ThinLens` and `ZernikeWFE` which are implicitly defined over a circular aperture. 

For the `CircularAperture` class  and those derived classes this functionality can be turned off via a new parameter (`gray_pixel=False`); This is useful in circumstances where you will have multiple circular apertures of identical radius in a row (e.g. an aperture, followed by a lens or Zernike WFE with the same radius). The motivation is, if you were to apply multiple gray pixels in a row, the intensity in that pixel will decrease after each aperture, whereas that is not what you would want for multiple sharp-edged circles in a row. This can be tricky, and there can be subtleties about when to use it or not.  Several unit tests had to get adjusted using this or other tweaks to work correctly given the change in aperture behavior.  These subtleties are much of why this branch languished and never quite got finished for the last couple years. 

For more complicated classes (arbitrarily complex apertures, etc), an alternative form of subsampling is available via an enhanced `fixed_sampling_optic` function, which now allows N*N subsampling of optics. In other words it will evaluate the optic on a high-resolution subsampled array, then bin it down to the desired sampling while averaging each N * N block of pixels. This is for now the best way to get gray pixels for aperture shapes other than circles. Note, it's less precise than the careful way in which we handle circles, but still better than doing nothing. Here's an example on hexagons:

![Unknown-1](https://user-images.githubusercontent.com/1151745/58299861-7b6c7e00-7dae-11e9-8725-1338db98fde5.png)

This needs some edits to the documentation and example code to go along with it.  But I'm adding the PR now for review and comment. Note, I don't expect anyone to do detailed review of the actual geometric calculations; that stuff's pretty dense. It's been tested against the equivalent code in IDL to verify correctness. 