### PR TITLE
enable shifts of Fresnel ideal quadratic lens 

### DIFF
--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -60,7 +60,7 @@ class QuadPhase(poppy.optics.AnalyticOpticalElement):
             a Fresnel Wavefront object
         """
 
-        y, x = wave.coordinates()
+        y, x = self.get_coordinates(wave)
         _log.debug("Applying spherical phase curvature ={0:0.2e}".format(self.z))
         _log.debug("Applying spherical lens phase ={0:0.2e}".format(1.0 / self.z))
         z = self._z_m  # numexpr can't evaluate self.


### PR DESCRIPTION
Bug fix: Enable QuadraticLens to be shifted using shift_x or shift_y parameters, consistent with any other analytic optical element.


This sort of shift does not work before this fix, does work after it's fixed:
```
mirror = poppy.fresnel.QuadraticLens(f_lens=800*u.cm, shift_x=5*u.cm)
mirror.display(what='opd', opd_vmax=1e-3, grid_size=20*u.cm)

```
![Unknown-2](https://user-images.githubusercontent.com/1151745/141836682-4e81f53f-5c9d-4afe-bf17-3e595f624c3d.png)

