### PR TITLE
Don't use stsynphot, use plain synphot.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,7 +16,6 @@ except ImportError:
 
 PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
 PYTEST_HEADER_MODULES['synphot'] = 'synphot'
-PYTEST_HEADER_MODULES['stsynphot'] = 'stsynphot'
 
 TESTED_VERSIONS['poppy'] = __version__
 

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -111,7 +111,7 @@ The general notion of an :py:class:`~poppy.Instrument` is that it consists of bo
 
 1. An optical system implemented in the usual fashion, optionally with several configurations such as
    selectable image plane or pupil plane stops or other adjustable properties, and
-2. Some defined spectral bandpass(es) such as selectable filters. If the :py:mod:`stsynphot` module is available, it will be used to perform careful synthetic photometry of targets with a given spectrum observed in the given bandpass. If :py:mod:`stsynphot` is not installed, the code will fall back to a much simpler model assuming constant number of counts vs wavelength.
+2. Some defined spectral bandpass(es) such as selectable filters. If the :py:mod:`synphot` module is available, it will be used to perform careful synthetic photometry of targets with a given spectrum observed in the given bandpass. If :py:mod:`synphot` is not installed, the code will fall back to a much simpler model assuming constant number of counts vs wavelength.
 
 
 Configurable options such as optical masks and filters are specified as properties of the instrument instance; an appropriate :py:class:`~poppy.OpticalSystem` will be generated when the :py:meth:`~poppy.Instrument.calc_psf` method is called.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,15 +26,15 @@ Requirements
   <http://www.astropy.org>`__ community-developed core library for astronomy.
 
 
-The following are *optional*.  The first, :py:mod:`stsynphot`, is recommended
+The following are *optional*.  The first, :py:mod:`synphot`, is recommended
 for most users. The other optional installs are only worth adding for speed
 improvements if you are spending substantial time running calculations. See
 :ref:`the appendix on performance optimization <performance_and_parallelization>` for details.
 
-* `stsynphot <https://stsynphot.readthedocs.io>`_ enables the simulation
+* `synphot <https://synphot.readthedocs.io>`_ enables the simulation
   of PSFs with proper spectral response to realistic source spectra.  Without
   this, PSF fidelity is reduced. See below for :ref:`installation instructions
-  for stsynphot <stsynphot_install>`.
+  for synphot <synphot_install>`.
 * `psutil <https://pypi.python.org/pypi/psutil>`__ enables slightly better
   automatic selection of numbers of processes for multiprocess calculations.
 * `pyFFTW <https://pypi.python.org/pypi/pyFFTW>`__. The FFTW library can speed
@@ -53,19 +53,19 @@ improvements if you are spending substantial time running calculations. See
   These optionally can provide improved performance particularly in the
   Fresnel code.
 
-.. _stsynphot_install:
+.. _synphot_install:
 
-Installing or updating stsynphot
+Installing or updating synphot
 --------------------------------
 
-`stsynphot <https://stsynphot.readthedocs.io>`_ is an optional dependency, but is highly recommended.
-See the `stsynphot installation docs here <https://stsynphot.readthedocs.io/en/latest/#installation-and-setup>`_
-to install ``stsynphot`` and (at least some of) its TRDS data files.
+`synphot <https://synphot.readthedocs.io>`_ is an optional dependency, but is highly recommended.
+See the `synphot installation docs here <https://synphot.readthedocs.io/en/latest/#installation-and-setup>`_
+to install ``synphot`` and (even more optionally) some of its TRDS data files.
 
 *The minimum needed to have stellar spectral models available for use when
-creating PSFs is stsynphot itself plus just one of the TRDS data files: the Castelli & Kurucz stellar atlas, file*
+creating PSFs is synphot itself plus just one of the TRDS data files: the Castelli & Kurucz stellar atlas, file*
 `synphot3_castelli-kurucz-2004.tar <https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_castelli-kurucz-2004-atlas_multi_v1_synphot3.tar>`_ (18
-MB). Feel free to ignore the rest of the synphot TRDS files unless you know you want a larger set of
+MB). Feel free to ignore the rest of the many GB of synphot TRDS files unless you know you want a larger set of
 input spectra or need the reference files for other purposes.
 
 

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -11,13 +11,13 @@ import scipy.interpolate
 import scipy.ndimage
 
 try:
-    import stsynphot
+    import synphot
     from synphot import SourceSpectrum
 
-    _HAS_STSYNPHOT = True
+    _HAS_SYNPHOT = True
 except ImportError:
-    stsynphot = None
-    _HAS_STSYNPHOT = False
+    synphot = None
+    _HAS_SYNPHOT = False
 
 from . import poppy_core
 from . import optics
@@ -35,7 +35,7 @@ class Instrument(object):
     """ A generic astronomical instrument, composed of
         (1) an optical system implemented using POPPY, optionally with several configurations such as
             selectable image plane or pupil plane stops, and
-        (2) some defined spectral bandpass(es) such as selectable filters, implemented using stsynphot.
+        (2) some defined spectral bandpass(es) such as selectable filters, implemented using synphot.
 
     This provides the capability to model both the optical and spectral responses of a given system.
     PSFs may be calculated for given source
@@ -114,7 +114,7 @@ class Instrument(object):
         # wrapped just below to create properties with validation.
         self._filter = None
         self._rotation = None
-        # for caching stsynphot results.
+        # for caching synphot results.
         self._spectra_cache = {}
         self.filter = self.filter_list[0]
 
@@ -782,7 +782,7 @@ class Instrument(object):
         return self.filter, name, nlambda
 
     def _get_synphot_bandpass(self, filtername):
-        """ Return a stsynphot.spectrum.ObservationSpectralElement object for the given desired band.
+        """ Return a synphot.spectrum.SpectralElement object for the given desired band.
 
         By subclassing this, you can define whatever custom bandpasses are appropriate for your instrument
 
@@ -793,20 +793,16 @@ class Instrument(object):
 
         Returns
         --------
-        a stsynphot.spectrum.ObservationSpectralElement object for that filter.
+        a synphot.spectrum.ObservationSpectralElement object for that filter.
 
         """
-        if not _HAS_STSYNPHOT:
-            raise RuntimeError("stsynphot not found")
+        if not _HAS_SYNPHOT:
+            raise RuntimeError("synphot not found")
 
-        if filtername.lower().startswith('f'):
-            # attempt to treat it as an HST filter name?
-            bpname = ('wfc3,uvis1,{}'.format(filtername)).lower()
-        else:
-            bpname = self._synphot_bandpasses[filtername]
+        bpname = self._synphot_bandpasses[filtername]
 
         try:
-            band = stsynphot.band(bpname)
+            band = synphot.spectrum.SpectralElement.from_filter(bpname)
         except Exception:
             raise LookupError("Don't know how to compute bandpass for a filter named " + bpname)
 
@@ -821,30 +817,30 @@ class Instrument(object):
         return 5
 
     def _get_filter_list(self):
-        """ Returns a list of allowable filters, and the corresponding stsynphot obsmode
+        """ Returns a list of allowable filters, and the corresponding synphot obsmode
         for each.
 
-        If you need to define bandpasses that are not already available in stsynphot, consider subclassing
-        _getSynphotBandpass instead to create a stsynphot spectrum based on data read from disk, etc.
+        If you need to define bandpasses that are not already available in synphot, consider subclassing
+        _getSynphotBandpass instead to create a synphot spectrum based on data read from disk, etc.
 
         Returns
         --------
         filterlist : list
             List of string filter names
         bandpasslist : dict
-            dictionary of string names for use by stsynphot
+            dictionary of string names for use by synphot
 
         This could probably be folded into one using an OrderdDict. FIXME do that later
 
         """
 
-        filterlist = ['B', 'I', 'R', 'U', 'V']
+        filterlist = ['U', 'B', 'V', 'R', 'I']
         bandpasslist = {
-            'B': 'johnson,b',
-            'I': 'johnson,i',
-            'R': 'johnson,r',
-            'U': 'johnson,u',
-            'V': 'johnson,v',
+            'U': 'johnson_u',
+            'B': 'johnson_b',
+            'V': 'johnson_v',
+            'R': 'johnson_r',
+            'I': 'johnson_i',
         }
 
         return filterlist, bandpasslist
@@ -855,7 +851,7 @@ class Instrument(object):
         """ Return the set of discrete wavelengths, and weights for each wavelength,
         that should be used for a PSF calculation.
 
-        Uses stsynphot (if installed), otherwise assumes simple-minded flat spectrum
+        Uses synphot (if installed), otherwise assumes simple-minded flat spectrum
 
         """
         if nlambda is None or nlambda == 0:
@@ -865,7 +861,7 @@ class Instrument(object):
             poppy_core._log.info("Monochromatic calculation requested.")
             return (np.asarray([monochromatic]), np.asarray([1]))
 
-        elif _HAS_STSYNPHOT and (isinstance(source, SourceSpectrum) or source is None):
+        elif _HAS_SYNPHOT and (isinstance(source, SourceSpectrum) or source is None):
             """ Given a SourceSpectrum object, perform synthetic photometry for
             nlambda bins spanning the wavelength range of interest.
 
@@ -877,7 +873,7 @@ class Instrument(object):
             from synphot.models import Box1D, BlackBodyNorm1D, Empirical1D
 
             poppy_core._log.debug(
-                "Calculating spectral weights using stsynphot, nlambda=%d, source=%s" % (nlambda, str(source)))
+                "Calculating spectral weights using synphot, nlambda=%d, source=%s" % (nlambda, str(source)))
             if source is None:
                 source = SourceSpectrum(BlackBodyNorm1D, temperature=5700 * units.K)
                 poppy_core._log.info("No source spectrum supplied, therefore defaulting to 5700 K blackbody")
@@ -940,7 +936,7 @@ class Instrument(object):
 
             newsource = (wave_m, effstims.to_value())
             if verbose:
-                _log.info(" Wavelengths and weights computed from stsynphot: " + str(newsource))
+                _log.info(" Wavelengths and weights computed from synphot: " + str(newsource))
             self._spectra_cache[self._get_spec_cache_key(source, nlambda)] = newsource
             return newsource
         elif isinstance(source, dict) and ('wavelengths' in source) and ('weights' in source):
@@ -950,11 +946,11 @@ class Instrument(object):
             # Allow user to provide directly a tuple, as in poppy.calc_psf source option #3
             return source
 
-        else:  # Fallback simple code for if we don't have stsynphot.
+        else:  # Fallback simple code for if we don't have synphot.
             poppy_core._log.warning(
-                "stsynphot unavailable (or invalid source supplied)! Assuming flat # of counts versus wavelength.")
+                "synphot unavailable (or invalid source supplied)! Assuming flat # of counts versus wavelength.")
             # compute a source spectrum weighted by the desired filter curves.
-            # The existing FITS files all have wavelength in ANGSTROMS since that is the stsynphot convention...
+            # The existing FITS files all have wavelength in ANGSTROMS since that is the synphot convention...
             filterfile = self._filters[self.filter].filename
             filterheader = fits.getheader(filterfile, 1)
             filterdata = fits.getdata(filterfile, 1)
@@ -970,7 +966,7 @@ class Instrument(object):
                 if re.match(r'[Aa]ngstroms?', waveunit) is None:
                     raise ValueError(
                         "The supplied file, {0}, has WAVEUNIT='{1}'. Only WAVEUNIT = Angstrom supported " +
-                        "when stsynphot is not installed.".format(filterfile, waveunit))
+                        "when synphot is not installed.".format(filterfile, waveunit))
             else:
                 waveunit = 'Angstrom'
                 poppy_core._log.warning(

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -12,8 +12,6 @@ import scipy.ndimage
 
 try:
     import synphot
-    from synphot import SourceSpectrum
-
     _HAS_SYNPHOT = True
 except ImportError:
     synphot = None
@@ -861,21 +859,20 @@ class Instrument(object):
             poppy_core._log.info("Monochromatic calculation requested.")
             return (np.asarray([monochromatic]), np.asarray([1]))
 
-        elif _HAS_SYNPHOT and (isinstance(source, SourceSpectrum) or source is None):
-            """ Given a SourceSpectrum object, perform synthetic photometry for
+        elif _HAS_SYNPHOT and (isinstance(source, synphot.SourceSpectrum) or source is None):
+            """ Given a synphot.SourceSpectrum object, perform synthetic photometry for
             nlambda bins spanning the wavelength range of interest.
 
             Because this calculation is kind of slow, cache results for reuse in the frequent
             case where one is computing many PSFs for the same spectral source.
             """
-            import synphot
             from synphot import SpectralElement, Observation
             from synphot.models import Box1D, BlackBodyNorm1D, Empirical1D
 
             poppy_core._log.debug(
                 "Calculating spectral weights using synphot, nlambda=%d, source=%s" % (nlambda, str(source)))
             if source is None:
-                source = SourceSpectrum(BlackBodyNorm1D, temperature=5700 * units.K)
+                source = synphot.SourceSpectrum(BlackBodyNorm1D, temperature=5700 * units.K)
                 poppy_core._log.info("No source spectrum supplied, therefore defaulting to 5700 K blackbody")
             poppy_core._log.debug("Computing spectral weights for source = " + str(source))
 

--- a/poppy/tests/test_instrument.py
+++ b/poppy/tests/test_instrument.py
@@ -6,7 +6,7 @@ import pytest
 from astropy import units as u
 
 from poppy import poppy_core, instrument, optics, utils
-from poppy.instrument import _HAS_STSYNPHOT
+from poppy.instrument import _HAS_SYNPHOT
 
 WEIGHTS_DICT = {'wavelengths': [2.0e-6, 2.1e-6, 2.2e-6], 'weights': [0.3, 0.5, 0.2]}
 WAVELENGTHS_ARRAY = np.array(WEIGHTS_DICT['wavelengths'])
@@ -57,8 +57,8 @@ def test_instrument_source_weight_array(wavelengths=WAVELENGTHS_ARRAY, weights=W
 
     return psf
 
-@pytest.mark.skipif(not _HAS_STSYNPHOT, reason="stsynphot dependency not met")
-def test_instrument_source_stsynphot():
+@pytest.mark.skipif(not _HAS_SYNPHOT, reason="synphot dependency not met")
+def test_instrument_source_synphot():
     """
     Tests the ability to provide a source as a SourceSpectrum object
     """
@@ -75,22 +75,22 @@ def test_instrument_source_stsynphot():
     psf_weights_explicit = inst.calc_psf(source=(wavelengths, weights), fov_pixels=FOV_PIXELS,
                                         detector_oversample=2, fft_oversample=2, nlambda=5)
     bb = SourceSpectrum(BlackBodyNorm1D, temperature=5700 * u.K)
-    psf_weights_stsynphot = inst.calc_psf(source=bb, fov_pixels=FOV_PIXELS,
+    psf_weights_synphot = inst.calc_psf(source=bb, fov_pixels=FOV_PIXELS,
                                          detector_oversample=2, fft_oversample=2, nlambda=5)
-    assert psf_weights_stsynphot[0].header['NWAVES'] == len(wavelengths), \
+    assert psf_weights_synphot[0].header['NWAVES'] == len(wavelengths), \
         "Number of wavelengths in PSF header does not match number requested"
 
-    assert np.allclose(psf_weights_explicit[0].data, psf_weights_stsynphot[0].data,
-            rtol=1e-4), ( # Slightly larger tolerance to accomodate minor changes w/ stsynphot versions
-        "stsynphot multiwavelength PSF does not match the weights and wavelengths pre-computed for "
-        "a 5500 K blackbody in Johnson B (has stsynphot changed?)"
+    assert np.allclose(psf_weights_explicit[0].data, psf_weights_synphot[0].data,
+            rtol=1e-4), ( # Slightly larger tolerance to accomodate minor changes w/ synphot versions
+        "synphot multiwavelength PSF does not match the weights and wavelengths pre-computed for "
+        "a 5500 K blackbody in Johnson B (has synphot changed?)"
     )
-    return psf_weights_stsynphot
+    return psf_weights_synphot
 
-@pytest.mark.skipif(not _HAS_STSYNPHOT, reason="stsynphot dependency not met")
-def test_stsynphot_spectra_cache():
+@pytest.mark.skipif(not _HAS_SYNPHOT, reason="synphot dependency not met")
+def test_synphot_spectra_cache():
     """
-    The result of the stsynphot calculation is cached. This ensures the appropriate
+    The result of the synphot calculation is cached. This ensures the appropriate
     key appears in the cache after one calculation, and that subsequent calculations
     proceed without errors (exercising the cache lookup code).
     """

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -1465,7 +1465,7 @@ def specFromSpectralType(sptype, return_list=False, catalog=None):
         import os
         cdbs = os.getenv('PYSYN_CDBS')
         if cdbs is None:
-            raise EnvironmentError("Environment variable $PYSYN_CDBS must be defined for stsynphot")
+            raise EnvironmentError("Environment variable $PYSYN_CDBS must be defined for synphot")
         if os.path.exists(os.path.join(os.getenv('PYSYN_CDBS'), 'grid', 'phoenix')):
             catalog = 'phoenix'
         elif os.path.exists(os.path.join(os.getenv('PYSYN_CDBS'), 'grid', 'ck04models')):
@@ -1629,7 +1629,7 @@ def specFromSpectralType(sptype, return_list=False, catalog=None):
             return grid_to_spec(catname, keys[0], keys[1], keys[2])
         except IOError:
             errmsg = ("Could not find a match in catalog {0} for key {1}. Check that is a valid name in the " +
-                      "lookup table, and/or that stsynphot is installed properly.".format(catname, sptype))
+                      "lookup table, and/or that synphot is installed properly.".format(catname, sptype))
             _log.critical(errmsg)
             raise LookupError(errmsg)
 

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -1456,7 +1456,10 @@ def specFromSpectralType(sptype, return_list=False, catalog=None):
         otherwise, it's CK04.
 
     """
-    from stsynphot import grid_to_spec
+    try:
+        from stsynphot import grid_to_spec
+    except ImportError:
+        raise ImportError("Need stsynphot for this functionality")
     from synphot import SourceSpectrum
     from synphot import units as syn_u
     from synphot.models import ConstFlux1D, PowerLawFlux1D

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ setup_requires = setuptools_scm
 
 [options.extras_require]
 all =
-    stsynphot
+    synphot
 test =
     pytest
     pytest-astropy

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps=
     cov: pytest-cov
     cov: coverage
     cov: codecov
-    syn: stsynphot
+    syn: synphot
     legacy: numpy==1.17.*
     legacy: astropy==4.0.*
     latest: -rrequirements.txt


### PR DESCRIPTION
Swap to synphot instead of pysynphot for poppy, at basically no loss in functionality we care about. This avoids needing to download many GBs of unrelated reference data. 

The HST calibration spectral dataset is 4.25 GB. That's not acceptable to force as a required download on all users, given the diverse set of use cases for poppy which are in some cases completely unrelated to HST/JWST data. (e.g. optics lab technology work and cubesat optical modeling)