### PR TITLE
allow passthrough of normalize keyword in measure_ee and measure_radius_at_ee

### DIFF
--- a/poppy/tests/test_utils.py
+++ b/poppy/tests/test_utils.py
@@ -166,7 +166,7 @@ def test_measure_FWHM(display=False, verbose=False):
         result = "Measured: {3:.4f} pixels; Desired: {0:.4f} pixels. Relative difference: {1:.4f}    Tolerance: {2:.4f}".format(desired_fwhm, reldiff, tolerance, meas_fwhm/pxscl)
         if verbose:
             print(result)
-        assert reldiff < tolerance, result 
+        assert reldiff < tolerance, result
 
     # Test on Poppy outputs too
     # We test both well sampled and barely sampled cases.
@@ -211,6 +211,17 @@ def test_measure_radius_at_ee():
     # The ee and rad functions should undo each other and yield the input value
     for i in [0.1, 0.5, 0.8]:
         np.testing.assert_almost_equal(i, ee(rad(i)), decimal=3, err_msg="Error: Values not equal")
+
+
+    # Repeat test with normalization to psf sum=1.
+    # This time we can go right up to 1.0, or at least arbitrarilyclose to it.
+    rad = utils.measure_radius_at_ee(psf, normalize='total')
+    ee = utils.measure_ee(psf, normalize='total')
+    for i in [0.1, 0.5,  0.9999]:
+        np.testing.assert_almost_equal(i, ee(rad(i)), decimal=3, err_msg="Error: Values not equal")
+
+
+
 
 @pytest.mark.skipif(pyfftw is None, reason="pyFFTW not found")
 def test_load_save_fftw_wisdom(tmpdir):

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -536,7 +536,7 @@ def radial_profile(hdulist_or_filename=None, ext=0, ee=False, center=None, stdde
         Compute standard deviation in each radial bin, not average?
     normalize : string
         set to 'peak' to normalize peak intensity =1, or to 'total' to normalize total flux=1.
-        Default is no normalization.
+        Default is no normalization (i.e. retain whatever normalization was used in computing the PSF itself)
     pa_range : list of floats, optional
         Optional specification for [min, max] position angles to be included in the radial profile.
         I.e. calculate that profile only for some wedge, not the full image. Specify the PA in degrees
@@ -648,7 +648,7 @@ def radial_profile(hdulist_or_filename=None, ext=0, ee=False, center=None, stdde
 #    PSF evaluation functions
 #
 
-def measure_ee(HDUlist_or_filename=None, ext=0, center=None, binsize=None):
+def measure_ee(HDUlist_or_filename=None, ext=0, center=None, binsize=None, normalize='None'):
     """ measure encircled energy vs radius and return as an interpolator
 
     Returns a function object which when called returns the Encircled Energy inside a given radius,
@@ -666,6 +666,9 @@ def measure_ee(HDUlist_or_filename=None, ext=0, center=None, binsize=None):
         Coordinates (x,y) of PSF center. Default is image center.
     binsize:
         size of step for profile. Default is pixel size.
+   normalize : string
+        set to 'peak' to normalize peak intensity =1, or to 'total' to normalize total flux=1.
+        Default is no normalization (i.e. retain whatever normalization was used in computing the PSF itself)
 
     Returns
     --------
@@ -680,7 +683,8 @@ def measure_ee(HDUlist_or_filename=None, ext=0, center=None, binsize=None):
 
     """
 
-    rr, radialprofile2, ee = radial_profile(HDUlist_or_filename, ext, ee=True, center=center, binsize=binsize)
+    rr, radialprofile2, ee = radial_profile(HDUlist_or_filename, ext, ee=True, center=center, binsize=binsize,
+                                            normalize=normalize)
 
     # append the zero at the center
     rr_ee = rr + (rr[1] - rr[0]) / 2.0  # add half a binsize to this, because the ee is measured inside the
@@ -693,7 +697,7 @@ def measure_ee(HDUlist_or_filename=None, ext=0, center=None, binsize=None):
     return ee_fn
 
 
-def measure_radius_at_ee(HDUlist_or_filename=None, ext=0, center=None, binsize=None):
+def measure_radius_at_ee(HDUlist_or_filename=None, ext=0, center=None, binsize=None, normalize='None'):
     """ measure encircled energy vs radius and return as an interpolator
     Returns a function object which when called returns the radius for a given Encircled Energy. This is the
     inverse function of measure_ee
@@ -708,6 +712,9 @@ def measure_radius_at_ee(HDUlist_or_filename=None, ext=0, center=None, binsize=N
         Coordinates (x,y) of PSF center. Default is image center.
     binsize:
         size of step for profile. Default is pixel size.
+    normalize : string
+        set to 'peak' to normalize peak intensity =1, or to 'total' to normalize total flux=1.
+        Default is no normalization (i.e. retain whatever normalization was used in computing the PSF itself)
 
     Returns
     --------
@@ -720,7 +727,8 @@ def measure_radius_at_ee(HDUlist_or_filename=None, ext=0, center=None, binsize=N
     >>> print "The EE is 50% at {} arcsec".format(ee(0.5))
     """
 
-    rr, radialprofile2, ee = radial_profile(HDUlist_or_filename, ext, ee=True, center=center, binsize=binsize)
+    rr, radialprofile2, ee = radial_profile(HDUlist_or_filename, ext, ee=True, center=center, binsize=binsize,
+                                            normalize=normalize)
 
     # append the zero at the center
     rr_ee = rr + (rr[1] - rr[0]) / 2.0  # add half a binsize to this, because the EE is measured inside the


### PR DESCRIPTION
The `measure_radial` function already supports normalizing PSFs to their sum=1; this small PR allows that feature to be used from the `measure_ee` and `measure_radius_at_ee` functions too. 

Addresses #332. Attention @ariedel 