### PR TITLE
Improve radial_profile to allow measurement of partial profiles for sources offset outside the FOV

### DIFF
--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -622,12 +622,14 @@ def radial_profile(hdulist_or_filename=None, ext=0, ee=False, center=None, stdde
     else:
         radialprofile2[0] = csim[0]  # otherwise if there's just one then just take it.
     radialprofile2[1:] = radialprofile
-    rr = np.arange(
-        len(radialprofile2)) * binsize + binsize * 0.5  # these should be centered in the bins, so add a half.
-    if pa_range is not None:
-        # for PA ranges < 45 deg or so, the innermost pixel that's valid in the mask may be
-        # more than a pixel from the center. Therefore we have to include that offset here
-        rr += binsize * np.floor(sr[0])
+
+    # Compute radius values corresponding to the measured points in the radial profile.
+    # including handling the case where the innermost pixel may be more
+    # than one pixel from the center. This can happen if pa_range is not None, since for
+    # small ranges < 45 deg or so the innermost pixel that's valid in the mask may be
+    # more than one pixel from the center. It can also happen if we are computing a
+    # radial profile centered on an offset source outside of the FOV.
+    rr = np.arange(ri.min(), ri.min()+len(radialprofile2)) * binsize + binsize * 0.5  # these should be centered in the bins, so add a half.
 
 
     if maxradius is not None:


### PR DESCRIPTION
In some cases it is useful to be able to compute a partial radial profile for a source that is offset outside out of the field of view. (Specific motivating use case: the JWST NIRSpec IFU and/or MIRI MRS, hypothetically observing a faint companion near a bright star, with the bright star just outside the IFU field of view). 

This PR makes a small change in the radial_profile function to correctly compute the returned radius coordinates in this case. This fixes a bug in the current code that always started the radius array at zero. The user still has to pass in the correct center location for the PSF using the existing `center` keyword, same as for a PSF offset within the FOV. 

A unit test demonstrates consistency of the profile for a centered and offset source in the overlap region. The profiles are checked for consistency at each of the test radii indicated by the vertical lines. 

![Unknown-7](https://user-images.githubusercontent.com/1151745/93378434-7563a180-f82a-11ea-9ecf-67d3857b7dc1.png)
