### PR TITLE
Fix Failing CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps=
     legacy: numpy==1.18.*
     legacy: astropy==4.0.*
     latest: -rrequirements.txt
-    astropydev: git+git://github.com/astropy/astropy
+    astropydev: git+https://github.com/astropy/astropy
     numexpr: numexpr>=2.0.0
 conda_deps=
     mkl: mkl_fft


### PR DESCRIPTION
The Astropy Development CI test was failing because there was and issue with our installation command, so I've updated that in the tox.ini file.