### PR TITLE
Updated installation instructions

### DIFF
--- a/docs/dev_notes.rst
+++ b/docs/dev_notes.rst
@@ -28,6 +28,10 @@ Release Process
 Releasing a new version through AstroConda
 ------------------------------------------
 
+.. admonition:: **Consider this section deprecated as of version 1.0.3!**
+
+ AstroConda is currently limited to Python <=3.7, while POPPY only supports Python >=3.8 as of v1.0.3.
+
 Do this after you've done the above.
 
 To test that an Astroconda package builds, you will need ``conda-build``::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,15 +1,13 @@
 Installation
 ==================
 
-POPPY may be installed one of three different ways.
+POPPY may be installed one of two different ways.
 
-1. Using ``conda`` through the `AstroConda channel <https://astroconda.readthedocs.io/en/latest/>`__. This is the recommended channel for most users on MacOS and Linux. But note that AstroConda does not support Windows.
-
-2. Using PyPi in the usual manner for Python packages::
+1. Using PyPI in the usual manner for Python packages::
 
     % pip install poppy --upgrade
 
-3. Cloning the source code hosted in `this repository on GitHub <https://github.com/spacetelescope/poppy>`_. It is possible to directly install the latest development version using your locally installed ``git`` package::
+2. Cloning the source code hosted in `this repository on GitHub <https://github.com/spacetelescope/poppy>`_. It is possible to directly install the latest development version using your locally installed ``git`` package::
 
     % git clone https://github.com/spacetelescope/poppy.git
     % cd poppy


### PR DESCRIPTION
I removed AstroConda from the installation instructions because it only supports Python <=3.7 at this time and we are dropping 3.7 support in this release. I also added a deprecation notice to the developer instructions for new releases.