### PR TITLE
Improve opd_expand_segments to optionally ignore some pixels at segment borders

### DIFF
--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -274,7 +274,8 @@ def test_piston_basis(verbose=False):
     """ Test that we can create randomly-pistoned segments, and then
     re-determine the amounts of those pistons.
 
-    This tests both the segment
+    This tests both the segment piston baseis, and the segment basis
+    decomposition function.
     """
 
     segment_piston_basis = zernike.Segment_Piston_Basis(rings=2)
@@ -285,13 +286,15 @@ def test_piston_basis(verbose=False):
     aperture = segment_piston_basis.aperture()
     #aperture = np.asarray(pistoned_opd != 0, dtype=int)
 
-    results = zernike.opd_expand_segments(pistoned_opd, basis=segment_piston_basis, aperture=aperture, nterms=18, verbose=verbose)
+    for border_pad in [None, 5]:
+        results = zernike.opd_expand_segments(pistoned_opd, basis=segment_piston_basis,
+                aperture=aperture, nterms=18, verbose=verbose, ignore_border=border_pad)
 
-    if verbose:
-        print(random_pistons)
-        print(results)
+        if verbose:
+            print(random_pistons)
+            print(results)
 
-    assert np.allclose(random_pistons, results)
+        assert np.allclose(random_pistons, results)
 
     return random_pistons, results, pistoned_opd
 


### PR DESCRIPTION
Add option to the `poppy.zernikes.opd_expand_segments` function, so that you can tell it to ignore a subset of border pixels around the edges of each segment when fitting Zernikes (or hexikes etc) to a given segment in an OPD map. This is useful sometimes to ignore edge effects, in particular interpolation artifacts can occur at segment edges if you have scaled up an ITM 256*256 OPD into 1024*1024 pixels as expected by WebbPSF. 

This fix was needed for ingesting Acton's deployment phase map for use in WebbPSF with JWST WFTP4. 