### PR TITLE
improve unit tests for Kolmogorov WFE

### DIFF
--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -683,7 +683,7 @@ class KolmogorovWFE(WavefrontError):
         opd_FFT = dq*a*np.sqrt(2.0*np.pi*self.dz*phi)
         opd = npix**2*np.fft.ifft2(opd_FFT)
         
-        self.opd = opd.real.value
+        self.opd = np.real(opd)
         
         return self.opd
     


### PR DESCRIPTION
Improvements to the unit tests for the Kolmogorov WFE class, to fix two practical issues. (This isn't a high priority right now in itself, but I am trying to make the whole test suite more robust): 

1. use a fixed seed for random number reproducibility. This fixes an issue in which, intermittently, the random number generator apparently produced a WFE instance which didn't quite meet the requirements. This resulted in rare failures for the CI tests. Making this a fixed seed for the RandomState ensures test repeatability. 
2. 10x reduced test runtime for an ensemble statistics test, `test_KolmogorovWFE_correlation`, which previously took 40% of the total runtime for the entire poppy test suite (~ 100 s out of 250 s total!). This is disproportionate for a single test of one part of functionality. This was reduced to ~10 s by dropping to a smaller number of wavefronts in the ensemble (800 vs 2000 before) and reducing the size of the WFE in spatial sampling (32 pixels vs 64 pixels before). Using smaller values than those resulted in the test not passing, presumably because of averaging over an insufficient number of statistical instances. 
3. Also, ensure the `test_KolmogorovWFE.test_get_opd` function actually gets ran and tested. Previously it was defined but not actually called. And then make that test pass in all instances of the test matrix. 