### PR TITLE
geometry.py np.arctan divide by zero warning 

### DIFF
--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -34,10 +34,11 @@ def _arc(x, y0, y1, r):
     is traversed clockwise then the area is negative, otherwise it is
     positive.
     """
-    if accel_math._USE_NUMEXPR:
-        return ne.evaluate("0.5 * r**2 * (arctan2(y1, x) - arctan2(y0, x))")
-    else:
-        return 0.5 * r**2 * (np.arctan2(y1, x) - np.arctan2(y0, x))
+    with np.errstate(divide='ignore'):
+        if accel_math._USE_NUMEXPR:
+            return ne.evaluate("0.5 * r**2 * (arctan(y1/x) - arctan(y0/x))")
+        else:
+            return 0.5 * r**2 * (np.arctan(y1/x) - np.arctan(y0/x))
 
 def _chord(x, y0, y1):
     """

--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -35,9 +35,9 @@ def _arc(x, y0, y1, r):
     positive.
     """
     if accel_math._USE_NUMEXPR:
-        return ne.evaluate("0.5 * r**2 * (arctan(y1/x) - arctan(y0/x))")
+        return ne.evaluate("0.5 * r**2 * (arctan2(y1/x) - arctan2(y0/x))")
     else:
-        return 0.5 * r**2 * (np.arctan(y1/x) - np.arctan(y0/x))
+        return 0.5 * r**2 * (np.arctan2(y1/x) - np.arctan2(y0/x))
 
 def _chord(x, y0, y1):
     """

--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -35,9 +35,9 @@ def _arc(x, y0, y1, r):
     positive.
     """
     if accel_math._USE_NUMEXPR:
-        return ne.evaluate("0.5 * r**2 * (arctan2(y1/x) - arctan2(y0/x))")
+        return ne.evaluate("0.5 * r**2 * (arctan2(y1, x) - arctan2(y0, x))")
     else:
-        return 0.5 * r**2 * (np.arctan2(y1/x) - np.arctan2(y0/x))
+        return 0.5 * r**2 * (np.arctan2(y1, x) - np.arctan2(y0, x))
 
 def _chord(x, y0, y1):
     """


### PR DESCRIPTION
closes #425 

~~Replaces `np.arctan` -> `np.arctan2` to handle divide by zero warnings.~~