### PR TITLE
Updating to meet INS JWST Software Standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ matrix:
 
     include:
         # do the actual tests.
-        # Do a test in Python 3.7
-        - env: TOXENV='py37-cov'
+        # Do a test in Python 3.8
+        - env: TOXENV='py38-cov'
 
         # Check accelerated math version too
         - env: TOXENV='py37-numexpr-cov'
@@ -27,7 +27,7 @@ matrix:
         - env: TOXENV='docbuild' TOX_ARGS=''
 
         # Try Astropy development version
-        - env: TOXENV='py37-astropydev-test'
+        - env: TOXENV='py38-astropydev-test'
 
         # Try Astropy & numpy minimum supported versions,
         # and older Python versions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,45 @@
+### Contributing Guide
+
 Please open a new issue or new pull request for bugs, feedback, or new features you would like to see. If there is an issue you would like to work on, please leave a comment and we will be happy to assist. New contributions and contributors are very welcome!
 
-New to github or open source projects? If you are unsure about where to start or haven't used github before, please feel free to contact the package maintainers. 
+See the instructions below for how to contribute to this repository using a forking workflow.
 
-Feedback and feature requests? Is there something missing you would like to see? Please open an issue or send an email to the maintainers. This package follows the Spacetelescope [Code of Conduct](CODE_OF_CONDUCT.md)  strives to provide a welcoming community to all of our users and contributors.
+#### Forking Workflow
+1. Create a personal fork of the `poppy` repository by visiting its location on GitHub and clicking the `Fork` button.  This will create a copy of the `poppy` repository under your personal GitHub account (hereby referred to as "personal fork").  Note that this only has to be done once.
+
+2. Make a local copy of your personal fork by cloning the repository (e.g. `git clone https://github.com/username/poppy.git`, found by clicking the green "clone or download" button.).  Note that, unless you explicitly delete your clone of the fork, this only has to be done once.
+
+3. Ensure that the personal fork is pointing to the `upstream` `poppy` repository with `git remote add upstream https://github.com/spacetelescope/poppy.git` (or use the SSH version if you have your SSH keys set up).  Note that, unless you explicitly change the remote location of the repository, this only has to be done once.
+
+4. Create a branch off of the `develop` branch on the personal clone to develop software changes on. Branch names should be short but descriptive (e.g. `new-database-table` or `fix-ingest-algorithm`), and not too generic (e.g. `bug-fix`).  Consistent use of hyphens is encouraged.
+    1. `git branch <branchname>`
+    2. `git checkout <branchname>` - you can use this command to switch back and forth between existing branches.
+    3. Perform local software changes using the nominal `git add`/`git commit -m` cycle:
+       1. `git status` -  allows you to see which files have changed.
+       2. `git add <new or changed files you want to commit>`
+       3. `git commit -m 'Explanation of changes you've done with these files'`
+
+5. Push the branch to the GitHub repository for the personal fork with `git push origin <branchname>`.
+
+6. In the `poppy` repository, create a pull request for the recently pushed branch.  You will want to set the base fork pointing to `poppy:develop` and the `head` fork pointing to the branch on your personal fork (i.e. `username:branchname`).  Note that if the branch is still under development, you can use the GitHub "Draft" feature (under the "Reviewers" section) to tag the pull request as a draft. Not until the "Ready for review" button at the bottom of the pull request is explicitly pushed is the pull request 'mergeable'.
+
+7. Assign the pull request a reviewer, selecting a maintainer of the `poppy` repository.  They will review your pull request and either accept the request and merge, or ask for additional changes.
+
+8. Iterate with your reviewer(s) on additional changes if necessary, addressing any comments on your pull request.  If changes are required, you may end up iterating over steps 4.iii and 5 several times while working with your reviewer.
+
+9. Once the pull request has been accepted and merged, you can delete your local branch with `git branch -d <branchname>`.
+
+#### Keeping your fork updated
+If you wish to, you can keep a personal fork up-to-date with the `poppy` repository by fetching and rebasing with the `upstream` remote. Do this for both the `master` branch (shown below) and the `develop` branch:
+1. `git checkout master`
+2. `git fetch upstream master`
+3. `git rebase upstream/master`
+
+#### Collaborating on someone else's fork
+Users can contribute to another user's personal fork by adding a `remote` that points to their fork and using the nominal forking workflow, e.g.:
+
+1. `git remote add <username> <remote URL>`
+2. `git fetch <username>`
+3. `git checkout -b <branchname> <username>/<branchname>`
+4. Make some changes (i.e. `add/commit` cycle)
+5. `git push <username> <branchname>`

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,0 @@
-name: poppy-env
-channels:
-   - http://ssb.stsci.edu/astroconda
-   - defaults
-dependencies:
-   - numpy >= 1.13.0
-   - scipy >= 1.0.0
-   - matplotlib >= 2.0.0
-   - astropy >= 3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 astropy==4.2
-matplotlib==3.3.3
+matplotlib==3.3.4
 numpy==1.19.4
-scipy==1.5.0
+scipy==1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+astropy==4.2
+matplotlib==3.3.3
+numpy==1.19.4
+scipy==1.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37}-test
-    py{36,37}-{astropydev,legacy}-test
-    py{36,37}-cov
+    py{36,37,38}-test
+    py{36,37,38}-{astropydev,legacy}-test
+    py{36,37,38}-cov
     py37-numexpr-cov
 
 [testenv]


### PR DESCRIPTION
This PR updates the repo to adhere to INS-JWST community software standards outlined in https://github.com/spacetelescope/ins-jwst-community-software/ (which while poppy is not in the community software list, we might as well update it alongside webbpsf)

We were mostly complient, but I added the following updates:
- Start testing with python 3.8 to match what webbpsf tests
- Expand the contributing guide
- Replace the environment.yaml file with a requirements.txt file because dependabot works with requirements files and I thought it best not to have duplicate files
- Update the dependencies in the requirements.txt file, except for 1 (numpy) in order to test depedabot (which I'm setting up next)