### PR TITLE
Fix failures in CI

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -61,7 +61,14 @@ jobs:
     - name: Check conda info
       run: conda info
 
+    - name: Run tests with requirements file
+      if: ${{ contains(matrix.toxenv,'-latest') }}
+      run: |
+        cp $RUNNER_WORKSPACE/poppy/requirements.txt /tmp/
+        tox -e ${{ matrix.toxenv }}
+
     - name: Run tests
+      if: ${{ contains(matrix.toxenv,'-latest') != true }}
       run: tox -e ${{ matrix.toxenv }}
 
     - name: Upload coverage to codecov


### PR DESCRIPTION
This PR fixes the failing latest dependencies check that can be seen in #455. The failure seems to come from github actions now looking for the requirements.txt file in the tmp directory rather than the repository. I don't know where this change came from, but I fixed it by copying over the requirements file to the tmp directory first, and now the CI finds the file.