### PR TITLE
Updated ReadTheDocs build's Python version

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,7 +5,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-    version: 3.7
+    version: 3.9
     install:
         - method: pip
           path: .


### PR DESCRIPTION
It turns out the ReadTheDocs builds [have been failing](https://readthedocs.org/projects/poppy-optics/builds/17009557/) for a few weeks due to a version conflict – `poppy` dropped support for Python 3.7, but our yaml file for the docs still requires it. This means any changes made to the docs in the past few weeks haven't made it onto the site.

I made the change to 3.9. Hopefully, that's all we need to get the docs working again.