### PR TITLE
minor: add missing import in one test function for optional displays 

### DIFF
--- a/poppy/tests/test_sign_conventions.py
+++ b/poppy/tests/test_sign_conventions.py
@@ -249,6 +249,7 @@ def test_segment_tilt_sign_and_direction(display=False):
     hexdm.set_actuator(2, 0, 0, 1 * u.arcsec)  # tilt
 
     if display:
+        import matplotlib.pyplot as plt
         hexdm.display(what='opd', colorbar_orientation='vertical', opd_vmax=2e-6)
         plt.figure(figsize=(14, 5))
         plt.suptitle("Segment tilt sign test (Fraunhofer propagation)", fontweight='bold')


### PR DESCRIPTION
Trivial one-line PR to fix a missing import, for a test function that has an optional `display` parameter and needs matplotlib if that's set. 

ci skip and no review needed since this is trivial. 