### PR TITLE
allow shifts of optics to be specified with astropy Quantities. 

### DIFF
--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -300,8 +300,11 @@ class AnalyticOpticalElement(OpticalElement):
         "shift_x", "shift_y", "rotation", "inclination_x", "inclination_y"
         If any of them are present, then the coordinates are modified accordingly.
 
-        Shifts are given in meters for pupil optics and arcseconds for image
-        optics. Rotations and inclinations are given in degrees.
+        Shifts are given by default implicitly in meters for pupil optics and arcseconds for image
+        plane optics. Shifts may optionally also be given with explicit units using Astropy Quantities,
+        which in this case must be convertable into meters or arcseconds as appropriate.
+
+        Rotations and inclinations are given implicitly in degrees.
 
         For multiple transformations, the order of operations is:
             shift, rotate, incline.
@@ -309,9 +312,19 @@ class AnalyticOpticalElement(OpticalElement):
 
         y, x = wave.coordinates()
         if hasattr(self, "shift_x"):
-            x -= float(self.shift_x)
+            if isinstance(self.shift_x, u.Quantity):
+                desired_unit = u.arcsecond if self.planetype==PlaneType.image else u.meter
+                shift_value = self.shift_x.to_value(desired_unit)
+                x -= float(shift_value)
+            else:
+                x -= float(self.shift_x)
         if hasattr(self, "shift_y"):
-            y -= float(self.shift_y)
+            if isinstance(self.shift_y, u.Quantity):
+                desired_unit = u.arcsecond if self.planetype == PlaneType.image else u.meter
+                shift_value = self.shift_y.to_value(desired_unit)
+                y -= float(shift_value)
+            else:
+                y -= float(self.shift_y)
         if hasattr(self, "rotation"):
             angle = np.deg2rad(self.rotation)
             xp = np.cos(angle) * x + np.sin(angle) * y

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -106,6 +106,12 @@ def test_shifting_optics( npix=30,  grid_size = 3, display=False):
         plt.imshow(circ_samp-circ_shift_samp)
     assert np.allclose(circ_samp, circ_shift_samp) is False, "Shift didn't change array"
 
+    # create shifted version, using explicit units rather than implicitly in meters.
+    # Verify that gives the same result as without explicit units
+    circ_shift_via_units = poppy.CircularAperture( shift_x=shift_size*1000*u.millimeter)
+    circ_shift_via_units_samp = circ_shift_via_units.sample(npix=npix, grid_size=grid_size)
+    assert np.allclose(circ_shift_samp, circ_shift_via_units_samp), "Shift with value as Quantity didn't give same result as shift with value as bare float in meters"
+
     # Make a FITS element.
     circ_fits = circ.to_fits(npix=npix, grid_size=grid_size)
 


### PR DESCRIPTION
Fixes #387, allowing use of Quantities when shifting optics. This works now: 
```
ap1 = poppy.RectangleAperture(width=50*u.micron, height=300*u.micron, shift_x = 100*u.micron)
ap1.display()
```
