### PR TITLE
Fix failing rotation test from numpy 1.22

### DIFF
--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -329,8 +329,8 @@ class AnalyticOpticalElement(OpticalElement):
             angle = np.deg2rad(self.rotation)
             xp = np.cos(angle) * x + np.sin(angle) * y
             yp = -np.sin(angle) * x + np.cos(angle) * y
-            x = np.trunc(xp * 1e9) / 1e9  # handle vectorization of numpy umath that lowers precision
-            y = np.trunc(yp * 1e9) / 1e9
+            x = xp
+            y = yp
         # inclination around X axis rescales Y, and vice versa:
         if hasattr(self, "inclination_x"):
             y /= np.cos(np.deg2rad(self.inclination_x))

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -329,8 +329,8 @@ class AnalyticOpticalElement(OpticalElement):
             angle = np.deg2rad(self.rotation)
             xp = np.cos(angle) * x + np.sin(angle) * y
             yp = -np.sin(angle) * x + np.cos(angle) * y
-            x = xp
-            y = yp
+            x = np.trunc(xp * 1e9) / 1e9  # handle vectorization of numpy umath that lowers precision
+            y = np.trunc(yp * 1e9) / 1e9
         # inclination around X axis rescales Y, and vice versa:
         if hasattr(self, "inclination_x"):
             y /= np.cos(np.deg2rad(self.inclination_x))

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -271,8 +271,8 @@ def test_rotations():
     # Some simple tests of the rotation code on AnalyticOpticalElements. Incomplete!
 
     # rotating a square by +45 and -45 should give the same result
-    ar1 = optics.SquareAperture(rotation=45, size=np.sqrt(2)).sample(npix=256, grid_size=2)
-    ar2 = optics.SquareAperture(rotation=-45, size=np.sqrt(2)).sample(npix=256, grid_size=2)
+    ar1 = optics.SquareAperture(rotation=45, size=np.sqrt(2)).sample(npix=255, grid_size=2)
+    ar2 = optics.SquareAperture(rotation=-45, size=np.sqrt(2)).sample(npix=255, grid_size=2)
     assert np.allclose(ar1,ar2)
 
     # rotating a rectangle with flipped side lengths by 90 degrees should give the same result


### PR DESCRIPTION
This PR fixes a test that is failing for newer versions of numpy (>= 1.22). In the newest numpy, they have changes in the umath functions to speed them up, but as part of that change, they have also decreased precision. This is not a problem for most of our tests, because the decreased precision is still within the tolerance, but this test works differently.

The test_rotations() test rotates the optical element by -45 and 45 degrees and compares the results. Inside this code, the AnalyticOpticalElement objects use np.sin() and np.cos() to do this rotation, and then does a comparison on the output values and uses that to set the array to 1s or 0s. So that slight precision change in the x and y values leads to a number being miss-set as 1 or 0. So it is a tolerance problem.

We fixed this by changing the test's sampling to 255 in order to avoid the precision being a problem. 