### PR TITLE
add rot90 optimization (fixes #408), and fix inconsistent sign bug in rotation

### DIFF
--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -3011,7 +3011,7 @@ class FITSOpticalElement(OpticalElement):
                     # this is imperfect at best, of course...
                     self.amplitude = scipy.ndimage.interpolation.rotate(self.amplitude, -rotation,  # negative = CCW
                                                                         reshape=False).clip(min=0, max=1.0)
-                    wnoise = np.where((self.amplitude < 1e-3) & (self.amplitude > 0))
+                    wnoise = (self.amplitude < 1e-3) & (self.amplitude > 0)
                     self.amplitude[wnoise] = 0
                     self.opd = scipy.ndimage.interpolation.rotate(self.opd, -rotation, reshape=False)  # negative = CCW
                 _log.info("  Rotated optic by %f degrees counter clockwise." % rotation)

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -880,8 +880,16 @@ class BaseWavefront(ABC):
         # Huh, the ndimage rotate function does not work for complex numbers. That's weird.
         # so let's treat the real and imaginary parts individually
         # FIXME TODO or would it be better to do this on the amplitude and phase?
-        rot_real = scipy.ndimage.interpolation.rotate(self.wavefront.real, angle, reshape=False)
-        rot_imag = scipy.ndimage.interpolation.rotate(self.wavefront.imag, angle, reshape=False)
+
+        k, remainder = np.divmod(angle, 90)
+        if remainder == 0:
+            # rotation is a multiple of 90
+            rot_real = np.rot90(self.wavefront.real, k=-k)  # negative = CCW
+            rot_imag = np.rot90(self.wavefront.imag, k=-k)
+        else:
+            # arbitrary free rotation with interpolation
+            rot_real = scipy.ndimage.interpolation.rotate(self.wavefront.real, -angle, reshape=False)  # negative = CCW
+            rot_imag = scipy.ndimage.interpolation.rotate(self.wavefront.imag, -angle, reshape=False)
         self.wavefront = rot_real + 1.j * rot_imag
 
         self.history.append('Rotated by {:.2f} degrees, CCW'.format(angle))
@@ -2991,13 +2999,21 @@ class FITSOpticalElement(OpticalElement):
             # ---- transformation: rotation ----
             # If a rotation is specified and we're NOT a null (scalar) optic, then do the rotation:
             if rotation is not None and len(self.amplitude.shape) == 2:
-                # do rotation with interpolation, but try to clean up some of the artifacts afterwards.
-                # this is imperfect at best, of course...
-                self.amplitude = scipy.ndimage.interpolation.rotate(self.amplitude, -rotation,  # negative = CCW
-                                                                    reshape=False).clip(min=0, max=1.0)
-                wnoise = np.where((self.amplitude < 1e-3) & (self.amplitude > 0))
-                self.amplitude[wnoise] = 0
-                self.opd = scipy.ndimage.interpolation.rotate(self.opd, -rotation, reshape=False)  # negative = CCW
+
+                k,remainder = np.divmod(rotation, 90)
+                if remainder==0:
+                    # rotation is a multiple of 90
+                    self.amplitude = np.rot90(self.amplitude, k=-k)   # negative = CCW
+                    self.opd = np.rot90(self.opd, k=-k)
+                else:
+                    # arbitrary free rotation with interpolation
+                    # do rotation with interpolation, but try to clean up some of the artifacts afterwards.
+                    # this is imperfect at best, of course...
+                    self.amplitude = scipy.ndimage.interpolation.rotate(self.amplitude, -rotation,  # negative = CCW
+                                                                        reshape=False).clip(min=0, max=1.0)
+                    wnoise = np.where((self.amplitude < 1e-3) & (self.amplitude > 0))
+                    self.amplitude[wnoise] = 0
+                    self.opd = scipy.ndimage.interpolation.rotate(self.opd, -rotation, reshape=False)  # negative = CCW
                 _log.info("  Rotated optic by %f degrees counter clockwise." % rotation)
                 self._rotation = rotation
 

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -538,6 +538,26 @@ def test_fits_rot90_vs_ndimagerotate_consistency(plot=False):
         axes[1].imshow(opt2.amplitude)
         axes[1].set_title("ndimage rotate(89.9999)")
 
+def test_analytic_vs_FITS_rotation_consistency(plot=False):
+    """Test that rotating an AnalyticOpticalElement vs
+    rotating a discretized version as a FITSOpticalElement
+    are consistent in rotation direction (counterclockwise)
+    and amount"""
+    opt1 = poppy.optics.LetterFAperture(rotation=90)
+
+    letterf_hdu = poppy.optics.LetterFAperture().to_fits(npix=128)
+    opt2 = poppy.FITSOpticalElement(transmission=letterf_hdu,
+                                    rotation=90)
+
+    if plot:
+        opt1.display()
+        plt.figure()
+        opt2.display()
+
+    array1 = opt1.sample(npix=128)
+    array2 = opt2.amplitude
+    assert np.allclose(array1, array2)
+
 ### OpticalSystem tests and related
 
 def test_source_offsets_in_OpticalSystem(npix=128, fov_size=1):


### PR DESCRIPTION
- Adds a check for 90 degree rotation (for rotations of either a Wavefront or FITSOpticalElement) or multiple of 90 degrees, and if so uses the faster and more exact `np.rot90` rather than an interpolation
- Add new tests to test consistency of the exact 90 degree rotation and an 89.9999 deg rotation via the interpolation method. This demonstrates consistent signs of rotation (positive is counterclockwise following the usual astronomical convention)
- _Fixes a bug (sign inconsistency) that I hadn't realized existed_, in which positive rotations were clockwise for wavefronts. This behavior directly contradicted the doc string of Wavefront.rotation which states rotations are counterclockwise; see poppy_core.py line 869. (Not sure how this didn't get caught before; whoops!) I opted to fix the function behavior for consistency with the docs, as well as consistency with the other rotations in poppy. 
- Update test for rotations in an optical system, to reflect the correct behavior after the above bug fix. 
- Add test that rotating an optic as an analytic function vs as a FITS array yields consistent results.