### PR TITLE
update minimum versions of dependencies

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,16 +19,17 @@ latest development version from git::
 Requirements
 --------------
 
-* Python 3.6, or more recent. Earlier versions of Python are no longer supported.
+* Python 3.6, or more recent.
 * The standard Python scientific stack: :py:mod:`numpy`, :py:mod:`scipy`,
   :py:mod:`matplotlib`
 * POPPY relies upon the `astropy
   <http://www.astropy.org>`__ community-developed core library for astronomy.
-  astropy, version 1.3 or more recent, is needed.
 
 The following are *optional*.  The first, :py:mod:`pysynphot`, is recommended
-for most users. The other optional installs are only worth adding for speed
-improvements if you are spending substantial time running calculations.
+for most users. The other optional installs can provide speed
+improvements if you are spending substantial time running calculations. See
+:ref:`the appendix on performance optimization <performance_and_parallelization>` for details.
+
 
 * `pysynphot <http://pysynphot.readthedocs.org/en/latest/>`_ enables the simulation
   of PSFs with proper spectral response to realistic source spectra.  Without

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,10 @@ max-line-length = 120
 zip_safe = False
 packages = find:
 install_requires =
-    numpy>=1.16.0
-    scipy>=1.0.0
-    matplotlib>=2.0.0
-    astropy>=3.2.0
+    numpy>=1.17.0
+    scipy>=1.4.0
+    matplotlib>=3.0.0
+    astropy>=4.0.0
 python_requires = >=3.6
 setup_requires = setuptools_scm
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ deps=
     cov: pytest-cov
     cov: coverage
     cov: codecov
-    legacy: numpy==1.16.*
-    legacy: astropy==3.2.*
+    legacy: numpy==1.17.*
+    legacy: astropy==4.0.*
     latest: -rrequirements.txt
     astropydev: git+git://github.com/astropy/astropy
     numexpr: numexpr>=2.0.0


### PR DESCRIPTION
Update astropy, matplotlib etc. minimum required versions to the current major release version. 

For scipy and numpy I semi-arbitrarily adjusted the to versions from sometime in 2019, not from any particular need but just a sense that we may not need to support arbitrarily old versions indefinitely. poppy 1.0 is a good time to update these minimums. 

