### PR TITLE
Tried Python 3.8 with ReadTheDocs instead

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,7 +5,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-    version: 3.9
+    version: 3.8
     install:
         - method: pip
           path: .


### PR DESCRIPTION
The [failed build](https://readthedocs.org/projects/poppy-optics/builds/17358684/) after #512's merge explains that ReadTheDocs is currently compatible with Python <=3.8, so I moved its yaml file back down to 3.8.