### PR TITLE
update travis test setup for py3.5, limit to astropy < 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
         # Try Astropy & numpy minimum supported versions, 
         # and older Python versions
         - python: 3.5
-          env: NUMPY_VERSION=1.13 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.13 ASTROPY_VERSION=3.2 SETUP_CMD='test'
 
 install:
 


### PR DESCRIPTION
Minor update to 'lowest supported versions' test case: astropy 4.0 is released now, but we still support 3.2. 
