### PR TITLE
API update: rename Zernike functions (no change in functionality, just name update, with back compatibility)

### DIFF
--- a/docs/wfe.rst
+++ b/docs/wfe.rst
@@ -256,11 +256,15 @@ desired in the basis, as well as the desired sampling (how many pixels across ea
 Using any of the above basis functions, OPD arrays can be decomposed into coefficients per each term, or conversely
 OPD arrays can be generated from provided coefficients. There are several functions provided for OPD decomposition, tuned for different usage scenarios.
 
- * :func:`poppy.zernike.opd_from_zernikes` generates an OPD from providend coefficients. Despite the name this function can actually be used with any of the above basis sets.
- * :func:`poppy.zernike.opd_expand` projects a given OPD into a Zernike or Hexike basis, and returns the resulting coefficients. This works best when dealing with cases closer to ideal, i.e. Zernikes over an actually-circular aperture.
- * :func:`poppy.zernike.opd_expand_nonorthonormal` does the same, but uses an alternate iterative algorithm that works better when dealing with basis sets that are not strictly orthonormal over the given aperture.
- * :func:`poppy.zernike.opd_expand_segments` uses the same iterative algorithm but with some adjustments to better handle spatially disjoint basis elements such as different segments. Use this for best results if you're dealing with a segmented aperture.
+ * :func:`poppy.zernike.compose_opd_from_basis` generates an OPD from providend coefficients for any of the above basis sets.
+ * :func:`poppy.zernike.decompose_opd` projects a given OPD into a basis, and returns the resulting coefficients. This version of the function works best when dealing with cases closer to ideal, i.e. Zernikes over an actually-circular aperture.
+ * :func:`poppy.zernike.decompose_opd_nonorthonormal_basis` does the same, but uses an alternate iterative algorithm that works better when dealing with basis sets that are not strictly orthonormal over the given aperture.
+ * :func:`poppy.zernike.decompose_opd_segments` uses a similar iterative algorithm but with some adjustments to better handle spatially disjoint basis elements such as different segments. Use this for best results if you're dealing with a segmented aperture.
 
+
+.. note::
+  The names of the above functions changed in poppy version 1.0. The previous names are retained for back compatibility, but will be deprecated in a future version.
+  The original names of these functions are respectively `opd_from_zernikes`, `opd_expand`, `opd_expand_nonorthonormal`, and `opd_expand_segments`.
 
 
 .. rubric:: Footnotes

--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -205,7 +205,7 @@ def test_cross_arbitrary_basis():
         _test_cross_arbitrary_basis(testj=testj, nterms=6)
 
 
-def test_opd_expand(npix=512, input_coefficients=(0.1, 0.2, 0.3, 0.4, 0.5)):
+def test_decompose_opd(npix=512, input_coefficients=(0.1, 0.2, 0.3, 0.4, 0.5)):
     basis = zernike.zernike_basis(nterms=len(input_coefficients), npix=npix)
     for idx, coeff in enumerate(input_coefficients):
         basis[idx] *= coeff
@@ -227,7 +227,7 @@ def test_opd_expand(npix=512, input_coefficients=(0.1, 0.2, 0.3, 0.4, 0.5)):
     assert max_diff_v2 < 1e-3, "recovered coefficients from wf_expand more than 0.1% off"
 
 
-def test_opd_from_zernikes():
+def test_compose_opd_from_basis():
     coeffs = [0,0.1, 0.4, 2, -0.3]
     opd = zernike.compose_opd_from_basis(coeffs, npix=256)
 

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -38,7 +38,8 @@ from functools import lru_cache
 
 __all__ = [
     'R', 'cached_zernike1', 'hex_aperture', 'hexike_basis', 'noll_indices',
-    'opd_expand', 'opd_expand_nonorthonormal', 'opd_expand_segments', 'opd_from_zernikes',
+    'decompose_opd', 'decompose_opd_nonorthonormal_basis', 'decompose_opd_segments', 'compose_opd_from_basis',
+    'opd_expand', 'opd_expand_nonorthonormal', 'opd_expand_segments', 'opd_from_zernikes', # back compatibility aliases
     'str_zernike', 'zern_name', 'zernike', 'zernike1', 'zernike_basis',
     'Segment_Piston_Basis','Segment_PTT_Basis', 'arbitrary_basis'
 ]
@@ -618,6 +619,12 @@ def hexike_basis_wss(nterms=9, npix=512, rho=None, theta=None,
     This function has an attributed hexike_basis_wss.label_strings for
     convenient use in plot labeling.
 
+    Historical note on ordering: The reordering here relative to the more typical
+    ordering of Zernikes is motivated by moving spherical to position 9, and using
+    just the first 8 for JWST. This is because focus and spherical are not orthogonal
+    when in hexike versions on the JWST aperture, so "spherical was booted out of the picture"
+
+
 
     Parameters
     ----------
@@ -941,8 +948,8 @@ class Segment_Piston_Basis(Segment_PTT_Basis):
         return basis[0:nterms]
 
 
-def opd_expand(opd, aperture=None, nterms=15, basis=zernike_basis,
-               **kwargs):
+def decompose_opd(opd, aperture=None, nterms=15, basis=zernike_basis,
+                  **kwargs):
     """Given a wavefront OPD map, return the list of coefficients in a
     given basis set (by default, Zernikes) that best fit the OPD map.
 
@@ -1016,8 +1023,8 @@ def opd_expand(opd, aperture=None, nterms=15, basis=zernike_basis,
     return coeffs
 
 
-def opd_expand_nonorthonormal(opd, aperture=None, nterms=15, basis=zernike_basis_faster,
-                              iterations=5, verbose=False, **kwargs):
+def decompose_opd_nonorthonormal_basis(opd, aperture=None, nterms=15, basis=zernike_basis_faster,
+                                       iterations=5, verbose=False, **kwargs):
     """ Modified version of opd_expand, for cases where the basis function is
     *not* orthonormal, for instance using the regular Zernike functions on
     obscured apertures.
@@ -1098,8 +1105,8 @@ def opd_expand_nonorthonormal(opd, aperture=None, nterms=15, basis=zernike_basis
     return coeffs
 
 
-def opd_from_zernikes(coeffs, basis=zernike_basis_faster, aperture=None, outside=np.nan,
-                      **kwargs):
+def compose_opd_from_basis(coeffs, basis=zernike_basis_faster, aperture=None, outside=np.nan,
+                           **kwargs):
     """ Synthesize an OPD from a set of coefficients
 
     Parameters
@@ -1170,8 +1177,8 @@ def opd_from_zernikes(coeffs, basis=zernike_basis_faster, aperture=None, outside
     return output
 
 
-def opd_expand_segments(opd, aperture=None, nterms=15, basis=None,
-                              iterations=2, verbose=False, ignore_border=None, **kwargs):
+def decompose_opd_segments(opd, aperture=None, nterms=15, basis=None,
+                           iterations=2, verbose=False, ignore_border=None, **kwargs):
     """
     Expand OPD into a basis defined by segments, typically with piston, tip, & tilt of each.
 
@@ -1270,3 +1277,9 @@ def opd_expand_segments(opd, aperture=None, nterms=15, basis=None,
         if verbose:
             print("Iteration {}/{}: {}".format(count, iterations, coeffs))
     return coeffs
+
+# Back compatibility aliases, for the names in poppy pre 1.0:
+opd_expand = decompose_opd
+opd_expand_nonorthonormal = decompose_opd_nonorthonormal_basis
+opd_expand_segments = decompose_opd_segments
+opd_from_zernikes = compose_opd_from_basis

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -835,7 +835,7 @@ class Segment_PTT_Basis(object):
         the MultiHexagonAperture class. Set that when creating
         an instance of this class, then you can call the resulting function object
         to generate a basis set with the desired sampling, or pass it to
-        the opd_from_zernikes or opd_expand_segments functions.
+        the compse_opd_from_basis or decompse_opd_segments functions.
 
         The basis is generated over a square array that exactly circumscribes
         the hexagonal aperture.
@@ -955,8 +955,8 @@ def decompose_opd(opd, aperture=None, nterms=15, basis=zernike_basis,
 
     Note that this implementation of the function treats the Zernikes as
     an orthonormal basis, which is only true on the unobscured unit circle.
-    See also `opd_expand_nonorthonormal` for an alternative approach for
-    basis vectors that are not orthonormal, or `opd_expand_segments` for
+    See also `decompose_opd_nonorthonormal` for an alternative approach for
+    basis vectors that are not orthonormal, or `decompose_opd_segments` for
     basis vectors defined over physically disjoint segments.
 
     Parameters
@@ -986,7 +986,7 @@ def decompose_opd(opd, aperture=None, nterms=15, basis=zernike_basis,
     Note: Recovering coefficients used to generate synthetic/test data
     depends greatly on the sampling (as one might expect). Generating
     test data using zernike_basis with npix=256 and passing the result
-    through opd_expand reproduces the input coefficients within <0.1%.
+    through decompose_opd reproduces the input coefficients within <0.1%.
 
     Returns
     -------
@@ -1025,7 +1025,7 @@ def decompose_opd(opd, aperture=None, nterms=15, basis=zernike_basis,
 
 def decompose_opd_nonorthonormal_basis(opd, aperture=None, nterms=15, basis=zernike_basis_faster,
                                        iterations=5, verbose=False, **kwargs):
-    """ Modified version of opd_expand, for cases where the basis function is
+    """ Modified version of decompose_opd, for cases where the basis function is
     *not* orthonormal, for instance using the regular Zernike functions on
     obscured apertures.
 
@@ -1132,7 +1132,7 @@ def compose_opd_from_basis(coeffs, basis=zernike_basis_faster, aperture=None, ou
 
     Example
     --------
-    opd = opd_from_zernikes([0,0,-5,1,0,4,0,8], npix=512)
+    opd = compose_opd_from_basis([0,0,-5,1,0,4,0,8], npix=512)
 
     """
 
@@ -1182,7 +1182,7 @@ def decompose_opd_segments(opd, aperture=None, nterms=15, basis=None,
     """
     Expand OPD into a basis defined by segments, typically with piston, tip, & tilt of each.
 
-    Similar algorithm as opd_expand_nonorthonormal, but adjusted slightly for
+    Similar algorithm as decompose_opd_nonorthonormal, but adjusted slightly for
     spatially disjoint basis vectors, and also for different expected normalization
     of the piston and tip/tilt basis terms.
 


### PR DESCRIPTION
A 1.0 release is a good time to update the API, so I want to take the opportunity to improve slightly a part of the API that's bugged me for a while. This PR introduces new names for the various Zernike composition/decomposition functions, for better consistency with typical usage. 

* `opd_expand` -> `decompose_opd`. This is consistent with typical usage (and the vocabulary used with the JWST WSS for instance) about phase decomposition.  
* `opd_from_zernikes` -> `compose_opd_from_basis`. This name makes it clearer this is an inverse function to the decomposition, and also it fixes the not-ideal situation of having "zernikes" baked into the function name when instead that function can be used with hexikes or any other arbitrary basis, not just Zernikes. 

The existing names are retained as back-compatible aliases, so no changes are needed in existing code. Both the old and new names will work interchangeably. 