### PR TITLE
Add a travis test for latest dep versions 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ matrix:
         # and older Python versions
         - env: TOXENV='py36-legacy-test'
 
+    allow_failures:
+        # Try latest versions of all dependencies
+        - env: TOXENV='py38-latest-test'
+
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,12 @@ matrix:
         # Try Astropy development version
         - env: TOXENV='py38-astropydev-test'
 
+        # Try latest versions of all dependencies
+        - env: TOXENV='py38-latest-test'
+
         # Try Astropy & numpy minimum supported versions,
         # and older Python versions
         - env: TOXENV='py36-legacy-test'
-
-    allow_failures:
-        # Try latest versions of all dependencies
-        - env: TOXENV='py38-latest-test'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,10 @@ max-line-length = 120
 zip_safe = False
 packages = find:
 install_requires =
-    numpy>=1.13.0
+    numpy>=1.16.0
     scipy>=1.0.0
     matplotlib>=2.0.0
-    astropy>=3.0.0
+    astropy>=3.2.0
 python_requires = >=3.6
 setup_requires = setuptools_scm
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38}-test
-    py{36,37,38}-{astropydev,legacy}-test
+    py{36,37,38}-{astropydev,legacy,latest}-test
     py{36,37,38}-cov
     py37-numexpr-cov
 
@@ -15,6 +15,7 @@ deps =
     cov: codecov
     legacy: numpy==1.16.*
     legacy: astropy==3.2.*
+    latest: -rrequirements.txt
     astropydev: git+git://github.com/astropy/astropy
     numexpr: numexpr>=2.0.0
 conda deps =


### PR DESCRIPTION
This PR creates a `travis` test that installs the latest versions of all the dependencies using the `requirements.txt` file. Dependabot will tell us ahead of time if there's a problem with this test, but it will also check it for any new changes

We'll need to merge this PR and rebase the open dependabot PR in order to actually have it test the newest requirements.