### PR TITLE
minor: bugfix for pixel scale comparison in adding wavefronts

### DIFF
--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -267,7 +267,7 @@ class FresnelWavefront(BaseWavefront):
             _log.debug("Skipping oversampling, oversample < 1 or already padded ")
 
         if self.oversample < 2:
-            _log.warning("Oversampling > 2x suggested for reliable results.")
+            _log.warning("Oversampling > 2x suggested for reliable results in Fresnel propagation.")
 
         self._y, self._x = np.indices(self.shape, dtype=float)
         self._y -= (self.wavefront.shape[0]) / 2.0

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -206,7 +206,7 @@ class BaseWavefront(ABC):
             raise ValueError('Wavefronts can only be added if they have the same size and shape: {} vs {} '.format(
                 self.wavefront.shape, wave.wavefront.shape))
 
-        if not self.pixelscale == wave.pixelscale:
+        if not np.isclose(self.pixelscale.value, wave.pixelscale.to(self.pixelscale.unit).value):
             raise ValueError('Wavefronts can only be added if they have the same pixelscale: {} vs {}'.format(
                 self.pixelscale, wave.pixelscale))
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -206,9 +206,14 @@ class BaseWavefront(ABC):
             raise ValueError('Wavefronts can only be added if they have the same size and shape: {} vs {} '.format(
                 self.wavefront.shape, wave.wavefront.shape))
 
-        if not np.isclose(self.pixelscale.value, wave.pixelscale.to(self.pixelscale.unit).value):
-            raise ValueError('Wavefronts can only be added if they have the same pixelscale: {} vs {}'.format(
-                self.pixelscale, wave.pixelscale))
+
+        try:
+            if not np.isclose(self.pixelscale.value, wave.pixelscale.to(self.pixelscale.unit).value):
+                raise ValueError('Wavefronts can only be added if they have the same pixelscale: {} vs {}'.format(
+                    self.pixelscale, wave.pixelscale))
+        except u.UnitConversionError:
+            raise ValueError('Wavefronts can only be added if they have equivalent units: {} vs {}'.format(
+                self.pixelscale.unit, wave.pixelscale.unit))
 
 
         self.wavefront += wave.wavefront

--- a/poppy/tests/test_errorhandling.py
+++ b/poppy/tests/test_errorhandling.py
@@ -153,7 +153,7 @@ if _HAVE_PYTEST:
         inputs_and_errors = ((3, "Wavefronts can only be summed with other Wavefronts"),
                              (fw1, "Wavefronts can only be summed with other Wavefronts of the same class"),
                              (w3, "Wavefronts can only be added if they have the same pixelscale"),
-                             (w4, "Wavefronts can only be added if they have the same pixelscale"),
+                             (w4, "Wavefronts can only be added if they have equivalent units"),
                              (w5, "Wavefronts can only be added if they have the same size and shape"))
         for test_input, expected_error in inputs_and_errors:
             with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
Trivial bug fix of a float comparison that should be `np.isclose` instead of a strict equality. 

Unrelatedly, also a trivial change to an error string to make the error message clearer. 