### PR TITLE
faster array indexing via boolean masks. Addresses #412.

### DIFF
--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -887,7 +887,7 @@ class Instrument(object):
             poppy_core._log.info("Computing wavelength weights using synthetic photometry for %s..." % self.filter)
             band = self._get_synphot_bandpass(self.filter)
             # choose reasonable min and max wavelengths
-            w_above10 = np.where(band.throughput > 0.10 * band.throughput.max())
+            w_above10 = (band.throughput > 0.10 * band.throughput.max())
 
             minwave = band.wave[w_above10].min()
             maxwave = band.wave[w_above10].max()
@@ -956,8 +956,7 @@ class Instrument(object):
 
             poppy_core._log.warning(
                 "CAUTION: Just interpolating rather than integrating filter profile, over {0} steps".format(nlambda))
-            wtrans = np.where(throughputs > 0.4)
-            lrange = wavelengths[wtrans] * 1e-10  # convert from Angstroms to Meters
+            lrange = wavelengths[throughputs > 0.4] * 1e-10  # convert from Angstroms to Meters
             # get evenly spaced points within the range of allowed lambdas, centered on each bin
             lambd = np.linspace(np.min(lrange), np.max(lrange), nlambda, endpoint=False) + (
                     np.max(lrange) - np.min(lrange)) / (2 * nlambda)

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -416,7 +416,7 @@ class BaseWavefront(ABC):
         # areas with particularly low intensity
         phase = self.phase.copy()
         mean_intens = np.mean(intens[intens != 0])
-        phase[np.where(intens < mean_intens / 100)] = np.nan
+        phase[intens < mean_intens / 100] = np.nan
         amp = self.amplitude
 
         y, x = self.coordinates()
@@ -453,7 +453,7 @@ class BaseWavefront(ABC):
         if what == 'best':
             if self.planetype == PlaneType.image:
                 what = 'intensity'  # always show intensity for image planes
-            elif phase[np.where(np.isfinite(phase))].sum() == 0:
+            elif phase[(np.isfinite(phase))].sum() == 0:
                 what = 'intensity'  # for perfect pupils
             # FIXME re-implement this in some better way that doesn't depend on
             # optic positioning in the plot grid!
@@ -555,7 +555,7 @@ class BaseWavefront(ABC):
             wfe = self.wfe.to(u.nanometer).value.copy()
             if self.planetype == PlaneType.pupil and self.ispadded and not showpadding:
                 wfe = utils.removePadding(wfe, self.oversample)
-            wfe[np.where(intens < mean_intens / 100)] = np.nan
+            wfe[intens < mean_intens / 100] = np.nan
             vmx = np.nanmax(np.abs(wfe))
             norm_wfe = matplotlib.colors.Normalize(vmin=-vmx, vmax=vmx)
 
@@ -2615,7 +2615,7 @@ class OpticalElement(object):
         # Evaluate the wavefront at the desired sampling and pixel scale.
         ampl = self.get_transmission(temp_wavefront)
         opd = self.get_opd(temp_wavefront).copy()
-        opd[np.where(ampl == 0)] = np.nan
+        opd[(ampl == 0)] = np.nan
 
         # define a helper function for the actual plotting - we do it this way so
         # we can call it twice if the 'both' option is chosen. This avoids the complexities of the

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -169,7 +169,7 @@ def test_Circular_Aperture_PTP_long(display=False, npix=512, display_proper=Fals
 
     # also let's test that the output is centered on the array as expected.
     # the peak pixel should be at the coordinates (0,0)
-    assert inten[np.where((y==0) & (x==0))] == inten.max()
+    assert inten[((y==0) & (x==0))] == inten.max()
 
     # and the image should be symmetric if you flip in X or Y
     # (approximately but not perfectly to machine precision

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -628,16 +628,16 @@ def test_ThinLens(display=False):
 
     # Now test the values at some precisely chosen pixels
     y, x = wave.coordinates()
-    at_radius = np.where((x==1) & (y==0))
+    at_radius = ((x==1) & (y==0))
     assert np.allclose(wave.phase[at_radius], np.pi/2), "Didn't get 1/2 wave OPD at edge of optic"
     assert len(at_radius[0]) > 0, "Array indices messed up - need to have a pixel at exactly (1,0)"
 
-    at_radius = np.where((x==0) & (y==1))
+    at_radius = ((x==0) & (y==1))
     assert np.allclose(wave.phase[at_radius], np.pi/2), "Didn't get 1/2 wave OPD at edge of optic"
     assert len(at_radius[0]) > 0, "Array indices messed up - need to have a pixel at exactly (0,1)"
 
 
-    at_center = np.where((x==0) & (y==0))
+    at_center = ((x==0) & (y==0))
     assert np.allclose(wave.phase[at_center], -np.pi/2), "Didn't get -1/2 wave OPD at center of optic"
     assert len(at_radius[0]) > 0, "Array indices messed up - need to have a pixel at exactly (0,0)"
 

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -245,8 +245,7 @@ def zernike(n, m, npix=100, rho=None, theta=None, outside=np.nan,
     if not np.all(rho.shape == theta.shape):
         raise ValueError('The rho and theta arrays do not have consistent shape.')
 
-    aperture = np.ones(rho.shape)
-    aperture[np.where(rho > 1)] = 0.0  # this is the aperture mask
+    aperture = (rho <= 1)
 
     if m == 0:
         if n == 0:
@@ -261,7 +260,7 @@ def zernike(n, m, npix=100, rho=None, theta=None, outside=np.nan,
         norm_coeff = np.sqrt(2) * np.sqrt(n + 1) if noll_normalize else 1
         zernike_result = norm_coeff * R(n, m, rho) * np.sin(np.abs(m) * theta) * aperture
 
-    zernike_result[np.where(rho > 1)] = outside
+    zernike_result[(rho > 1)] = outside
     return zernike_result
 
 
@@ -489,9 +488,9 @@ def hex_aperture(npix=1024, rho=None, theta=None, vertical=False, outside=0):
     absy = np.abs(y)
 
     aperture = np.full(x.shape, outside)
-    w_rect = np.where((np.abs(x) <= 0.5) & (np.abs(y) <= np.sqrt(3) / 2))
-    w_left_tri = np.where((x <= -0.5) & (x >= -1) & (absy <= (x + 1) * np.sqrt(3)))
-    w_right_tri = np.where((x >= 0.5) & (x <= 1) & (absy <= (1 - x) * np.sqrt(3)))
+    w_rect = ((np.abs(x) <= 0.5) & (np.abs(y) <= np.sqrt(3) / 2))
+    w_left_tri = ((x <= -0.5) & (x >= -1) & (absy <= (x + 1) * np.sqrt(3)))
+    w_right_tri = ((x >= 0.5) & (x <= 1) & (absy <= (1 - x) * np.sqrt(3)))
     aperture[w_rect] = 1
     aperture[w_left_tri] = 1
     aperture[w_right_tri] = 1
@@ -1009,10 +1008,9 @@ def opd_expand(opd, aperture=None, nterms=15, basis=zernike_basis,
         **kwargs
     )
 
-    wgood = np.where(apmask)
     ngood = apmask.sum()
 
-    coeffs = [(opd * b)[wgood].sum() / ngood
+    coeffs = [(opd * b)[apmask].sum() / ngood
               for b in basis_set]
 
     return coeffs
@@ -1083,7 +1081,7 @@ def opd_expand_nonorthonormal(opd, aperture=None, nterms=15, basis=zernike_basis
         **kwargs
     )
 
-    wgood = np.where(apmask & np.isfinite(basis_set[1]))
+    wgood = (apmask & np.isfinite(basis_set[1]))
     ngood = apmask.sum()
 
     coeffs = np.zeros(nterms)


### PR DESCRIPTION
Low-level change in numpy array indexing syntax to use e.g. `array[blah is true]` rather than `w = np.where(blah is true); array[w]`. Speeds up a variety of tasks such as optic setup and sampling.  A small optimization for performance but adds up over time.

I didn't extensively benchmark every part individually, but some spot tests confirm noticeable speedups:

**current develop**:

```
%pylab inline
import poppy

ap = poppy.HexagonAperture()
%timeit ap.sample(npix=1024)
43.8 ms ± 1.51 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

ap = poppy.CircularAperture()
%timeit ap.sample(npix=1024)
45.5 ms ± 1.22 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

ap = poppy.SquareAperture()
%timeit ap.sample(npix=1024)
40 ms ± 1.28 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

**with this PR:**

```
ap = poppy.HexagonAperture()
%timeit ap.sample(npix=1024)
30.8 ms ± 768 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

ap = poppy.CircularAperture()
%timeit ap.sample(npix=1024)
40.6 ms ± 1.39 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

ap = poppy.SquareAperture()
%timeit ap.sample(npix=1024)
27.7 ms ± 1.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

