### PR TITLE
runtime improvement by avoiding rotating zero-padding

### DIFF
--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1142,7 +1142,7 @@ class FresnelOpticalSystem(BaseOpticalSystem):
 
         for optic, distance in zip(self.planes, self.distances):
 
-            if poppy.conf.enable_speed_tests:
+            if poppy.conf.enable_speed_tests:  # pragma: no cover
                 s0 = time.time()
 
             # The actual propagation:
@@ -1175,21 +1175,21 @@ class FresnelOpticalSystem(BaseOpticalSystem):
             if return_intermediates:  # save intermediate wavefront, summed for polychromatic if needed
                 intermediate_wfs.append(wavefront.copy())
 
-            if poppy.conf.enable_speed_tests:
+            if poppy.conf.enable_speed_tests:  # pragma: no cover
                 s1 = time.time()
                 _log.debug(f"\tTIME {s1-s0:.4f} s\t for propagating past optic '{optic.name}'.")
 
             if display_intermediates:
-                if poppy.conf.enable_speed_tests:
+                if poppy.conf.enable_speed_tests:  # pragma: no cover
                     t0 = time.time()
 
                 wavefront._display_after_optic(optic)
 
-                if poppy.conf.enable_speed_tests:
+                if poppy.conf.enable_speed_tests:  # pragma: no cover
                     t1 = time.time()
                     _log.debug("\tTIME %f s\t for displaying the wavefront." % (t1 - t0))
 
-        if poppy.conf.enable_speed_tests:
+        if poppy.conf.enable_speed_tests: # pragma: no cover
             t_stop = time.time()
             _log.debug("\tTIME %f s\tfor propagating one wavelength" % (t_stop - t_start))
 

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1141,6 +1141,10 @@ class FresnelOpticalSystem(BaseOpticalSystem):
         intermediate_wfs = []
 
         for optic, distance in zip(self.planes, self.distances):
+
+            if poppy.conf.enable_speed_tests:
+                s0 = time.time()
+
             # The actual propagation:
             wavefront.propagate_to(optic, distance)
             wavefront *= optic
@@ -1170,6 +1174,10 @@ class FresnelOpticalSystem(BaseOpticalSystem):
 
             if return_intermediates:  # save intermediate wavefront, summed for polychromatic if needed
                 intermediate_wfs.append(wavefront.copy())
+
+            if poppy.conf.enable_speed_tests:
+                s1 = time.time()
+                _log.debug(f"\tTIME {s1-s0:.4f} s\t for propagating past optic '{optic.name}'.")
 
             if display_intermediates:
                 if poppy.conf.enable_speed_tests:

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -709,7 +709,7 @@ class Instrument(object):
             result[0].header['JITRTYPE'] = ('None', 'Type of jitter applied')
             return
 
-        if conf.enable_speed_tests: t0 = time.time()
+        if conf.enable_speed_tests: t0 = time.time()  # pragma: no cover
 
         poppy_core._log.info("Calculating jitter using " + str(local_options['jitter']))
 
@@ -742,7 +742,7 @@ class Instrument(object):
         else:
             raise ValueError('Unknown jitter option value: ' + local_options['jitter'])
 
-        if conf.enable_speed_tests:
+        if conf.enable_speed_tests: # pragma: no cover
             t1 = time.time()
             _log.debug("\tTIME %f s\t for jitter model" % (t1 - t0))
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1011,7 +1011,7 @@ class Wavefront(BaseWavefront):
 
         # do FFT
         if conf.enable_flux_tests: _log.debug("\tPre-FFT total intensity: " + str(self.total_intensity))
-        if conf.enable_speed_tests: t0 = time.time()
+        if conf.enable_speed_tests: t0 = time.time()  # pragma: no cover
 
         self.wavefront = accel_math.fft_2d(self.wavefront, forward=fft_forward)
 
@@ -1023,7 +1023,7 @@ class Wavefront(BaseWavefront):
 
         self._last_transform_type = 'FFT'
 
-        if conf.enable_speed_tests:
+        if conf.enable_speed_tests:  # pragma: no cover
             t1 = time.time()
             _log.debug("\tTIME %f s\t for the FFT" % (t1 - t0))
 
@@ -1713,7 +1713,7 @@ class BaseOpticalSystem(ABC):
             (n.b. This will be empty if `retain_intermediates` is False and singular if retain_final is True.)
         """
 
-        if conf.enable_speed_tests:
+        if conf.enable_speed_tests:  # pragma: no cover
             t_start = time.time()
         if self.verbose:
             _log.info(" Propagating wavelength = {0:g}".format(wavelength))
@@ -1734,7 +1734,7 @@ class BaseOpticalSystem(ABC):
         if (not retain_intermediates) & retain_final:  # return the full complex wavefront of the last plane.
             intermediate_wfs = [wavefront]
 
-        if conf.enable_speed_tests:
+        if conf.enable_speed_tests:  # pragma: no cover
             t_stop = time.time()
             _log.debug("\tTIME %f s\tfor propagating one wavelength" % (t_stop - t_start))
 
@@ -2060,7 +2060,7 @@ class OpticalSystem(BaseOpticalSystem):
         # note: 0 is 'before first optical plane; 1 = 'after first plane and before second plane' and so on
         for optic in self.planes:
 
-            if conf.enable_speed_tests:
+            if conf.enable_speed_tests:  # pragma: no cover
                 s0 = time.time()
             # The actual propagation:
             wavefront.propagate_to(optic)
@@ -2089,7 +2089,7 @@ class OpticalSystem(BaseOpticalSystem):
             if conf.enable_flux_tests:
                 _log.debug("  Flux === " + str(wavefront.total_intensity))
 
-            if conf.enable_speed_tests:
+            if conf.enable_speed_tests:  # pragma: no cover
                 s1 = time.time()
                 _log.debug(f"\tTIME {s1 - s0:.4f} s\t for propagating past optic '{optic.name}'.")
 

--- a/poppy/special_prop.py
+++ b/poppy/special_prop.py
@@ -274,7 +274,7 @@ class MatrixFTCoronagraph(poppy_core.OpticalSystem):
 
         """
 
-        if conf.enable_speed_tests:
+        if conf.enable_speed_tests:  # pragma: no cover
             t_start = time.time()
         if self.verbose:
             _log.info(" Propagating wavelength = {0:g} meters using "
@@ -334,7 +334,7 @@ class MatrixFTCoronagraph(poppy_core.OpticalSystem):
         if normalize.lower() == 'last':
             wavefront.normalize()
 
-        if conf.enable_speed_tests:
+        if conf.enable_speed_tests:  # pragma: no cover
             t_stop = time.time()
             _log.debug("\tTIME %f s\tfor propagating one wavelength" % (t_stop - t_start))
 


### PR DESCRIPTION
When rotating wavefronts, if they're zero-padded don't bother rotating all those zeros. 

Addresses downstream issue in webbpsf: https://github.com/spacetelescope/webbpsf/issues/406. Provides a substantial improvement in JWST MIRI simulations (reduces runtime by 50%).

Relatedly, improve the debugging option `conf.enable_speed_tests` to debug log the calculation runtime for each optical element in an optical system, not just the overall runtime per wavelength. This was useful in pinning down that it really was the rotation step that was taking so much time. 