### PR TITLE
Multi circular aperture

### DIFF
--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -7,6 +7,7 @@ import scipy.ndimage.interpolation
 import scipy.signal
 import astropy.io.fits as fits
 import astropy.units as u
+from abc import ABC, abstractmethod
 
 from . import utils, accel_math, poppy_core, optics
 
@@ -673,30 +674,13 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
             raise NotImplementedError("Display of influence functions from files not yet written.")
 
 
-class HexSegmentedDeformableMirror(optics.MultiHexagonAperture):
-    """ Hexagonally segmented DM. Each actuator is controlalble in piston, tip, and tilt
 
-            Parameters
-            ----------
-            rings, flattoflat, gap, center : various
-                All keywords for defining the segmented aperture geometry are inherited from
-                the MultiHexagonAperture class. See that class for details.
-
-             include_factor_of_two : Bool
-                include the factor of two due to reflection in the OPD function (optional, default False).
-                If this is set False (default), actuator commands are interpreted as being in units of
-                desired wavefront error directly; the returned WFE will be directly proportional to the requested
-                values (convolved with the actuator response function etc).
-                If this is set to True, then the actuator commands are interpreted as being in physical surface
-                units, and the WFE is therefore a factor of two larger. The returned WFE will be twice the
-                amplitude of the requested values (convolved with the actuator response function etc.)
+class SegmentedDeformableMirror(ABC):
+    """ Abstract class for segmented DMs.
+    See below for subclasses for hexagonal and circular apertures.
     """
-
-    def __init__(self, rings=3, flattoflat=1.0 * u.m, gap=0.01 * u.m,
-                 name='HexDM', center=True, include_factor_of_two=False, **kwargs):
-        optics.MultiHexagonAperture.__init__(self, name=name, rings=rings, flattoflat=flattoflat,
-                                             gap=gap, center=center, **kwargs)
-        self._surface = np.zeros((self._n_hexes_inside_ring(rings+1), 3))
+    def __init__(self, rings=1, include_factor_of_two=False):
+        self._surface = np.zeros((self._n_aper_inside_ring(rings + 1), 3))
 
         # see _setup_arrays for the following
         self._last_npix = np.nan
@@ -759,132 +743,7 @@ class HexSegmentedDeformableMirror(optics.MultiHexagonAperture):
 
         self.transmission = np.zeros((npix, npix))
         for i in self.segmentlist:
-            self._one_hexagon(wave, i, value=i+1)
-        self._seg_mask = self.transmission
-        self._transmission = np.asarray(self._seg_mask != 0, dtype=float)
-
-        y, x = self.get_coordinates((wave))
-
-        for i in self.segmentlist:
-            wseg = np.where(self._seg_mask == i+1)
-            self._seg_indices[i] = wseg
-            ceny, cenx = self._hex_center(i)
-            self._seg_x[wseg] = x[wseg] - cenx
-            self._seg_y[wseg] = y[wseg] - ceny
-
-    def get_opd(self, wave):
-        """ Return OPD  - Faster version with caching"""
-        self._setup_arrays(wave.shape[0], wave.pixelscale, wave=wave)
-
-        self.opd = np.zeros(wave.shape)
-        for i in self.segmentlist:
-            wseg = self._seg_indices[i]
-            self.opd[wseg] = (self._surface[i, 0] +
-                              self._surface[i, 1] * self._seg_x[wseg] +
-                              self._surface[i, 2] * self._seg_y[wseg])
-
-        # account for DM being reflective (optional, governed by include_factor_of_two parameter)
-        if self.include_factor_of_two:
-            self.opd *= 2
-
-        return self.opd
-
-    def get_transmission(self, wave):
-        """ Return transmission - Faster version with caching"""
-        # return optics.MultiHexagonAperture.get_transmission(self,wave)
-        self._setup_arrays(wave.shape[0], wave.pixelscale, wave=wave)
-        return self._transmission
-
-class CircularSegmentedDeformableMirror(optics.MultiCircularAperture):
-    
-    """
-    Circularly segmented DM. Each actuator is controlalble in piston, tip, and tilt (and any zernike term)
-
-            Parameters
-            ----------
-            rings, segRadius, gap, center : various
-                All keywords for defining the segmented aperture geometry are inherited from
-                the MultiHexagonAperture class. See that class for details.
-
-             include_factor_of_two : Bool
-                include the factor of two due to reflection in the OPD function (optional, default False).
-                If this is set False (default), actuator commands are interpreted as being in units of
-                desired wavefront error directly; the returned WFE will be directly proportional to the requested
-                values (convolved with the actuator response function etc).
-                If this is set to True, then the actuator commands are interpreted as being in physical surface
-                units, and the WFE is therefore a factor of two larger. The returned WFE will be twice the
-                amplitude of the requested values (convolved with the actuator response function etc.)
-    """
-    
-    def __init__(self, rings=1, segRadius=1.0 * u.m, gap=0.01 * u.m,
-                 name='CircSegDM', center=True, include_factor_of_two=False, **kwargs):
-        #FIXME ? using grey pixel does not work. something in the geometry module generate a true divide error
-        optics.MultiCircularAperture.__init__(self, name=name, rings=rings, segRadius=segRadius,
-                                             gap=gap, center=center, gray_pixel = False, **kwargs)
-        self._surface = np.zeros((self._n_aper_inside_ring(rings+1), 3))
-
-        # see _setup_arrays for the following
-        self._last_npix = np.nan
-        self._last_pixelscale = np.nan * u.meter / u.pixel
-
-        self.include_factor_of_two = include_factor_of_two
-
-    @property
-    def dm_shape(self):
-        """ DM actuator geometry - i.e. how many actuators """
-        return len(self.segmentlist)
-
-    @property
-    def surface(self):
-        """ The surface shape of the deformable mirror, in
-        **meters**. This is the commanded shape, input to the DM.
-        See the .opd property for the output. """
-        return self._surface
-
-    def flatten(self):
-        """Flatten the DM by setting all actuators to zero piston"""
-        self._surface[:] = 0
-
-    @utils.quantity_input(piston=u.meter, tip=u.radian, tilt=u.radian)
-    def set_actuator(self, segnum, piston, tip, tilt):
-        """ Set an individual actuator of the DM.
-        Parameters
-        -------------
-        segnum : integer
-            Index of the actuator you wish to control
-        piston, tip, tilt : floats or astropy Quantities
-            Piston (in meters or other length units) and tip and tilt
-            (in radians or other angular units)
-        """
-
-        if segnum not in self.segmentlist:
-            raise ValueError("Segment {} is not present for this DM instance.".format(segnum))
-        self._surface[segnum] = [piston.to(u.meter).value,
-                                 tip.to(u.radian).value,
-                                 tilt.to(u.radian).value]
-
-    def _setup_arrays(self, npix, pixelscale, wave=None):
-        """ Set up the arrays to compute an OPD into.
-        This is relatively slow, but we only need to do this once for
-        each size of input array. A simple caching mechanism avoids
-        unnecessary recomputations.
-
-        """
-        # Don't recompute if values unchanged.
-        if (npix == self._last_npix) and (pixelscale == self._last_pixelscale):
-            return
-        else:
-            self._last_npix = npix
-            self._last_pixelscale = pixelscale
-
-        self._seg_mask = np.zeros((npix, npix))
-        self._seg_x = np.zeros((npix, npix))
-        self._seg_y = np.zeros((npix, npix))
-        self._seg_indices = dict()
-
-        self.transmission = np.zeros((npix, npix))
-        for i in self.segmentlist:
-            self._one_aperture(wave, i, value=i+1)
+            self._one_aperture(wave, i, value=i + 1)
         self._seg_mask = self.transmission
         self._transmission = np.asarray(self._seg_mask != 0, dtype=float)
 
@@ -916,6 +775,61 @@ class CircularSegmentedDeformableMirror(optics.MultiCircularAperture):
 
     def get_transmission(self, wave):
         """ Return transmission - Faster version with caching"""
-        # return optics.MultiHexagonAperture.get_transmission(self,wave)
         self._setup_arrays(wave.shape[0], wave.pixelscale, wave=wave)
         return self._transmission
+
+
+# note, must inherit first from SegmentedDeformableMirror to get correct method resolution order
+class HexSegmentedDeformableMirror(SegmentedDeformableMirror, optics.MultiHexagonAperture, ):
+    """ Hexagonally segmented DM. Each actuator is controllable in piston, tip, and tilt
+
+            Parameters
+            ----------
+            rings, flattoflat, gap, center : various
+                All keywords for defining the segmented aperture geometry are inherited from
+                the MultiHexagonAperture class. See that class for details.
+
+             include_factor_of_two : Bool
+                include the factor of two due to reflection in the OPD function (optional, default False).
+                If this is set False (default), actuator commands are interpreted as being in units of
+                desired wavefront error directly; the returned WFE will be directly proportional to the requested
+                values (convolved with the actuator response function etc).
+                If this is set to True, then the actuator commands are interpreted as being in physical surface
+                units, and the WFE is therefore a factor of two larger. The returned WFE will be twice the
+                amplitude of the requested values (convolved with the actuator response function etc.)
+    """
+
+    def __init__(self, rings=3, flattoflat=1.0 * u.m, gap=0.01 * u.m,
+                 name='HexDM', center=True, include_factor_of_two=False, **kwargs):
+        optics.MultiHexagonAperture.__init__(self, name=name, rings=rings, flattoflat=flattoflat,
+                                             gap=gap, center=center, **kwargs)
+        SegmentedDeformableMirror.__init__(self, rings=rings, include_factor_of_two=include_factor_of_two)
+
+
+
+# note, must inherit first from SegmentedDeformableMirror to get correct method resolution order
+class CircularSegmentedDeformableMirror(SegmentedDeformableMirror, optics.MultiCircularAperture):
+    """ Circularly segmented DM. Each actuator is controllable in piston, tip, and tilt (and any zernike term)
+
+            Parameters
+            ----------
+            rings, segment_radius, gap, center : various
+                All keywords for defining the segmented aperture geometry are inherited from
+                the MultiCircularperture class. See that class for details.
+
+             include_factor_of_two : Bool
+                include the factor of two due to reflection in the OPD function (optional, default False).
+                If this is set False (default), actuator commands are interpreted as being in units of
+                desired wavefront error directly; the returned WFE will be directly proportional to the requested
+                values (convolved with the actuator response function etc).
+                If this is set to True, then the actuator commands are interpreted as being in physical surface
+                units, and the WFE is therefore a factor of two larger. The returned WFE will be twice the
+                amplitude of the requested values (convolved with the actuator response function etc.)
+    """
+    
+    def __init__(self, rings=1, segment_radius=1.0 * u.m, gap=0.01 * u.m,
+                 name='CircSegDM', center=True, include_factor_of_two=False, **kwargs):
+        #FIXME ? using grey pixel does not work. something in the geometry module generate a true divide error
+        optics.MultiCircularAperture.__init__(self, name=name, rings=rings, segment_radius=segment_radius,
+                                              gap=gap, center=center, gray_pixel = False, **kwargs)
+        SegmentedDeformableMirror.__init__(self, rings=rings, include_factor_of_two=include_factor_of_two)

--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -795,7 +795,7 @@ class HexSegmentedDeformableMirror(optics.MultiHexagonAperture):
         self._setup_arrays(wave.shape[0], wave.pixelscale, wave=wave)
         return self._transmission
 
-class CircularSegmentedDeformableMirror(optics.multiCircularAperture):
+class CircularSegmentedDeformableMirror(optics.MultiCircularAperture):
     
     """
     Circularly segmented DM. Each actuator is controlalble in piston, tip, and tilt (and any zernike term)
@@ -819,7 +819,7 @@ class CircularSegmentedDeformableMirror(optics.multiCircularAperture):
     def __init__(self, rings=1, segRadius=1.0 * u.m, gap=0.01 * u.m,
                  name='CircSegDM', center=True, include_factor_of_two=False, **kwargs):
         #FIXME ? using grey pixel does not work. something in the geometry module generate a true divide error
-        optics.multiCircularAperture.__init__(self, name=name, rings=rings, segRadius=segRadius,
+        optics.MultiCircularAperture.__init__(self, name=name, rings=rings, segRadius=segRadius,
                                              gap=gap, center=center, gray_pixel = False, **kwargs)
         self._surface = np.zeros((self._n_aper_inside_ring(rings+1), 3))
 

--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -17,7 +17,7 @@ _log = logging.getLogger('poppy')
 if accel_math._USE_NUMEXPR:
     import numexpr as ne
 
-__all__ = ['ContinuousDeformableMirror', 'HexSegmentedDeformableMirror']
+__all__ = ['ContinuousDeformableMirror', 'HexSegmentedDeformableMirror', 'CircularSegmentedDeformableMirror']
 
 
 # noinspection PyUnresolvedReferences
@@ -769,6 +769,131 @@ class HexSegmentedDeformableMirror(optics.MultiHexagonAperture):
             wseg = np.where(self._seg_mask == i+1)
             self._seg_indices[i] = wseg
             ceny, cenx = self._hex_center(i)
+            self._seg_x[wseg] = x[wseg] - cenx
+            self._seg_y[wseg] = y[wseg] - ceny
+
+    def get_opd(self, wave):
+        """ Return OPD  - Faster version with caching"""
+        self._setup_arrays(wave.shape[0], wave.pixelscale, wave=wave)
+
+        self.opd = np.zeros(wave.shape)
+        for i in self.segmentlist:
+            wseg = self._seg_indices[i]
+            self.opd[wseg] = (self._surface[i, 0] +
+                              self._surface[i, 1] * self._seg_x[wseg] +
+                              self._surface[i, 2] * self._seg_y[wseg])
+
+        # account for DM being reflective (optional, governed by include_factor_of_two parameter)
+        if self.include_factor_of_two:
+            self.opd *= 2
+
+        return self.opd
+
+    def get_transmission(self, wave):
+        """ Return transmission - Faster version with caching"""
+        # return optics.MultiHexagonAperture.get_transmission(self,wave)
+        self._setup_arrays(wave.shape[0], wave.pixelscale, wave=wave)
+        return self._transmission
+
+class CircularSegmentedDeformableMirror(optics.multiCircularAperture):
+    
+    """
+    Circularly segmented DM. Each actuator is controlalble in piston, tip, and tilt (and any zernike term)
+
+            Parameters
+            ----------
+            rings, segRadius, gap, center : various
+                All keywords for defining the segmented aperture geometry are inherited from
+                the MultiHexagonAperture class. See that class for details.
+
+             include_factor_of_two : Bool
+                include the factor of two due to reflection in the OPD function (optional, default False).
+                If this is set False (default), actuator commands are interpreted as being in units of
+                desired wavefront error directly; the returned WFE will be directly proportional to the requested
+                values (convolved with the actuator response function etc).
+                If this is set to True, then the actuator commands are interpreted as being in physical surface
+                units, and the WFE is therefore a factor of two larger. The returned WFE will be twice the
+                amplitude of the requested values (convolved with the actuator response function etc.)
+    """
+    
+    def __init__(self, rings=1, segRadius=1.0 * u.m, gap=0.01 * u.m,
+                 name='CircSegDM', center=True, include_factor_of_two=False, **kwargs):
+        #FIXME ? using grey pixel does not work. something in the geometry module generate a true divide error
+        optics.multiCircularAperture.__init__(self, name=name, rings=rings, segRadius=segRadius,
+                                             gap=gap, center=center, gray_pixel = False, **kwargs)
+        self._surface = np.zeros((self._n_aper_inside_ring(rings+1), 3))
+
+        # see _setup_arrays for the following
+        self._last_npix = np.nan
+        self._last_pixelscale = np.nan * u.meter / u.pixel
+
+        self.include_factor_of_two = include_factor_of_two
+
+    @property
+    def dm_shape(self):
+        """ DM actuator geometry - i.e. how many actuators """
+        return len(self.segmentlist)
+
+    @property
+    def surface(self):
+        """ The surface shape of the deformable mirror, in
+        **meters**. This is the commanded shape, input to the DM.
+        See the .opd property for the output. """
+        return self._surface
+
+    def flatten(self):
+        """Flatten the DM by setting all actuators to zero piston"""
+        self._surface[:] = 0
+
+    @utils.quantity_input(piston=u.meter, tip=u.radian, tilt=u.radian)
+    def set_actuator(self, segnum, piston, tip, tilt):
+        """ Set an individual actuator of the DM.
+        Parameters
+        -------------
+        segnum : integer
+            Index of the actuator you wish to control
+        piston, tip, tilt : floats or astropy Quantities
+            Piston (in meters or other length units) and tip and tilt
+            (in radians or other angular units)
+        """
+
+        if segnum not in self.segmentlist:
+            raise ValueError("Segment {} is not present for this DM instance.".format(segnum))
+        self._surface[segnum] = [piston.to(u.meter).value,
+                                 tip.to(u.radian).value,
+                                 tilt.to(u.radian).value]
+
+    def _setup_arrays(self, npix, pixelscale, wave=None):
+        """ Set up the arrays to compute an OPD into.
+        This is relatively slow, but we only need to do this once for
+        each size of input array. A simple caching mechanism avoids
+        unnecessary recomputations.
+
+        """
+        # Don't recompute if values unchanged.
+        if (npix == self._last_npix) and (pixelscale == self._last_pixelscale):
+            return
+        else:
+            self._last_npix = npix
+            self._last_pixelscale = pixelscale
+
+        self._seg_mask = np.zeros((npix, npix))
+        self._seg_x = np.zeros((npix, npix))
+        self._seg_y = np.zeros((npix, npix))
+        self._seg_indices = dict()
+
+        self.transmission = np.zeros((npix, npix))
+        for i in self.segmentlist:
+            self._one_aperture(wave, i, value=i+1)
+        self._seg_mask = self.transmission
+        self._transmission = np.asarray(self._seg_mask != 0, dtype=float)
+
+        y, x = self.get_coordinates((wave))
+
+        for i in self.segmentlist:
+            wseg = np.where(self._seg_mask == i+1)
+            self._seg_indices[i] = wseg
+            ceny, cenx = self._aper_center(i)
             self._seg_x[wseg] = x[wseg] - cenx
             self._seg_y[wseg] = y[wseg] - ceny
 

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -1519,7 +1519,7 @@ class multiCircularAperture(AnalyticOpticalElement):
     
     @utils.quantity_input(segRadius=u.meter, gap=u.meter)
     def __init__(self, name = "multiCirc",rings = 1, segRadius = 1.0, gap = 0.01, 
-                 segmentList = None, center = True,gray_pixel = True, **kwargs):
+                 segmentlist = None, center = True,gray_pixel = True, **kwargs):
         self.segRadius = segRadius
         self.segDiameter = 2*segRadius
         self.rings = rings
@@ -1530,12 +1530,12 @@ class multiCircularAperture(AnalyticOpticalElement):
         self.pupil_diam = (self.segDiameter+ self.gap) * (2 * self.rings + 1)
 
         # make a list of all the segments included in this hex aperture
-        if segmentList is not None:
-            self.segmentList = segmentList
+        if segmentlist is not None:
+            self.segmentlist = segmentlist
         else:
-            self.segmentList = list(range(self._n_aper_inside_ring(self.rings + 1)))
+            self.segmentlist = list(range(self._n_aper_inside_ring(self.rings + 1)))
             if not center:
-                self.segmentList.remove(0)  # remove center segment 0
+                self.segmentlist.remove(0)  # remove center segment 0
                 
         self._use_gray_pixel = bool(gray_pixel)
         
@@ -1625,7 +1625,7 @@ class multiCircularAperture(AnalyticOpticalElement):
 
         self.transmission = np.zeros(wave.shape, dtype=_float())
 
-        for i in self.segmentList:
+        for i in self.segmentlist:
             self._one_aperture(wave, i)
 
         return self.transmission

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -23,10 +23,9 @@ __all__ = ['AnalyticOpticalElement', 'ScalarTransmission', 'ScalarOpticalPathDif
            'BandLimitedCoron', 'BandLimitedCoronagraph', 'IdealFQPM', 'CircularPhaseMask', 'RectangularFieldStop', 'SquareFieldStop',
            'AnnularFieldStop', 'HexagonFieldStop',
            'CircularOcculter', 'BarOcculter', 'FQPM_FFT_aligner', 'CircularAperture',
-           'HexagonAperture', 'MultiHexagonAperture', 'NgonAperture', 'multiCircularAperture', 'RectangleAperture',
+           'HexagonAperture', 'MultiHexagonAperture', 'NgonAperture', 'MultiCircularAperture', 'RectangleAperture',
            'SquareAperture', 'SecondaryObscuration', 'LetterFAperture', 'AsymmetricSecondaryObscuration',
            'ThinLens',  'GaussianAperture', 'KnifeEdge', 'TiltOpticalPathDifference', 'CompoundAnalyticOptic', 'fixed_sampling_optic']
-
 
 # ------ Generic Analytic elements -----
 
@@ -1490,7 +1489,7 @@ class NgonAperture(AnalyticOpticalElement):
 
         return self.transmission
 
-class multiCircularAperture(AnalyticOpticalElement):
+class MultiCircularAperture(AnalyticOpticalElement):
     """ Defines a circularly segmented aperture in close compact configuration
     
     Parameters

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -6,6 +6,7 @@ import astropy.io.fits as fits
 import astropy.units as u
 import warnings
 import logging
+from abc import ABC, abstractmethod
 
 from . import utils
 from . import conf
@@ -1255,8 +1256,127 @@ class HexagonAperture(AnalyticOpticalElement):
 
         return self.transmission
 
+class MultiSegmentAperture(AnalyticOpticalElement, ABC):
+    """Abstract base class for an aperture made of sub-apertures
+    This is subclassed to hexagons and circles below.
+    """
 
-class MultiHexagonAperture(AnalyticOpticalElement):
+    @utils.quantity_input(segment_size=u.meter, gap=u.meter)
+    def __init__(self, name="MultiSegment", segment_size=1, gap=0.01, rings=1,
+                 segmentlist=None, center=False, **kwargs):
+        self.rings = rings
+        self.gap = gap
+        AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil, **kwargs)
+
+        # spacing between segment centers
+        self._segment_spacing = (segment_size + gap).to_value(u.meter)
+
+        self.pupil_diam = (self._segment_spacing) * (2 * self.rings + 1)
+
+        # make a list of all the segments included in this hex aperture
+        if segmentlist is not None:
+            self.segmentlist = segmentlist
+        else:
+            self.segmentlist = list(range(self._n_aper_inside_ring(self.rings + 1)))
+            if not center:
+                self.segmentlist.remove(0)  # remove center segment 0
+
+    def _n_aper_in_ring(self, n):
+        """ How many hexagons or circles in ring N? """
+        return 1 if n == 0 else 6 * n
+
+    def _n_aper_inside_ring(self, n):
+        """ How many hexagons or circles interior to ring N, not counting N?"""
+        return sum([self._n_aper_in_ring(i) for i in range(n)])
+
+    def _aper_in_ring(self, hex_index):
+        """ What ring is a given hexagon or circle in?"""
+        if hex_index == 0:
+            return 0
+        for i in range(100):
+            if self._n_aper_inside_ring(i) <= hex_index < self._n_aper_inside_ring(i + 1):
+                return i
+        raise ValueError("Loop exceeded! MultiSegmentAperture is limited to <100 rings of segments.")
+
+    def _aper_radius(self, hex_index):
+        """ Radius of a given hexagon from the center """
+        ring = self._aper_in_ring(hex_index)
+        if ring <= 1:
+            return (self._segment_spacing) * ring
+
+    def _aper_center(self, aper_index):
+        """ Center coordinates of a given hexagon
+        counting clockwise around each ring
+
+        Returns y, x coords
+
+        """
+        ring = self._aper_in_ring(aper_index)
+
+        # handle degenerate case of center segment
+        # to avoid div by 0 in the main code below
+        if ring == 0:
+            return 0, 0
+
+        # now count around from the starting point:
+        index_in_ring = aper_index - self._n_aper_inside_ring(ring) + 1  # 1-based
+        angle_per_hex = 2 * np.pi / self._n_aper_in_ring(ring)  # angle in radians
+
+        radius = (self._segment_spacing) * ring  # like JWST 'B' segments, aka corners for a hexagon
+        if np.mod(index_in_ring, ring) == 1:
+            angle = angle_per_hex * (index_in_ring - 1)
+            ypos = radius * np.cos(angle)
+            xpos = radius * np.sin(angle)
+        else:
+            # find position of previous 'B' type segment.
+            last_B_angle = ((index_in_ring - 1) // ring) * ring * angle_per_hex
+            ypos0 = radius * np.cos(last_B_angle)
+            xpos0 = radius * np.sin(last_B_angle)
+
+            # count around from that corner
+            da = (self._segment_spacing) * np.cos(30 * np.pi / 180)
+            db = (self._segment_spacing) * np.sin(30 * np.pi / 180)
+
+            whichside = (index_in_ring - 1) // ring  # which of the sides are we on?
+            if whichside == 0:
+                dx, dy = da, -db
+            elif whichside == 1:
+                dx, dy = 0, -self._segment_spacing
+            elif whichside == 2:
+                dx, dy = -da, -db
+            elif whichside == 3:
+                dx, dy = -da, db
+            elif whichside == 4:
+                dx, dy = 0, self._segment_spacing
+            elif whichside == 5:
+                dx, dy = da, db
+
+            xpos = xpos0 + dx * np.mod(index_in_ring - 1, ring)
+            ypos = ypos0 + dy * np.mod(index_in_ring - 1, ring)
+
+        return ypos, xpos
+
+    @abstractmethod
+    def _one_aperture(self, wave, index, value=1):
+        """Implement how to draw one aperture"""
+        pass
+
+    def get_transmission(self, wave):
+        """ Compute the transmission inside/outside of the occulter.
+        """
+        if not isinstance(wave, BaseWavefront):
+            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
+        assert (wave.planetype != PlaneType.image)
+
+        self.transmission = np.zeros(wave.shape, dtype=_float())
+
+        for i in self.segmentlist:
+            self._one_aperture(wave, i)
+
+        return self.transmission
+
+
+class MultiHexagonAperture(MultiSegmentAperture):
     """ Defines a hexagonally segmented aperture
 
     Parameters
@@ -1302,121 +1422,18 @@ class MultiHexagonAperture(AnalyticOpticalElement):
         else:
             self.side = flattoflat / np.sqrt(3.)
         self.flattoflat = self.side * np.sqrt(3)
-        self.rings = rings
-        self.gap = gap
-        AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil, **kwargs)
 
-        self.pupil_diam = (self.flattoflat + self.gap) * (2 * self.rings + 1)
+        super().__init__(name=name, segment_size=self.flattoflat,
+                         gap=gap, rings=rings, segmentlist=segmentlist, center=center, **kwargs)
 
-        # make a list of all the segments included in this hex aperture
-        if segmentlist is not None:
-            self.segmentlist = segmentlist
-        else:
-            self.segmentlist = list(range(self._n_hexes_inside_ring(self.rings + 1)))
-            if not center:
-                self.segmentlist.remove(0)  # remove center segment 0
 
-    def _n_hexes_in_ring(self, n):
-        """ How many hexagons in ring N? """
-        return 1 if n == 0 else 6 * n
-
-    def _n_hexes_inside_ring(self, n):
-        """ How many hexagons interior to ring N, not counting N?"""
-        return sum([self._n_hexes_in_ring(i) for i in range(n)])
-
-    def _hex_in_ring(self, hex_index):
-        """ What ring is a given hexagon in?"""
-        if hex_index == 0:
-            return 0
-        for i in range(100):
-            if self._n_hexes_inside_ring(i) <= hex_index < self._n_hexes_inside_ring(i + 1):
-                return i
-        raise ValueError("Loop exceeded! MultiHexagonAperture is limited to <100 rings of hexagons.")
-
-    def _hex_radius(self, hex_index):
-        """ Radius of a given hexagon from the center """
-        ring = self._hex_in_ring(hex_index)
-        if ring <= 1:
-            return (self.flattoflat + self.gap) * ring
-
-    def _hex_center(self, hex_index):
-        """ Center coordinates of a given hexagon
-        counting clockwise around each ring
-
-        Returns y, x coords
-
-        """
-        ring = self._hex_in_ring(hex_index)
-
-        # handle degenerate case of center segment
-        # to avoid div by 0 in the main code below
-        if ring == 0:
-            return 0, 0
-
-        # now count around from the starting point:
-        index_in_ring = hex_index - self._n_hexes_inside_ring(ring) + 1  # 1-based
-        angle_per_hex = 2 * np.pi / self._n_hexes_in_ring(ring)  # angle in radians
-
-        # Now figure out what the radius is:
-        flattoflat = self.flattoflat.to(u.meter).value
-        gap = self.gap.to(u.meter).value
-        side = self.side.to(u.meter).value
-
-        radius = (flattoflat + gap) * ring  # JWST 'B' segments, aka corners
-        if np.mod(index_in_ring, ring) == 1:
-            angle = angle_per_hex * (index_in_ring - 1)
-            ypos = radius * np.cos(angle)
-            xpos = radius * np.sin(angle)
-        else:
-            # find position of previous 'B' type segment.
-            last_B_angle = ((index_in_ring - 1) // ring) * ring * angle_per_hex
-            ypos0 = radius * np.cos(last_B_angle)
-            xpos0 = radius * np.sin(last_B_angle)
-
-            # count around from that corner
-            da = (flattoflat + gap) * np.cos(30 * np.pi / 180)
-            db = (flattoflat + gap) * np.sin(30 * np.pi / 180)
-
-            whichside = (index_in_ring - 1) // ring  # which of the sides are we on?
-            if whichside == 0:
-                dx, dy = da, -db
-            elif whichside == 1:
-                dx, dy = 0, -(flattoflat + gap)
-            elif whichside == 2:
-                dx, dy = -da, -db
-            elif whichside == 3:
-                dx, dy = -da, db
-            elif whichside == 4:
-                dx, dy = 0, (flattoflat + gap)
-            elif whichside == 5:
-                dx, dy = da, db
-
-            xpos = xpos0 + dx * np.mod(index_in_ring - 1, ring)
-            ypos = ypos0 + dy * np.mod(index_in_ring - 1, ring)
-
-        return ypos, xpos
-
-    def get_transmission(self, wave):
-        """ Compute the transmission inside/outside of the occulter.
-        """
-        if not isinstance(wave, BaseWavefront):
-            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
-        assert (wave.planetype != PlaneType.image)
-
-        self.transmission = np.zeros(wave.shape, dtype=_float())
-
-        for i in self.segmentlist:
-            self._one_hexagon(wave, i)
-
-        return self.transmission
-
-    def _one_hexagon(self, wave, index, value=1):
+    def _one_aperture(self, wave, index, value=1):
         """ Draw one hexagon into the self.transmission array """
 
         y, x = self.get_coordinates(wave)
         side = self.side.to(u.meter).value
 
-        ceny, cenx = self._hex_center(index)
+        ceny, cenx = self._aper_center(index)
 
         y -= ceny
         x -= cenx
@@ -1489,7 +1506,7 @@ class NgonAperture(AnalyticOpticalElement):
 
         return self.transmission
 
-class MultiCircularAperture(AnalyticOpticalElement):
+class MultiCircularAperture(MultiSegmentAperture):
     """ Defines a circularly segmented aperture in close compact configuration
     
     Parameters
@@ -1498,7 +1515,7 @@ class MultiCircularAperture(AnalyticOpticalElement):
         descriptive name
     rings : integer
          The number of rings of hexagons to include, not counting the central segment
-    subPupilRadius : float, optional
+    segment_radius : float, optional
         radius of the circular sub-apertures in meters, default is 1 meters
     gap: float, otional
         Gap between adjacent segments, in meters. Default is 0.01 m = 1 cm
@@ -1516,124 +1533,22 @@ class MultiCircularAperture(AnalyticOpticalElement):
     
     """
     
-    @utils.quantity_input(segRadius=u.meter, gap=u.meter)
-    def __init__(self, name = "multiCirc",rings = 1, segRadius = 1.0, gap = 0.01, 
-                 segmentlist = None, center = True,gray_pixel = True, **kwargs):
-        self.segRadius = segRadius
-        self.segDiameter = 2*segRadius
-        self.rings = rings
-        self.gap = gap
-        
-        AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil,**kwargs)
-        
-        self.pupil_diam = (self.segDiameter+ self.gap) * (2 * self.rings + 1)
+    @utils.quantity_input(segment_radius=u.meter, gap=u.meter)
+    def __init__(self, name = "multiCirc",rings = 1, segment_radius = 1.0, gap = 0.01,
+                 segmentlist = None, center = True, gray_pixel = True, **kwargs):
+        self.segment_radius = segment_radius
+        segment_diameter = 2*segment_radius
 
-        # make a list of all the segments included in this hex aperture
-        if segmentlist is not None:
-            self.segmentlist = segmentlist
-        else:
-            self.segmentlist = list(range(self._n_aper_inside_ring(self.rings + 1)))
-            if not center:
-                self.segmentlist.remove(0)  # remove center segment 0
-                
+        super().__init__(name=name, segment_size=segment_diameter,
+                         gap=gap, rings=rings, segmentlist=segmentlist, center=center, **kwargs)
+
         self._use_gray_pixel = bool(gray_pixel)
         
-    def _n_aper_in_ring(self, n):
-        """ How many hexagons in ring N? """
-        return 1 if n == 0 else 6 * n
-        
-    def _n_aper_inside_ring(self, n):
-        """ How many apertures interior to ring N, not counting N?"""
-        return sum([self._n_aper_in_ring(i) for i in range(n)])
-    
-    def _aper_in_ring(self, aper_index):
-        """ What aper is a given hexagon in?"""
-        if aper_index == 0:
-            return 0
-        for i in range(100):
-            if self._n_aper_inside_ring(i) <= aper_index < self._n_aper_inside_ring(i + 1):
-                return i
-        raise ValueError("Loop exceeded! MultiCircularAperture is limited to <100 rings of apertures.")
-        
-    def _aper_radius(self, aper_index):
-        """ Radius of a given hexagon from the center """
-        ring = self._aper_in_ring(aper_index)
-        if ring <= 1:
-            return (self.segDiameter + self.gap) * ring
-        
-    def _aper_center(self, aper_index):
-        """ Center coordinates of a given hexagon
-        counting clockwise around each ring
-        Returns y, x coords
-        """
-        ring = self._aper_in_ring(aper_index)
-
-        # handle degenerate case of center segment
-        # to avoid div by 0 in the main code below
-        if ring == 0:
-            return 0, 0
-
-        # now count around from the starting point:
-        index_in_ring = aper_index - self._n_aper_inside_ring(ring) + 1  # 1-based
-        angle_per_aper = 2 * np.pi / self._n_aper_in_ring(ring)  # angle in radians
-
-        # Now figure out what the radius is:
-        segDiameter = self.segDiameter.to(u.meter).value
-        gap = self.gap.to(u.meter).value
-
-        radius = (segDiameter + gap) * ring  # JWST 'B' segments, aka corners
-        if np.mod(index_in_ring, ring) == 1:
-            angle = angle_per_aper * (index_in_ring - 1)
-            ypos = radius * np.cos(angle)
-            xpos = radius * np.sin(angle)
-        else:
-            # find position of previous 'B' type segment.
-            last_B_angle = ((index_in_ring - 1) // ring) * ring * angle_per_aper
-            ypos0 = radius * np.cos(last_B_angle)
-            xpos0 = radius * np.sin(last_B_angle)
-
-            # count around from that corner
-            da = (segDiameter + gap) * np.cos(30 * np.pi / 180)
-            db = (segDiameter + gap) * np.sin(30 * np.pi / 180)
-
-            whichside = (index_in_ring - 1) // ring  # which of the sides are we on?
-            if whichside == 0:
-                dx, dy = da, -db
-            elif whichside == 1:
-                dx, dy = 0, -(segDiameter + gap)
-            elif whichside == 2:
-                dx, dy = -da, -db
-            elif whichside == 3:
-                dx, dy = -da, db
-            elif whichside == 4:
-                dx, dy = 0, (segDiameter + gap)
-            elif whichside == 5:
-                dx, dy = da, db
-
-            xpos = xpos0 + dx * np.mod(index_in_ring - 1, ring)
-            ypos = ypos0 + dy * np.mod(index_in_ring - 1, ring)
-
-        return ypos, xpos
-    
-    def get_transmission(self, wave):
-        """ Compute the transmission inside/outside of the occulter.
-        """
-        if not isinstance(wave, BaseWavefront):
-            raise ValueError("get_transmission must be called with a Wavefront to define the spacing")
-        assert (wave.planetype != PlaneType.image)
-
-        self.transmission = np.zeros(wave.shape, dtype=_float())
-
-        for i in self.segmentlist:
-            self._one_aperture(wave, i)
-
-        return self.transmission
-
     def _one_aperture(self, wave, index, value=1):
         """ Draw one circular aperture into the self.transmission array """
 
         y, x = self.get_coordinates(wave)
-        segRadius = self.segRadius.to(u.meter).value
+        segRadius = self.segment_radius.to(u.meter).value
 
         ceny, cenx = self._aper_center(index)
 


### PR DESCRIPTION
Dear all,

I needed to simulate a segmented mirror with circular segments. The modifications are heavily copy/pasted from the `HexSegmentedDeformableMirror` and the `MultiHexagonAperture` classes. I only made changes to account for the circular segments instead of hexagonal. 
I hit only one small snag: I used the `CircularAperture` class to draw the segments (again a copy paste) and you can grey scale pixels at the edge of the circular apertures. I tried to have this accessible from the dms but it yield an error in the geometry method. hence, for now the grey scaling is forced to not happen. I left a `FIXME?` in the code to mark where this is happening. 

I hope I did a good enough job and you find this addition interesting and consider it for the general poppy library.

Best Regards,
Anne-Laure Cheffot