### PR TITLE
update branch URLs in docs for master -> stable (or develop, as appropriate)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,16 @@ POPPY: Physical Optics Propagation in Python
    :target: https://pypi.python.org/pypi/poppy
    :alt: Badge showing current released PyPI version
 
-.. image:: https://travis-ci.org/spacetelescope/poppy.svg?branch=master
+.. image:: https://travis-ci.org/spacetelescope/poppy.svg?branch=develop
    :target: https://travis-ci.org/spacetelescope/poppy
    :alt: Badge showing continuous integration test status
 
-.. image:: https://codecov.io/gh/spacetelescope/poppy/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/spacetelescope/poppy
+.. image:: https://codecov.io/gh/spacetelescope/poppy/branch/develop/graph/badge.svg
+   :target: https://codecov.io/gh/spacetelescope/poppy
+
+.. |Documentation Status| image:: https://img.shields.io/readthedocs/poppy-optics/latest.svg?logo=read%20the%20docs&logoColor=white&label=Docs&version=stable
+   :target: https://poppy-optics.readthedocs.io/en/latest/
+   :alt: Documentation Status
 
 .. image:: https://img.shields.io/badge/ascl-1602.018-blue.svg?colorB=262255
    :target: http://ascl.net/1602.018

--- a/docs/coronagraphs.rst
+++ b/docs/coronagraphs.rst
@@ -4,9 +4,9 @@ Efficient Lyot coronagraph propagation
 
 
 Poppy has extensive functionality to faciliate the modeling of coronagraph point spread functions. In addition to the general summary of those capabilities here, see the examples in the notebooks subdirectory:
-`POPPY Examples <https://github.com/spacetelescope/poppy/blob/master/notebooks/POPPY%20Examples.ipynb>`_
+`POPPY Examples <https://github.com/spacetelescope/poppy/blob/stable/notebooks/POPPY%20Examples.ipynb>`_
 and
-`MatrixFTCoronagraph_demo <https://github.com/spacetelescope/poppy/blob/master/notebooks/MatrixFTCoronagraph_demo.ipynb>`_.
+`MatrixFTCoronagraph_demo <https://github.com/spacetelescope/poppy/blob/stable/notebooks/MatrixFTCoronagraph_demo.ipynb>`_.
 
 Introduction
 --------------

--- a/docs/dev_notes.rst
+++ b/docs/dev_notes.rst
@@ -6,20 +6,22 @@ Release Process
 ---------------
 
 #. Get the `develop` branch to the state you would like for the release. This includes all tests passing, both on Travis and locally via tox.
-#. Tag the commit with `v<version>`, being sure to sign the tag with the `-s` option.
+#. Locally, checkout the `develop` branch and ensure it's current with respect to Github.
+#. Tag the latest commit in `develop` with `v<version>`, being sure to sign the tag with the `-s` option. (You will need to ensure you have git commit signing via GPG setup prior to this).
    * ``git tag -s v<version> -m "Release v<version>"``
 
-#. Push tag to github, on develop
+#. Push tag to github:  ``git push upstream v<version>``
 #. On github, make a PR from `develop` to `stable` (this can be done ahead of time and left open, until all individual PRs are merged into `develop`.).
-#. After verifying that PR is complete and tests pass, merge it. (Once merged, both the `stable` and `develop` branches should match).
+#. After verifying that PR is complete and waiting for tests to pass, merge it. (Once merged, both the `stable` and `develop` branches should match).
 #. Release on Github:
 
    #. On Github, click on "[N] Releases".
    #. Select "Draft a new release".
+   #. We want to create the release from the tag just added. To do so, select 'Tags', then on the line for the latest tag ``v<version>``, at the far right click on the ``...`` button to bring up a small menu containing "Create release".
    #. Specify the version number, title, and brief description of the release.
    #. Press "Publish Release".
 
-#. Release to PyPI. This should now happen automatically on Travis. This is triggered by a Travis build of a tagged commit on the `stable` branch.
+#. Release to PyPI. This should now happen automatically on Travis. This is triggered by a Travis build of a tagged commit on the `stable` branch, so should happen automatically after the PR to `stable`.
 
 #. Release to AstroConda, via steps below.
 
@@ -33,7 +35,7 @@ To test that an Astroconda package builds, you will need ``conda-build``::
    $ conda install conda-build
 
 #. Fork (if needed) and clone https://github.com/astroconda/astroconda-contrib
-#. Edit `poppy/meta.yaml <https://github.com/astroconda/astroconda-contrib/blob/master/poppy/meta.yaml>`_ to reflect the new ``version`` and ``git_tag``.
+#. Edit `poppy/meta.yaml <https://github.com/astroconda/astroconda-contrib/blob/develop/poppy/meta.yaml>`_ to reflect the new ``version`` and ``git_tag``.
 #. Edit in the ``git_tag`` name from ``git tag`` in the PyPI release instructions (``v0.X.Y``).
 #. Verify that you can build the package from the astroconda-contrib directory: ``conda build -c http://ssb.stsci.edu/astroconda poppy``
 #. Commit your changes to a new branch and push to GitHub.

--- a/docs/dev_notes.rst
+++ b/docs/dev_notes.rst
@@ -35,7 +35,7 @@ To test that an Astroconda package builds, you will need ``conda-build``::
    $ conda install conda-build
 
 #. Fork (if needed) and clone https://github.com/astroconda/astroconda-contrib
-#. Edit `poppy/meta.yaml <https://github.com/astroconda/astroconda-contrib/blob/develop/poppy/meta.yaml>`_ to reflect the new ``version`` and ``git_tag``.
+#. Edit `poppy/meta.yaml <https://github.com/astroconda/astroconda-contrib/blob/master/poppy/meta.yaml>`_ to reflect the new ``version`` and ``git_tag``.
 #. Edit in the ``git_tag`` name from ``git tag`` in the PyPI release instructions (``v0.X.Y``).
 #. Verify that you can build the package from the astroconda-contrib directory: ``conda build -c http://ssb.stsci.edu/astroconda poppy``
 #. Commit your changes to a new branch and push to GitHub.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,7 +7,7 @@ Let's dive right in to some example code.
 
 
 (A runnable notebook version of this examples page is included in the `notebooks` subdirectory of the
-``poppy`` source, or is available from `here <https://github.com/spacetelescope/poppy/blob/master/notebooks/POPPY%20Examples.ipynb>`_.)
+``poppy`` source, or is available from `here <https://github.com/spacetelescope/poppy/blob/stable/notebooks/POPPY%20Examples.ipynb>`_.)
 
 
 For all of the following examples, you will have more informative text output when running the code

--- a/docs/fresnel.rst
+++ b/docs/fresnel.rst
@@ -29,7 +29,7 @@ poppy. There are :class:`~poppy.FresnelWavefront` and :class:`~poppy.FresnelOpti
 be used for the most part similar to the :class:`~poppy.Wavefront` and :class:`~poppy.OpticalSystem` classes.
 
 Users are encouraged to consult the Jupyter notebook `Fresnel_Propagation_Demo
-<https://github.com/spacetelescope/poppy/blob/master/notebooks/Fresnel_Propagation_Demo.ipynb>`_
+<https://github.com/spacetelescope/poppy/blob/develop/notebooks/Fresnel_Propagation_Demo.ipynb>`_
 for examples of how to use the Fresnel code.
 
 Key Differences from Fraunhofer mode
@@ -102,7 +102,7 @@ Example Jupyter Notebooks
 .. admonition:: A non-astronomical example
 
     A worked example of a compound microscope in POPPY is available
-    `here <https://github.com/douglase/poppy_example_notebooks/blob/master/Fresnel/Microscope_Example.ipynb>`_,
+    `here <https://github.com/douglase/poppy_example_notebooks/blob/develop/Fresnel/Microscope_Example.ipynb>`_,
     reproducing the microscope example case provided in the PROPER manual.
 
 Fresnel calculations with Physical units
@@ -114,7 +114,7 @@ total intensity (power).  This code was developed and contributed by `Phillip
 Springer <https://github.com/DaPhil>`_.
 
 See `this notebook
-<https://github.com/spacetelescope/poppy/blob/master/notebooks/Physical%20Units%20Demo.ipynb>`_
+<https://github.com/spacetelescope/poppy/blob/develop/notebooks/Physical%20Units%20Demo.ipynb>`_
 for examples and further discussion.
 
 

--- a/docs/fresnel.rst
+++ b/docs/fresnel.rst
@@ -95,7 +95,7 @@ Example Jupyter Notebooks
 
    For more details and examples of code usage, consult the Jupyter
    notebook `Fresnel_Propagation_Demo
-   <https://github.com/spacetelescope/poppy/blob/master/notebooks/Fresnel_Propagation_Demo.ipynb>`_.
+   <https://github.com/spacetelescope/poppy/blob/stable/notebooks/Fresnel_Propagation_Demo.ipynb>`_.
    In addition to details on code usage, this includes a worked example of
    a Fresnel model of the Hubble Space Telescope.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ Summary
 
 .. admonition:: Quickstart IPython Notebook
 
-       This documentation is complemented by an `IPython Notebook quickstart tutorial <http://nbviewer.ipython.org/github/spacetelescope/poppy/blob/master/notebooks/POPPY_tutorial.ipynb>`_.
+       This documentation is complemented by an `IPython Notebook quickstart tutorial <http://nbviewer.ipython.org/github/spacetelescope/poppy/blob/stable/notebooks/POPPY_tutorial.ipynb>`_.
 
        Downloading and running that notebook is a great way to get started using POPPY. The documentation following here provides greater details on the algorithms and API.
 

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -203,7 +203,7 @@ improved upon in a future release.
 
  * New `PhysicalFresnelWavefront` class that uses physical units for the wavefront (e.g.
    volts/meter) and intensity (watts). See `this notebook
-   <https://github.com/spacetelescope/poppy/blob/master/notebooks/Physical%20Units%20Demo.ipynb>`_ for
+   <https://github.com/spacetelescope/poppy/blob/stable/notebooks/Physical%20Units%20Demo.ipynb>`_ for
    examples and further discussion.  (`#248 <https://github.com/spacetelescope/poppy/pull/248>`, @daphil).
  * `calc_psf` gains a new parameter to request returning the complex wavefront (`#234
    <https://github.com/spacetelescope/poppy/pull/234>`_,@douglase).

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -26,8 +26,8 @@ This is a minor release primarily for updates in packaging infrastructure, plus 
 
 **Software Infrastructure Updates and Internals:**
 
- * Removed dependency on the deprecated astropy-helpers package framework. (:pr:`349` by :user:`sosborne`). Fixes :issue:`355`.
- * Switched code coverage CI service to codecov.io. (:pr:`349` by :user:`sosborne`)
+ * Removed dependency on the deprecated astropy-helpers package framework. (:pr:`349` by :user:`shanosborne`). Fixes :issue:`355`.
+ * Switched code coverage CI service to codecov.io. (:pr:`349` by :user:`shanosborne`)
  * The minimum Python version is now 3.6. (:pr:`356` by :user:`mperrin`)
 
 0.9.0


### PR DESCRIPTION
Missed this step in #361 : Need to update various URLs now that we no longer have a "master" branch. 