### PR TITLE
Release 0.9.2

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -24,7 +24,7 @@ The Team
 POPPY is developed primarily by a team of astronomers at the `Space Telescope
 Science Insitute <http://www.stsci.edu/>`_, but is open to contributions from
 scientists and software developers around the world. Development takes place
-on Github at http://github.com/spacetelescope/poppy . See that page for the most up-to-date
+on Github at http://github.com/spacetelescope/poppy. See that page for the most up-to-date
 list of contributors. 
 
 Direct contributors to POPPY code
@@ -88,7 +88,7 @@ in Astronomy.
 License
 -----------------
 
-Copyright (C) 2010-2017 Association of Universities for Research in Astronomy (AURA)
+Copyright (C) 2010-2021 Association of Universities for Research in Astronomy (AURA)
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -31,10 +31,13 @@ Direct contributors to POPPY code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
  * Marshall Perrin (:user:`mperrin`)
- * Joseph Long (:user:`josephoenix`)
  * Ewan Douglas (:user:`douglase`)
+ * Joseph Long (:user:`josephoenix`)
  * Shannon Osborne (:user:`shanosborne`)
  * Neil Zimmerman (:user:`neilzim`)
+ * Robel Geda (:user:`robelgeda`)
+ * Scott Will (:user:`sdwill`)
+ * Iva Laginja (:user:`ivalaginja`)
  * Anand Sivaramakrishnan (:user:`anand0xff`)
  * Maciek Grochowicz (:user:`maciekgroch`)
  * Phillip Springer (:user:`daphil`)
@@ -42,12 +45,12 @@ Direct contributors to POPPY code
  * Kyle Douglass (:user:`kmdouglas`)
  * Christine Slocum (:user:`cslocum`)
  * Matt Mechtley (:user:`mmechtley`)
- * Scott Will (:user:`sdwill`)
- * Iva Laginja (:user:`ivalaginja`)
  * Mike Fitzgerald (:user:`astrofitz`)
  * Keira Brooks (:user:`kjbrooks`)
  * Justin Otor (:user:`ojustino`)
  * Rachel Morgan (:user:`remorgan01`)
+ * Fanpeng Kong (:user:`fanpeng-kong`)
+ * Kim Ward-Duong (:user:`spacegal-spiff`)
 
 Indirect Contributors (algorithms, advice, ideas, inspirations)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -5,14 +5,14 @@ Release Notes
 
 For a list of contributors, see :ref:`about`.
 
-1.0.0
+0.9.2
 -----
 
-.. _rel1.0.0:
+.. _rel0.9.2:
 
-*2021 Jan TBD*
+*2021 Feb 10*
 
-Release summary sentence here. 
+This release includes several updated optical element classes, bug fixes, and improved documentation. This is intended as a maintenance release shortly before v 1.0 which will introduce some backwards-incompatible changes. 
 
 **New Functionality:**
  * New OpticalElement classes for ScalarOpticalPathDifference, LetterFAperture, and LetterFOpticalPathDifference. (:pr:`386` by :user:`mperrin`)
@@ -36,8 +36,6 @@ Release summary sentence here.
  * Minor doc string clarification for get_opd (:pr:`381` by :user:`douglase`)
  * Remove unused parameter to Detector class (:pr:`385` by :user:`mperrin`)
 
-
-ADD fanpeng-kong, spacegal-spiff TO CONTRIBUTORS
 
 
 0.9.1

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -10,7 +10,7 @@ For a list of contributors, see :ref:`about`.
 
 .. _rel0.9.2:
 
-*2021 Feb 10*
+*2021 Feb 11*
 
 This release includes several updated optical element classes, bug fixes, and improved documentation. This is intended as a maintenance release shortly before v 1.0 which will introduce some backwards-incompatible changes. 
 
@@ -22,6 +22,7 @@ This release includes several updated optical element classes, bug fixes, and im
 **Other enhancements and fixes:**
  * The ShackHartmannWavefrontSensor class was refactored and improved . (:pr:`369` by :user:`fanpeng-kong`). And a unit test case for this class was added (:pr:`376` by :user:`remorgan123` in collaboration with :user:`douglase`)
  * Expanded documentation and example code for usage of astropy Units. (:pr:`374`, :pr:`378` by :user:`mperrin`; with thanks to :user:`keflavich’ and  :user:`mcbeth`)
+* Made the HexagonalSegmentedDeformableMirror class consistent with ContinuousDeformableMirror in having an 'include_factor_of_two' parameter, for control in physical surface versus wavefront error units
  * Bug fix for influence functions of rotated hexagonally segmented deformable mirrors. (:pr:`371` by :user:`mperrin`)
  * Bug fix for FWHM measurement on integer data type images. (:pr:`368` by :user:`kjbrooks`)
  * Bug fix for StatisticalPSDWFE to avoid side effects from changing global numpy random generator state. (:pr:`377` by :user:`ivalaginja`)
@@ -31,10 +32,12 @@ This release includes several updated optical element classes, bug fixes, and im
 **Software Infrastructure Updates and Internals:**
  * The minimum numpy version is now 1.16. (:pr:`356` by :user:`mperrin`)
  * The main branches were renamed/relabeled to ’stable’  (rather than ‘master’) and ‘develop’. (:pr:`361`, :pr:`370` by :user:`mperrin`)
- * The minimum numpy version is now 1.16. (:pr:`367` by :user:`shanosborne`)
+ * Updates to Travis CI settings. (:pr:`367`, :pr:`395` by :user:`shanosborne`)
  * Avoid deprecated modification of matplotlib colormaps (:pr:`379` by :user:`spacegal-spiff`)
  * Minor doc string clarification for get_opd (:pr:`381` by :user:`douglase`)
  * Remove unused parameter to Detector class (:pr:`385` by :user:`mperrin`)
+ * Updates to meet STScI INS's JWST Software Standards (:pr:`390` by :user:`shanosborne`)
+ * Use Github's Dependabot to test and update dependencies (:pr:`391: by :user:`shanosborne`)
 
 
 

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -5,6 +5,41 @@ Release Notes
 
 For a list of contributors, see :ref:`about`.
 
+1.0.0
+-----
+
+.. _rel1.0.0:
+
+*2021 Jan TBD*
+
+Release summary sentence here. 
+
+**New Functionality:**
+ * New OpticalElement classes for ScalarOpticalPathDifference, LetterFAperture, and LetterFOpticalPathDifference. (:pr:`386` by :user:`mperrin`)
+ * Improved `radial_profile` function to allow measurement of partial profiles for sources offset outside the FOV (:pr:`380` by :user:`mperrin`)
+ * Improved the CompoundAnalyticOptic class to correctly handle OPDS for compound optics with multiple non-overlapping apertures. (:pr:`386` by :user:`mperrin`)
+
+**Other enhancements and fixes:**
+ * The ShackHartmannWavefrontSensor class was refactored and improved . (:pr:`369` by :user:`fanpeng-kong`). And a unit test case for this class was added (:pr:`376` by :user:`remorgan123` in collaboration with :user:`douglase`)
+ * Expanded documentation and example code for usage of astropy Units. (:pr:`374`, :pr:`378` by :user:`mperrin`; with thanks to :user:`keflavich’ and  :user:`mcbeth`)
+ * Bug fix for influence functions of rotated hexagonally segmented deformable mirrors. (:pr:`371` by :user:`mperrin`)
+ * Bug fix for FWHM measurement on integer data type images. (:pr:`368` by :user:`kjbrooks`)
+ * Bug fix for StatisticalPSDWFE to avoid side effects from changing global numpy random generator state. (:pr:`377` by :user:`ivalaginja`)
+ * Bug fix for image display in cases using angular coordinates in units other than arc seconds. (:pr:`378` by :user:`mperrin`; with thanks to :user:`mcbeth`)
+
+
+**Software Infrastructure Updates and Internals:**
+ * The minimum numpy version is now 1.16. (:pr:`356` by :user:`mperrin`)
+ * The main branches were renamed/relabeled to ’stable’  (rather than ‘master’) and ‘develop’. (:pr:`361`, :pr:`370` by :user:`mperrin`)
+ * The minimum numpy version is now 1.16. (:pr:`367` by :user:`shanosborne`)
+ * Avoid deprecated modification of matplotlib colormaps (:pr:`379` by :user:`spacegal-spiff`)
+ * Minor doc string clarification for get_opd (:pr:`381` by :user:`douglase`)
+ * Remove unused parameter to Detector class (:pr:`385` by :user:`mperrin`)
+
+
+ADD fanpeng-kong, spacegal-spiff TO CONTRIBUTORS
+
+
 0.9.1
 -----
 

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -259,7 +259,7 @@ class Instrument(object):
 
         # ---- now at last, actually do the PSF calc:
         #  instantiate an optical system using the current parameters
-        self.optsys = self.get_optical_system(fov_arcsec=fov_arcsec, fov_pixels=fov_pixels,
+        self.optsys = self._get_optical_system(fov_arcsec=fov_arcsec, fov_pixels=fov_pixels,
                                                fft_oversample=fft_oversample, detector_oversample=detector_oversample,
                                                options=local_options)
         self._check_for_aliasing(wavelens)
@@ -624,7 +624,7 @@ class Instrument(object):
         # Here we ensure the prior version works, back compatibly.
         import warnings
         warnings.warn("_get_optical_system is deprecated; use get_optical_system (without leading underscore) instead.",
-                      warnings.DeprecationWarning)
+                      DeprecationWarning)
         return self.get_optical_system(*args, **kwargs)
 
     def _check_for_aliasing(self, wavelengths):
@@ -763,7 +763,7 @@ class Instrument(object):
         # (specifically auto-selected pupils based on filter selection)
         wavelengths, _ = self._get_weights(nlambda=1)
         self._validate_config(wavelengths=wavelengths)
-        optsys = self.get_optical_system()
+        optsys = self._get_optical_system()
         optsys.display(what='both')
         if old_no_sam is not None:
             self.options['no_sam'] = old_no_sam


### PR DESCRIPTION
As discussed in slack, let's have a v0.9.2 release: 
> for poppy + webbpsf releases here is my thinking currently. It’s turned into a bit of a tangle given the interlinked dependencies between these two (and the optics lab code on the research side).
I’m going to make an v0.9.2 release branch of poppy containing the current code - but backing out the change in _get_optical_system syntax that I had meant to be backwards compatible but turned out not to be. I will make sure that both the released webbpsf 0.9.1 and current develop run correctly on that brach of poppy. That can be a poppy release v0.9.2 but does not need a webbpsf release, I don’t think.
That will give a stable point right now, so the optics lab code can continue with that for the time being, and then on top of that I can then finish up the 1.0 release and sign conventions change without disrupting anything in the lab
(which eventually wants that update, but I have enough moving pieces right now I want to treat it as a separable problem rather than having to deal with everything all at once)

Toward that end I:
* Copied over and updated the release notes that had been originally drafted for v1.0
* Reverted the back-incompatible change in the get_optical_system syntax
* Tested that both the released webbpsf v0.9.1 and current develop webbpsf pass their own tests on this branch. That's true and they do. 