### PR TITLE
Remove wavelength limit from instrument.py

### DIFF
--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -310,8 +310,6 @@ class Instrument(object):
         """
 
         nwavelengths = len(wavelengths)
-        if nwavelengths > 100:
-            raise ValueError("Maximum number of wavelengths exceeded. Cannot be more than 100.")
 
         # Set up cube and initialize structure based on PSF at first wavelength
         poppy_core._log.info("Starting multiwavelength data cube calculation.")


### PR DESCRIPTION
I'm working with @mperrin on PSF subtraction and came across a scenario where I wanted to generate a data cube with more than 100 slices but was hit with an error -- `ValueError: Maximum number of wavelengths exceeded. Cannot be more than 100`. 

I brought it up to Marshall and he couldn't remember why this limit existed, so I'm proposing a pull request that removes it from `instrument.py` to see what `poppy`'s other developers think.