### PR TITLE
update minimum vers of dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,9 @@ max-line-length = 120
 zip_safe = False
 packages = find:
 install_requires =
-    numpy>=1.17.0
-    scipy>=1.4.0
-    matplotlib>=3.0.0
+    numpy>=1.18.0
+    scipy>=1.5.0
+    matplotlib>=3.2.0
     astropy>=4.0.0
 python_requires = >=3.7
 setup_requires = setuptools_scm

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps=
     cov: coverage
     cov: codecov
     syn: synphot
-    legacy: numpy==1.17.*
+    legacy: numpy==1.18.*
     legacy: astropy==4.0.*
     latest: -rrequirements.txt
     astropydev: git+git://github.com/astropy/astropy


### PR DESCRIPTION
Update numpy, scipy, matplotlib minimum dependencies to versions as of mid 2020.

Like PR https://github.com/spacetelescope/poppy/pull/415, but it's been 9 months since that so we might as well freshen up again prior to 1.0 release. 