### PR TITLE
Allow Segmented_PTT_Basis to take in additional keyword arguments

### DIFF
--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -820,7 +820,7 @@ def arbitrary_basis(aperture, nterms=15, rho=None, theta=None, outside=np.nan):
 
 class Segment_PTT_Basis(object):
     def __init__(self, rings=2, flattoflat=1*u.m, gap=1*u.cm, center=False,
-                pupil_diam=None):
+                pupil_diam=None, **kwargs):
         """
         Eigenbasis of segment pistons, tips, tilts.
         (Or of pistons only using the Segment_Piston_Basis subclass.)
@@ -854,9 +854,10 @@ class Segment_PTT_Basis(object):
         # a wrapper on MultiHexagonAperture
         import poppy.dms
         self.hexdm = poppy.dms.HexSegmentedDeformableMirror(rings=rings,
-                                              flattoflat=flattoflat,
-                                              gap=gap,
-                                              center=center)
+                                                            flattoflat=flattoflat,
+                                                            gap=gap,
+                                                            center=center,
+                                                            **kwargs)
         if pupil_diam is not None:
             self.hexdm.pupil_diam = pupil_diam
         self.segmentlist = self.hexdm.segmentlist
@@ -1270,4 +1271,3 @@ def opd_expand_segments(opd, aperture=None, nterms=15, basis=None,
         if verbose:
             print("Iteration {}/{}: {}".format(count, iterations, coeffs))
     return coeffs
-

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -820,7 +820,7 @@ def arbitrary_basis(aperture, nterms=15, rho=None, theta=None, outside=np.nan):
 
 class Segment_PTT_Basis(object):
     def __init__(self, rings=2, flattoflat=1*u.m, gap=1*u.cm, center=False,
-                pupil_diam=None, **kwargs):
+                 pupil_diam=None, **kwargs):
         """
         Eigenbasis of segment pistons, tips, tilts.
         (Or of pistons only using the Segment_Piston_Basis subclass.)
@@ -848,6 +848,9 @@ class Segment_PTT_Basis(object):
             Diameter of the array on which to generate the basis; by default
             this is chosen to circumscribe the multihex aperture given the
             specified segment and gap sizes and number of segments.
+
+        Additional keyword arguments to this function are passed through to the
+        HexSegmentedDeformableMirror callable.
 
         """
         # Internally this is implemented as a wrapper on HexDM which in turn is


### PR DESCRIPTION
I am using `Segmented_PTT_Basis` in the ST lab for creating commands to send to segmented deformable mirrors. We need to be able to specify custom apertures with this command and this can be done through the `segmentlist` variable in the `MultiHexagonAperture` class which is inherited by `HexSegmentedDeformableMirror` which is used in `Segmented_PTT_Basis`. However, to be able to access this from `Segmented_PTT_Basis`, we need to be able to pass in additional keyword arguments used by `HexSegmentedDeformableMirror` and therefore `MultiHexagonAperture`. 

This PR adds **kwargs to the`Segmented_PTT_Basis` input. 