### PR TITLE
Fixes for failures when using astropy develop.

### DIFF
--- a/poppy/tests/test_multiprocessing.py
+++ b/poppy/tests/test_multiprocessing.py
@@ -10,7 +10,6 @@ import astropy
 import astropy.io.fits as fits
 import sys
 from distutils.version import LooseVersion
-from astropy.tests.helper import remote_data
 
 try:
     import pytest

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -1340,7 +1340,7 @@ class BackCompatibleQuantityInput(object):
         self.decorator_kwargs = kwargs
 
     def __call__(self, wrapped_function):
-        from astropy.utils.decorators import wraps
+        from functools import wraps
         from astropy.units import UnitsError, add_enabled_equivalencies, Quantity
         import inspect
 


### PR DESCRIPTION
Currently, `poppy` is causing failures in the `jwst` development dependencies CI. These failures are due to a change in the some of the APIs in `astropy` introduced by the merger of PR astropy/astropy#12633. This PR resolves these issues, allowing `poppy` to properly work with the current state of the `astropy` develop branch.