### PR TITLE
Use Intel MKL FFT, if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         - env: TOXENV='py38-cov'
 
         # Check accelerated math version too
-        - env: TOXENV='py37-numexpr-cov'
+        - env: TOXENV='py37-numexpr-mkl-cov'
 
         # Check for Sphinx doc build errors
         - env: TOXENV='docbuild' TOX_ARGS=''

--- a/docs/fft_optimization.rst
+++ b/docs/fft_optimization.rst
@@ -1,6 +1,11 @@
 Appendix B: Optimizing FFT Performance with FFTW
 ================================================
 
+.. warning::
+
+    This page is obsolete, and superceded by subsequent library development. You probably want
+    to use Intel MKL rather than FFTW. See :ref:`_performance_and_parallelization`.
+
 Optimizing numerical performance of FFTs is a complicated subject. Just using the FFTW library is no guarantee of optimal performance; you need to know how to configure it.
 
 .. note::

--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -61,6 +61,8 @@ class Conf(_config.ConfigNamespace):
     autosave_fftw_wisdom = _config.ConfigItem(True, 'Should POPPY ' +
                                               'automatically save and reload FFTW ' +
                                               '"wisdom" for improved speed?')
+    use_mkl = _config.ConfigItem(True, "Use Intel MKL for FFTs (assuming it is available). "
+                                       "This has highest priority for CPU-based FFT over other FFT options, if multiple are set True.")
 
     use_cuda = _config.ConfigItem(True, 'Use cuda for FFTs on GPU (assuming it' +
             'is available)?')

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{36,37,38}-test
     py{36,37,38}-{astropydev,legacy,latest}-test
     py{36,37,38}-cov
-    py37-numexpr-cov
+    py37-numexpr-mkl-cov
 
 [testenv]
 passenv = *
@@ -18,6 +18,7 @@ deps =
     latest: -rrequirements.txt
     astropydev: git+git://github.com/astropy/astropy
     numexpr: numexpr>=2.0.0
+    mkl: mkl_fft
 conda deps =
     scipy
     matplotlib

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [testenv]
 passenv = *
-deps =
+deps=
     pytest
     cov: pytest-astropy
     cov: pytest-cov
@@ -18,10 +18,12 @@ deps =
     latest: -rrequirements.txt
     astropydev: git+git://github.com/astropy/astropy
     numexpr: numexpr>=2.0.0
+conda_deps=
     mkl: mkl_fft
-conda deps =
-    scipy
-    matplotlib
+conda_channels=
+    mkl: intel
+conda_install_args=
+    mkl: --override-channels
 commands=
     test: pytest {posargs}
     cov: pytest {posargs} --cov-config=setup.cfg --cov-report=xml --cov=poppy poppy/tests/


### PR DESCRIPTION
@ehpor informed me that the Intel MKL FFT is no longer automatically patched in as a replacement for numpy.fft; you have to call mkl_fft specifically. This does so, for significant performance gains. 

We should add some mention to the docs performance section to recommend installing Intel MKL FFT; and more generally the performance discussions are in several placed outdated. 