### PR TITLE
Add environment.yml; update minimum deps to major versions as of 2017

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ matrix:
         # and older Python versions
         - python: 3.5
           env: NUMPY_VERSION=1.13 SETUP_CMD='test'
-        - python: 3.6
-          env: ASTROPY_VERSION=2.0 SETUP_CMD='test' CONDA_DEPENDENCIES='scipy matplotlib pytest-remotedata>=0.3.1'
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
           env: NUMPY_VERSION=1.13 SETUP_CMD='test'
         - python: 3.6
           env: ASTROPY_VERSION=2.0 SETUP_CMD='test'
+               CONDA_DEPENDENCIES='pytest-remotedata>=0.3.1'
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
         - python: 3.5
           env: NUMPY_VERSION=1.13 SETUP_CMD='test'
         - python: 3.6
-          env: NUMPY_VERSION=1.13
+          env: ASTROPY_VERSION=2.0 SETUP_CMD='TEST'
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
         - python: 3.5
           env: NUMPY_VERSION=1.13 SETUP_CMD='test'
         - python: 3.6
-          env: ASTROPY_VERSION=2.0 SETUP_CMD='test' PIP_DEPENDENCIES='pytest-remotedata>=0.3.1'
+          env: ASTROPY_VERSION=2.0 SETUP_CMD='test' CONDA_DEPENDENCIES='scipy matplotlib pytest-remotedata>=0.3.1'
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ matrix:
         # Try Astropy & numpy minimum supported versions, 
         # and older Python versions
         - python: 3.5
-          env: ASTROPY_VERSION=2.0 NUMPY_VERSION=1.13 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.13 SETUP_CMD='test'
         - python: 3.6
-          env: ASTROPY_VERSION=2.0 NUMPY_VERSION=1.13
+          env: NUMPY_VERSION=1.13
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,7 @@ matrix:
         - python: 3.5
           env: NUMPY_VERSION=1.13 SETUP_CMD='test'
         - python: 3.6
-          env: ASTROPY_VERSION=2.0 SETUP_CMD='test'
-               CONDA_DEPENDENCIES='pytest-remotedata>=0.3.1'
+          env: ASTROPY_VERSION=2.0 SETUP_CMD='test' PIP_DEPENDENCIES='pytest-remotedata>=0.3.1'
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
         - python: 3.5
           env: NUMPY_VERSION=1.13 SETUP_CMD='test'
         - python: 3.6
-          env: ASTROPY_VERSION=2.0 SETUP_CMD='TEST'
+          env: ASTROPY_VERSION=2.0 SETUP_CMD='test'
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-    - 3.6
+    - 3.7
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -28,33 +28,30 @@ matrix:
     include:
         # do the actual tests.
         # Do a coverage test in Python 3.
-        - python: 3.6
+        - python: 3.7
           env: SETUP_CMD='test --coverage'
 
         # Check accelerated math version too
-        - python: 3.6
+        - python: 3.7
           env: SETUP_CMD='test --coverage' PIP_DEPENDENCIES='numexpr'
 
         # Check for Sphinx doc build errors
-        - python: 3.6
+        - python: 3.7
           env: SETUP_CMD='build_sphinx'
                CONDA_DEPENDENCIES='scipy matplotlib nbsphinx pandoc'
                PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi sphinx-issues'
 
 
         # Try Astropy development version
-        - python: 3.6
+        - python: 3.7
           env: SETUP_CMD='test' ASTROPY_VERSION=development
 
-        # Try Astropy & numpy minimum supported versions
+        # Try Astropy & numpy minimum supported versions, 
+        # and older Python versions
         - python: 3.5
-          env: ASTROPY_VERSION=1.3 NUMPY_VERSION=1.10 SETUP_CMD='test'
-
-        # Try older numpy versions
+          env: ASTROPY_VERSION=2.0 NUMPY_VERSION=1.13 SETUP_CMD='test'
         - python: 3.6
-          env: NUMPY_VERSION=1.12
-        - python: 3.5
-          env: NUMPY_VERSION=1.11
+          env: ASTROPY_VERSION=2.0 NUMPY_VERSION=1.13
 
 install:
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,4 @@ dependencies:
    - numpy >= 1.13.0
    - scipy >= 1.0.0
    - matplotlib >= 2.0.0
-   - astropy >= 2.0.0
+   - astropy >= 3.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: poppy-env
+channels:
+   - http://ssb.stsci.edu/astroconda
+   - defaults
+dependencies:
+   - numpy >= 1.13.0
+   - scipy >= 1.0.0
+   - matplotlib >= 2.0.0
+   - astropy >= 2.0.0

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ LONG_DESCRIPTION = ast.get_docstring(module_ast)
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.9.0dev'
+VERSION = '0.9.0rc1'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION
@@ -118,10 +118,10 @@ for root, dirs, files in os.walk(PACKAGENAME):
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
 install_requires_packages = [
-      'numpy>=1.10.0',
-      'scipy>=0.14.0',
-      'matplotlib>=1.3.0',
-      'astropy>=1.3',
+      'numpy>=1.13.0',
+      'scipy>=1.0.0',
+      'matplotlib>=2.0.0',
+      'astropy>=2.0.0',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ install_requires_packages = [
       'numpy>=1.13.0',
       'scipy>=1.0.0',
       'matplotlib>=2.0.0',
-      'astropy>=2.0.0',
+      'astropy>=3.0.0',
 ]
 
 


### PR DESCRIPTION
Updates for minimum versions:
 - Add environment.yml for use in setting up Conda environments
 - Update minimum supported/required versions of dependencies to the major releases as of 2017. Earlier versions no longer supported. 

These versions are consistent with the similar PR for WebbPSF:  https://github.com/spacetelescope/webbpsf/pull/321


