### PR TITLE
Add jupyter as a dependency for docbuild with nbsphinx

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ deps=
     sphinx-issues
     sphinx-astropy
     nbsphinx
+    jupyter
 conda_deps=
     scipy
     matplotlib


### PR DESCRIPTION
Sometime in the last 10 days, the doc building test started failing here and on webbpsf with `Extension error: Could not import extension nbsphinx (exception: No module named 'ipython_genutils')`.

This is fixed by adding `jupyter` as a dependency for the testing suite