### PR TITLE
Remove python 3.7 and add python 3.10

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,7 +16,7 @@ jobs:
 
           - name: Coverage test in Python 3
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-syn-cov
 
           - name: Check for Sphinx doc build errors
@@ -36,7 +36,7 @@ jobs:
 
           - name: Try latest versions of all dependencies
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-latest-test
 
           - name: Try minimum supported versions

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,33 +16,33 @@ jobs:
 
           - name: Coverage test in Python 3
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-syn-cov
+            python: 3.10
+            toxenv: py310-syn-cov
 
           - name: Check for Sphinx doc build errors
             os: ubuntu-latest
-            python: 3.8
+            python: 3.9
             toxenv: docbuild
 
           - name: Check accelerated math version
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-numexpr-mkl-cov
+            python: 3.9
+            toxenv: py39-numexpr-mkl-cov
 
           - name: Try Astropy development version
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-astropydev-test
+            python: 3.9
+            toxenv: py39-astropydev-test
 
           - name: Try latest versions of all dependencies
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-latest-test
+            python: 3.10
+            toxenv: py310-latest-test
 
           - name: Try minimum supported versions
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-legacy-test
+            python: 3.8
+            toxenv: py38-legacy-test
 
     steps:
     - name: Checkout code

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,22 +5,12 @@ on:
     types: [released]
 
 jobs:
-  build:
-      name: Publish release to PyPI
-      env:
-        PYPI_USERNAME_STSCI_MAINTAINER: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
-        PYPI_PASSWORD_STSCI_MAINTAINER: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
-        PYPI_USERNAME_OVERRIDE: ${{ secrets.PYPI_USERNAME_OVERRIDE }}
-        PYPI_PASSWORD_OVERRIDE: ${{ secrets.PYPI_PASSWORD_OVERRIDE }}
-        PYPI_TEST: ${{ secrets.PYPI_TEST }}
-        INDEX_URL_OVERRIDE: ${{ secrets.INDEX_URL_OVERRIDE }}
-      runs-on: ubuntu-latest
-      steps:
-
-          # Check out the commit containing this workflow file.
-          - name: checkout repo
-            uses: actions/checkout@v2
-
-          - name: custom action
-            uses: spacetelescope/action-publish_to_pypi@master
-            id: custom_action_0
+  publish:
+    uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
+    with:
+      test: false
+      build_platform_wheels: false # Set to true if your package contains a C extension
+    secrets:
+      user: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
+      password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }} # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.
+      test_password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER_TEST }}

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ POPPY may be installed one of three different ways.
 Requirements
 --------------
 
-* Python 3.7, or more recent.
+* Python 3.8, or more recent.
 * The standard Python scientific stack: :py:mod:`numpy`, :py:mod:`scipy`,
   :py:mod:`matplotlib`
 * POPPY relies upon the `astropy

--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     __version__ = ''
 
-__minimum_python_version__ = "3.7"
+__minimum_python_version__ = "3.8"
 
 
 class UnsupportedPythonError(Exception):

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -144,7 +144,7 @@ class ParameterizedWFE(WavefrontError):
     @utils.quantity_input(coefficients=u.meter, radius=u.meter)
     def __init__(self, name="Parameterized Distortion", coefficients=None, radius=1*u.meter,
                  basis_factory=None, **kwargs):
-        if not isinstance(basis_factory, collections.Callable):
+        if not isinstance(basis_factory, collections.abc.Callable):
             raise ValueError("'basis_factory' must be a callable that can "
                              "calculate basis functions")
         self.radius = radius

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -84,7 +84,7 @@ def str_zernike(n, m):
     terms = []
     for k in range(int((n - m) / 2) + 1):
         coef = ((-1) ** k * factorial(n - k) /
-                (factorial(k) * factorial((n + m) / 2. - k) * factorial((n - m) / 2. - k)))
+                (factorial(k) * factorial(int((n + m) / 2) - k) * factorial(int((n - m) / 2) - k)))
         if coef != 0:
             formatcode = "{0:d}" if k == 0 else "{0:+d}"
             terms.append((formatcode + " r^{1:d} ").format(int(coef), n - 2 * k))
@@ -171,7 +171,7 @@ def R(n, m, rho):
     else:
         for k in range(int((n - m) / 2) + 1):
             coef = ((-1) ** k * factorial(n - k) /
-                    (factorial(k) * factorial((n + m) / 2. - k) * factorial((n - m) / 2. - k)))
+                    (factorial(k) * factorial(int((n + m) / 2) - k) * factorial(int((n - m) / 2) - k)))
             output += coef * rho ** (n - 2 * k)
         return output
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     scipy>=1.5.0
     matplotlib>=3.2.0
     astropy>=4.0.0
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{37,38,39}-test
-    py{37,38,39}-{astropydev,legacy,latest}-test
-    py{37,38,39}{,-syn}-cov
-    py38-numexpr-mkl-cov
+    py{38,39,310}-test
+    py{38,39,310}-{astropydev,legacy,latest}-test
+    py{38,39,310}{,-syn}-cov
+    py39-numexpr-mkl-cov
 
 [testenv]
 passenv = *
@@ -31,7 +31,7 @@ commands=
     cov: codecov -F -e TOXENV
 
 [testenv:docbuild]
-basepython= python3.8
+basepython= python3.9
 deps=
     sphinx
     sphinx_rtd_theme
@@ -48,7 +48,7 @@ commands=
     sphinx-build docs docs/_build
 
 [testenv:codestyle]
-basepython= python3.8
+basepython= python3.9
 skip_install = true
 description = check package code style
 deps =


### PR DESCRIPTION
Remove support for Python 3.7, increase all CI tests by 1 Python version and now include Python 3.10

Also adding this here: updating the publish-to-pypi.yml file to work with new git security changes. This fix comes from  @zanecodes and was also implemented here https://github.com/spacetelescope/pysiaf/pull/240