### PR TITLE
Correct zernike.py factorial() calls to ensure internal values are integers

### DIFF
--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -420,7 +420,7 @@ def zernike_basis_faster(nterms=15, npix=512, outside=np.nan):
         else:
             for k in range(int((n - m) / 2) + 1):
                 coef = ((-1) ** k * factorial(n - k) /
-                        (factorial(k) * factorial((n + m) / 2. - k) * factorial((n - m) / 2. - k)))
+                        (factorial(k) * factorial(int((n + m) / 2) - k) * factorial(int((n - m) / 2) - k)))
                 output += coef * rho ** (n - 2 * k)
             return output
 


### PR DESCRIPTION
Fix typing of values within factorial() calls to ensure they are integers. Prevents the following error with python 3.10 (also mentioned in issue #483):

```
  File "/Users/acarter/anaconda3/envs/coro_pipeline/lib/python3.10/site-packages/poppy/zernike.py", line 424, in cached_R
    (factorial(k) * factorial((n + m) / 2. - k) * factorial((n - m) / 2. - k)))
TypeError: 'float' object cannot be interpreted as an integer
```