### PR TITLE
Improve some uses of astropy units

### DIFF
--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1633,7 +1633,7 @@ class BaseOpticalSystem(ABC):
             utils.fftw_save_wisdom()
 
         # TODO update FITS header for oversampling here if detector is different from regular?
-        waves = np.asarray(wavelength)
+        waves = np.asarray([w.to(u.meter).value for w in wavelength])
         wts = np.asarray(weight)
         mnwave = (waves * wts).sum() / wts.sum()
         outfits[0].header['WAVELEN'] = (mnwave, 'Weighted mean wavelength in meters')

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1633,7 +1633,7 @@ class BaseOpticalSystem(ABC):
             utils.fftw_save_wisdom()
 
         # TODO update FITS header for oversampling here if detector is different from regular?
-        waves = np.asarray([w.to(u.meter).value for w in wavelength])
+        waves = np.asarray([w.to_value(u.meter) for w in wavelength])
         wts = np.asarray(weight)
         mnwave = (waves * wts).sum() / wts.sum()
         outfits[0].header['WAVELEN'] = (mnwave, 'Weighted mean wavelength in meters')

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -402,21 +402,43 @@ def test_return_complex():
 def test_displays():
     # Right now doesn't check the outputs are as expected in any way
     # TODO consider doing that? But it's hard given variations in matplotlib version etc
+
+    # As a result this just tests that the code runs to completion, without any assessment
+    # of the correctness of the output displays.
     import poppy
     import matplotlib.pyplot as plt
 
     osys = poppy.OpticalSystem()
     osys.add_pupil(poppy.CircularAperture())
-    osys.add_detector(fov_pixels=128, pixelscale=0.01)
+    osys.add_detector(fov_pixels=128, pixelscale=0.01*u.arcsec/u.pixel)
 
+    # Test optical system display
+    # This implicitly exercises the optical element display paths, too
     osys.display()
 
+    # Test PSF calculation with intermediate wavefronts
     plt.figure()
     psf = osys.calc_psf(display_intermediates=True)
 
+    # Test PSF display
     plt.figure()
-    #psf = osys.calc_psf(display_intermediates=True)
     poppy.display_psf(psf)
+
+    # Test PSF display with other units too
+    poppy.display_psf(psf, angular_coordinate_unit=u.urad)
+
+    # Test PSF calculation with intermediate wavefronts and other units
+    plt.figure()
+    psf = osys.calc_psf(display_intermediates=True)
+    osys2 = poppy.OpticalSystem()
+    osys2.add_pupil(poppy.CircularAperture())
+    osys2.add_detector(fov_pixels=128, pixelscale=0.05*u.urad/u.pixel)
+    psf2, waves = osys.calc_psf(display_intermediates=True, return_intermediates=True)
+
+    # Test wavefront display, implicitly including other units
+    waves[-1].display()
+
+    plt.close('all')
 
 
 def test_rotation_in_OpticalSystem(display=False, npix=1024):
@@ -560,6 +582,11 @@ def test_Detector_pixelscale_units():
     # Or scale in arcsec, and fov in arcsec:
     test_det = poppy_core.Detector(pixelscale=0.01 * u.arcsec / u.pixel, fov_arcsec=10)
     assert test_det.pixelscale == 0.01 * u.arcsec / u.pixel
+    assert test_det.shape == (1000, 1000)
+
+    # Or scale in microradians, and fov in milliradians (converted to arcsec, since the fov_arcsec parameter needs arcsec):
+    test_det = poppy_core.Detector(pixelscale=1 * u.urad / u.pixel, fov_arcsec=(1*u.mrad).to_value(u.arcsec))
+    assert test_det.pixelscale == 1 * u.urad / u.pixel
     assert test_det.shape == (1000, 1000)
 
     # It also works to leave the scale unspecified in unit, which is interpreted as arcsec


### PR DESCRIPTION
 Addresses comments on #373 by @mcbeth

- [x] fix use of units in computation of average wavelength FITS header keyword. The FITS header keyword WAVELEN is now always in units of meters, correctly, regardless of whether some other unit is specified as part of the PSF computation.  

- [x] check/fix use of units in detector pixel scales, to fix problems when setting detector pixel scale to something not in arcseconds, e.g. `100*u.nrad/u.pixel`. It turns out that the PSF computation itself was handling the units correctly - but the display functions on the other hand were not appropriately handling the different pixel scale units. I implemented a fix for that.  Further, I then made  related improvements to the display functions `Wavefront.display()` and `utils.display_PSF()`, to allow specifying PSF or wavefront display using any desired angular unit, not just arc seconds, for the X and Y axes scales.

As a result you can now do for instance the following, and all the unit handling works as expected: 

```python

osys = poppy.OpticalSystem()
circular_aperture = poppy.CircularAperture(radius=1*u.m)
osys.add_pupil(circular_aperture)
zernike_coefficients_sequence = [0, 100e-9, 0, -50e-9, 0, 35e-9]. #semi-arbitrary WFE
thinlens = poppy.ZernikeWFE(radius=1*u.m, coefficients=zernike_coefficients_sequence)
osys.add_pupil(thinlens)
osys.add_detector(pixelscale=0.02*u.urad/u.pixel, fov_pixels=128)

psf_with_zernikewfe = osys.calc_psf(wavelength=400*u.nm, display_intermediates=True)

plt.figure()
poppy.display_psf(psf_with_zernikewfe, angular_coordinate_unit=u.urad, markcentroid=True)
```
![Unknown-1](https://user-images.githubusercontent.com/1151745/103613071-c7245a80-4ef3-11eb-9dcd-e7f48b90201c.png)
![Unknown](https://user-images.githubusercontent.com/1151745/103613048-b83da800-4ef3-11eb-919e-f87d01b0a6ec.png)


(None of this directly helps any of the immediate use cases in webbpsf, but it does help make `poppy` more robust and extensible through more consistent use of the astropy.units framework)
