### PR TITLE
Fix minor bug in log string during MFT calc under certain circumstances

### DIFF
--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1039,13 +1039,15 @@ class Wavefront(BaseWavefront):
         det_calc_size_pixels = det.fov_pixels.to(u.pixel).value * det.oversample
 
         mft = MatrixFourierTransform(centering='ADJUSTABLE', verbose=False)
+
+        pixelscale = det.pixelscale if det.pixelscale is not None else det.fov_arcsec/det.fov_pixels
         if not np.isscalar(det_fov_lam_d):  # hasattr(det_fov_lam_d,'__len__'):
             msg = '    Propagating w/ MFT: {:.4f}     fov=[{:.3f},{:.3f}] lam/D    npix={} x {}'.format(
-                det.pixelscale / det.oversample, det_fov_lam_d[0], det_fov_lam_d[1],
+                pixelscale / det.oversample, det_fov_lam_d[0], det_fov_lam_d[1],
                 det_calc_size_pixels[0], det_calc_size_pixels[1])
         else:
             msg = '    Propagating w/ MFT: {:.4f}     fov={:.3f} lam/D    npix={:d}'.format(
-                det.pixelscale / det.oversample, det_fov_lam_d, int(det_calc_size_pixels))
+                pixelscale / det.oversample, det_fov_lam_d, int(det_calc_size_pixels))
         _log.debug(msg)
         self.history.append(msg)
         det_offset = det.det_offset if hasattr(det, 'det_offset') else (0, 0)


### PR DESCRIPTION
Encountered a bug in which a log string formatting inside MFT propagation raised an error, if provided with a detector or detector-like object with an implicit pixelscale. (i.e. `pixelscale` is not set, but `fov_arcsec` and `fov_pixels` are set). This is not usually relevant but can be the case if using the `propgation_hint='MFT'` override to force an MFT transform on a particular object. 

This small PR fixes the issue to infer the `pixelscale` from `fov_arcsec/fov_pixels` in that case. 
