### PR TITLE
Add long description to setup.cfg file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = poppy
 description = Physical optics propagation (wavefront diffraction) for optical simulations, particularly of telescopes.
-long_description = (this placeholder string will be replaced automatically with poppy's top-level docstring.)
+long_description = "POPPY (**P**\ hysical **O**\ ptics **P**\ ropagation in **Py**\ thon) is a Python package that simulates physical optical propagation including diffraction. It implements a flexible framework for modeling Fraunhofer and Fresnel diffraction and point spread function formation, particularly in the context of astronomical telescopes."
 author = Marshall Perrin
 author_email = mperrin@stsci.edu
 license = BSD


### PR DESCRIPTION
Adding the first line of the README to the `long_description` part of the setup.cfg file. 