### PR TITLE
Implement Scalar OPD optic; and update syntax for get_optical_system removing underscore.

### DIFF
--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -53,7 +53,7 @@ class Instrument(object):
 
     You will at a minimum want to override the following class methods:
 
-        * _get_optical_system
+        * get_optical_system
         * _get_filter_list
         * _get_default_nlambda
         * _get_default_fov

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -259,7 +259,7 @@ class Instrument(object):
 
         # ---- now at last, actually do the PSF calc:
         #  instantiate an optical system using the current parameters
-        self.optsys = self._get_optical_system(fov_arcsec=fov_arcsec, fov_pixels=fov_pixels,
+        self.optsys = self.get_optical_system(fov_arcsec=fov_arcsec, fov_pixels=fov_pixels,
                                                fft_oversample=fft_oversample, detector_oversample=detector_oversample,
                                                options=local_options)
         self._check_for_aliasing(wavelens)
@@ -759,7 +759,7 @@ class Instrument(object):
         # (specifically auto-selected pupils based on filter selection)
         wavelengths, _ = self._get_weights(nlambda=1)
         self._validate_config(wavelengths=wavelengths)
-        optsys = self._get_optical_system()
+        optsys = self.get_optical_system()
         optsys.display(what='both')
         if old_no_sam is not None:
             self.options['no_sam'] = old_no_sam

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -498,7 +498,7 @@ class Instrument(object):
         """
         pass
 
-    def _get_optical_system(self, fft_oversample=2, detector_oversample=None, fov_arcsec=2, fov_pixels=None,
+    def get_optical_system(self, fft_oversample=2, detector_oversample=None, fov_arcsec=2, fov_pixels=None,
                             options=None):
         """ Return an OpticalSystem instance corresponding to the instrument as currently configured.
 
@@ -615,13 +615,17 @@ class Instrument(object):
 
         return optsys
 
-    def get_optical_system(self, *args, **kwargs):
+    def _get_optical_system(self, *args, **kwargs):
         """ Return an OpticalSystem instance corresponding to the instrument as currently configured.
 
         """
         # Note, this has historically been an internal private API function (starting with an underscore)
         # As of version 0.9 it is promoted to a public part of the API for the Instrument class and subclasses.
-        return self._get_optical_system(*args, **kwargs)
+        # Here we ensure the prior version works, back compatibly.
+        import warnings
+        warnings.warn("_get_optical_system is deprecated; use get_optical_system (without leading underscore) instead.",
+                      warnings.DeprecationWarning)
+        return self.get_optical_system(*args, **kwargs)
 
     def _check_for_aliasing(self, wavelengths):
         """ Check for spatial frequency aliasing and warn if the

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -962,7 +962,7 @@ class Wavefront(BaseWavefront):
 
         """
         if self.oversample > 1 and not self.ispadded:  # add padding for oversampling, if necessary
-            assert self.oversample == optic.oversample
+            assert self.oversample == optic.oversample, "Unexpected sampling inconsistency in _propagate_fft!"
             self.wavefront = utils.pad_to_oversample(self.wavefront, self.oversample)
             self.ispadded = True
             if optic.verbose:
@@ -2472,7 +2472,7 @@ class OpticalElement(object):
                 units = "\n".join(textwrap.wrap(units, 20))
 
         ## Create a wavefront object to use when evaluating/sampling the optic.
-        if self.pixelscale is not None:
+        if self.pixelscale is not None and self.shape is not None:
             # This optic has an inherent sampling.  The display wavefront's sampling is
             # irrelevant; we get the native pixel scale opd and amplitude regardless and
             # display that.

--- a/poppy/tests/test_instrument.py
+++ b/poppy/tests/test_instrument.py
@@ -29,7 +29,7 @@ def test_instrument_source_weight_dict(weights_dict=WEIGHTS_DICT):
         "Number of wavelengths in PSF header does not match number requested"
 
     # Check weighted sum
-    osys = inst._get_optical_system(fov_pixels=FOV_PIXELS,
+    osys = inst.get_optical_system(fov_pixels=FOV_PIXELS,
                                   detector_oversample=2, fft_oversample=2)
     output = np.zeros((2 * FOV_PIXELS, 2 * FOV_PIXELS))
     for wavelength, weight in zip(weights_dict['wavelengths'], weights_dict['weights']):
@@ -51,7 +51,7 @@ def test_instrument_source_weight_array(wavelengths=WAVELENGTHS_ARRAY, weights=W
         "Number of wavelengths in PSF header does not match number requested"
 
     # Check weighted sum
-    osys = inst._get_optical_system(fov_pixels=FOV_PIXELS,
+    osys = inst.get_optical_system(fov_pixels=FOV_PIXELS,
                                   detector_oversample=2, fft_oversample=2)
     output = np.zeros((2 * FOV_PIXELS, 2 * FOV_PIXELS))
     for wavelength, weight in zip(wavelengths, weights):
@@ -174,7 +174,7 @@ def test_instrument_calc_datacube():
                     "Spectral axis of datacube does not match number requested"
 
     # Check individual planes
-    osys = inst._get_optical_system(fov_pixels=FOV_PIXELS,
+    osys = inst.get_optical_system(fov_pixels=FOV_PIXELS,
                                   detector_oversample=2, fft_oversample=2)
     for i, wavelength in enumerate(WAVELENGTHS_ARRAY):
 

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -57,6 +57,19 @@ def test_scalar_transmission():
         assert( np.all(optic.get_phasor(wave) == transmission))
 
 
+def test_scalar_opd():
+    """ Verify this adjusts the wavefront intensity appropriately """
+    wave = poppy_core.Wavefront(npix=100, wavelength=wavelength)
+
+    for opd in [1.0*u.micron, 1.0e-7*u.m, 0.0*u.m]:
+
+        optic = optics.ScalarOpticalPathDifference(opd=opd)
+        assert np.all(optic.get_opd(wave) == opd.to_value(u.m)), "OPD value not as expected"
+
+    # Also test with bare floats, which should be interpreted as meters
+    optic = optics.ScalarOpticalPathDifference(opd=2e-6)
+    assert np.all(optic.get_opd(wave) == 2e-6), "OPD value not as expected"
+
 
 def test_roundtrip_through_FITS():
     """ Verify we can make an analytic element, turn it into a FITS file and back,


### PR DESCRIPTION
This implements a very simple (but currently missing from poppy) optical element class for a simple scalar OPD value.

In most cases this isn't interesting to add (since just changing the total path length or piston has no effect on a PSF) but it can be useful as a building block for making compound optical elements. This PR also updates the CompoundAnalyticOptic class to correctly handle OPDS for compound optics with multiple apertures.  For instance here's a classical two slit interferometer. Adding half a wave of delay to one side makes for destructive interference on-axis, as expected: 

```python

wavelen = 500*u.nm
plt.figure(figsize=(20,8))
for i, delay_waves in enumerate([0, 0.5]):
    slit1 = poppy.RectangleAperture(width=50*u.micron, height=600*u.micron, shift_x = 100e-6)
    slit2 = poppy.RectangleAperture(width=50*u.micron, height=600*u.micron, shift_x = -100e-6)
    slit2_with_delay = poppy.CompoundAnalyticOptic((slit2,
                                                  poppy.optics.ScalarOpticalPathDifference(opd=delay_waves*wavelen)))
    slits = poppy.CompoundAnalyticOptic([slit1, slit2_with_delay], name='Two slits', mergemode='or')



    osys = poppy.FresnelOpticalSystem(pupil_diameter=1000*u.micron, npix=512, beam_ratio=0.25)
    osys.add_optic(slits)
    osys.add_detector(pixelscale=3*u.micron/u.pixel, fov_pixels=1024, distance=10*u.cm)
    psf = osys.calc_psf(wavelength=500*u.nm)
    
    plt.subplot(1,2,1+i)
    poppy.display_psf(psf, title=f'Two slits, with OPD={delay_waves} waves')
    plt.axvline(0, ls=':', color='white')
plt.figure()
slits.display(what='both')

```

![Unknown](https://user-images.githubusercontent.com/1151745/103618556-27b89500-4efe-11eb-8011-7a90ebd2c4ab.png)

![Unknown-1](https://user-images.githubusercontent.com/1151745/103618561-2a1aef00-4efe-11eb-9a8a-010f8cf841fc.png)



This PR adds the optic itself. I'll include it in the documentation with this example code in a subsequent PR. 


**Note added later:** This PR also updates the syntax for the Instrument.get_optical_system function, which originally was a private function with leading underscore but for a while now has been intended as a public part of the API. This was intended to be a transparent update just flipping the sign of the back compatibility wrapper, but it turns out to be a little more complex and needs some updates in downstream user packages including webbpsf and hicat package. 