### PR TITLE
Allow for non-integer oversampling in Fresnel propagation

### DIFF
--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -333,7 +333,7 @@ class FresnelWavefront(BaseWavefront):
         if self.oversample > 1 and not self.ispadded:  # add padding for oversampling, if necessary
             self.wavefront = utils.pad_to_oversample(self.wavefront, self.oversample)
             self.ispadded = True
-            logmsg = "Padded WF array for oversampling by {0:d}, to {1}.".format(
+            logmsg = "Padded WF array for oversampling by {0:.3f}, to {1}.".format(
                 self.oversample,
                 self.wavefront.shape
             )

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1261,7 +1261,7 @@ class FresnelOpticalSystem(BaseOpticalSystem):
             A wavefront appropriate for passing through this optical system.
 
         """
-        oversample = int(np.round(1 / self.beam_ratio))
+        oversample = 1 / self.beam_ratio
         if inwave is None:
             inwave = FresnelWavefront(self.pupil_diameter / 2, wavelength=wavelength,
                                       npix=self.npix, oversample=oversample)

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -884,3 +884,64 @@ def test_FixedSamplingImagePlaneElement(display=False):
                                err_msg="PSF pixelscale of this test does not match the saved result.", verbose=True)
     
 
+def test_fresnel_noninteger_oversampling(display_intermediates=False):
+    '''Test for noninteger oversampling for basic FresnelOpticalSystem() using HST example system'''
+    lambda_m = 0.5e-6 * u.m
+    diam = 2.4 * u.m
+    fl_pri = 5.52085 * u.m
+    d_pri_sec = 4.907028205 * u.m
+    fl_sec = -0.6790325 * u.m
+    d_sec_to_focus = 6.3919974 * u.m
+
+    m1 = poppy.QuadraticLens(fl_pri, name='Primary')
+    m2 = poppy.QuadraticLens(fl_sec, name='Secondary')
+    
+    npix = 128
+
+    oversample1 = 2
+    hst1 = poppy.FresnelOpticalSystem(pupil_diameter=diam, npix=npix, beam_ratio=1 / oversample1)
+    hst1.add_optic(poppy.CircularAperture(radius=diam.value / 2))
+    hst1.add_optic(poppy.SecondaryObscuration(secondary_radius=0.396,
+                                             support_width=0.0264,
+                                             support_angle_offset=45.0))
+    hst1.add_optic(m1)
+    hst1.add_optic(m2, distance=d_pri_sec)
+    hst1.add_optic(poppy.ScalarTransmission(planetype=poppy_core.PlaneType.intermediate, name='focus'), distance=d_sec_to_focus)
+
+    if display_intermediates: plt.figure(figsize=(12, 8))
+    psf1 = hst1.calc_psf(wavelength=lambda_m, display_intermediates=display_intermediates)
+
+    # now test the second system which has a different oversampling factor
+    oversample2 = 2.0
+    hst2 = poppy.FresnelOpticalSystem(pupil_diameter=diam, npix=npix, beam_ratio=1 / oversample2)
+    hst2.add_optic(poppy.CircularAperture(radius=diam.value / 2))
+    hst2.add_optic(poppy.SecondaryObscuration(secondary_radius=0.396,
+                                             support_width=0.0264,
+                                             support_angle_offset=45.0))
+    hst2.add_optic(m1)
+    hst2.add_optic(m2, distance=d_pri_sec)
+    hst2.add_optic(poppy.ScalarTransmission(planetype=poppy_core.PlaneType.intermediate, name='focus'), distance=d_sec_to_focus)
+    
+    if display_intermediates: plt.figure(figsize=(12, 8))
+    psf2 = hst2.calc_psf(wavelength=lambda_m, display_intermediates=display_intermediates)
+
+    # Now test a 3rd HST system with oversample of 2.5 and compare to hardcoded result
+    oversample3=2.5
+    hst3 = poppy.FresnelOpticalSystem(pupil_diameter=diam, npix=npix, beam_ratio=1 / oversample3)
+    hst3.add_optic(poppy.CircularAperture(radius=diam.value / 2))
+    hst3.add_optic(poppy.SecondaryObscuration(secondary_radius=0.396,
+                                             support_width=0.0264,
+                                             support_angle_offset=45.0))
+    hst3.add_optic(m1)
+    hst3.add_optic(m2, distance=d_pri_sec)
+    hst3.add_optic(poppy.ScalarTransmission(planetype=poppy_core.PlaneType.intermediate, name='focus'), distance=d_sec_to_focus)
+
+    if display_intermediates: plt.figure(figsize=(12, 8))
+    psf3 = hst3.calc_psf(wavelength=lambda_m, display_intermediates=display_intermediates)
+
+    assert np.allclose(psf1[0].data, psf2[0].data), 'PSFs with oversampling 2 and 2.0 are surprisingly different.'
+    np.testing.assert_almost_equal(psf3[0].header['PIXELSCL'], 4.790671212696879e-06, decimal=7, 
+                                   err_msg='pixelscale for the PSF with oversample of 2.5 is surprisingly different from expected result.')
+
+
+

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -887,6 +887,7 @@ def test_FixedSamplingImagePlaneElement(display=False):
 def test_fresnel_noninteger_oversampling(display_intermediates=False):
     '''Test for noninteger oversampling for basic FresnelOpticalSystem() using HST example system'''
     lambda_m = 0.5e-6 * u.m
+    # lambda_m = np.linspace(0.475e-6, 0.525e-6, 3) * u.m
     diam = 2.4 * u.m
     fl_pri = 5.52085 * u.m
     d_pri_sec = 4.907028205 * u.m
@@ -895,7 +896,8 @@ def test_fresnel_noninteger_oversampling(display_intermediates=False):
 
     m1 = poppy.QuadraticLens(fl_pri, name='Primary')
     m2 = poppy.QuadraticLens(fl_sec, name='Secondary')
-    
+    image_plane = poppy.ScalarTransmission(planetype=poppy_core.PlaneType.image, name='focus')
+
     npix = 128
 
     oversample1 = 2
@@ -906,7 +908,7 @@ def test_fresnel_noninteger_oversampling(display_intermediates=False):
                                              support_angle_offset=45.0))
     hst1.add_optic(m1)
     hst1.add_optic(m2, distance=d_pri_sec)
-    hst1.add_optic(poppy.ScalarTransmission(planetype=poppy_core.PlaneType.intermediate, name='focus'), distance=d_sec_to_focus)
+    hst1.add_optic(image_plane, distance=d_sec_to_focus)
 
     if display_intermediates: plt.figure(figsize=(12, 8))
     psf1 = hst1.calc_psf(wavelength=lambda_m, display_intermediates=display_intermediates)
@@ -920,7 +922,7 @@ def test_fresnel_noninteger_oversampling(display_intermediates=False):
                                              support_angle_offset=45.0))
     hst2.add_optic(m1)
     hst2.add_optic(m2, distance=d_pri_sec)
-    hst2.add_optic(poppy.ScalarTransmission(planetype=poppy_core.PlaneType.intermediate, name='focus'), distance=d_sec_to_focus)
+    hst2.add_optic(image_plane, distance=d_sec_to_focus)
     
     if display_intermediates: plt.figure(figsize=(12, 8))
     psf2 = hst2.calc_psf(wavelength=lambda_m, display_intermediates=display_intermediates)
@@ -934,14 +936,12 @@ def test_fresnel_noninteger_oversampling(display_intermediates=False):
                                              support_angle_offset=45.0))
     hst3.add_optic(m1)
     hst3.add_optic(m2, distance=d_pri_sec)
-    hst3.add_optic(poppy.ScalarTransmission(planetype=poppy_core.PlaneType.intermediate, name='focus'), distance=d_sec_to_focus)
+    hst3.add_optic(image_plane, distance=d_sec_to_focus)
 
     if display_intermediates: plt.figure(figsize=(12, 8))
     psf3 = hst3.calc_psf(wavelength=lambda_m, display_intermediates=display_intermediates)
 
     assert np.allclose(psf1[0].data, psf2[0].data), 'PSFs with oversampling 2 and 2.0 are surprisingly different.'
-    np.testing.assert_almost_equal(psf3[0].header['PIXELSCL'], 4.790671212696879e-06, decimal=7, 
+    np.testing.assert_almost_equal(psf3[0].header['PIXELSCL'], 0.017188733797782272, decimal=7, 
                                    err_msg='pixelscale for the PSF with oversample of 2.5 is surprisingly different from expected result.')
-
-
 

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -1088,7 +1088,8 @@ def pad_to_oversample(array, oversample):
     padToSize
     """
     npix = array.shape[0]
-    padded = np.zeros(shape=(npix * oversample, npix * oversample), dtype=array.dtype)
+    n = int(np.round(npix * oversample))
+    padded = np.zeros(shape=(n, n), dtype=array.dtype)
     n0 = float(npix) * (oversample - 1) / 2
     n1 = n0 + npix
     n0 = int(round(n0))  # because astropy test_plugins enforces integer indices


### PR DESCRIPTION
This PR contains changes in just a couple of lines of code that allow for non-integer oversampling to be utilized in Fresnel propagation. One line is in fresnel.py, and it is a simple change to the log message for what the array size has been padded to. The change allows for floats to be printed in the message. The other line is in utils.py in the pad_to_oversample function. It determines the array size that the padded array should be initialized to by taking the values of npix and oversample and then using np.round and int to form the array size value that can be given to np.zeros. 

On my personal machine, the code ran fine and passed all the expected tests. The built in Fresnel propagator seems to produce accurate results and calculate the correct pixelscales for the FresnelWavefronts generated. This has been found empirically by comparing wavefronts generated by poppy and wavefronts of the same systems generated by proper. 

@douglase was also involved in this PR. 