### PR TITLE
replacing np.float with np.float_ per Issue 544

### DIFF
--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -63,8 +63,8 @@ def _oneside(x, y0, y1, r):
     if np.isscalar(y0): y0 = np.asarray(y0)
     if np.isscalar(y1): y1 = np.asarray(y1)
     sx = x.shape
-    ans = np.zeros(sx, dtype=np.float)
-    yh = np.zeros(sx, dtype=np.float)
+    ans = np.zeros(sx, dtype=np.float_)
+    yh = np.zeros(sx, dtype=np.float_)
     to = (abs(x) >= r)
     ti = (abs(x) < r)
     if np.any(to):

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -1007,7 +1007,7 @@ def decompose_opd(opd, aperture=None, nterms=15, basis=zernike_basis,
     if aperture is None:
         _log.warning("No aperture supplied - "
                   "using the finite (non-NaN) part of the OPD map as a guess.")
-        aperture = np.isfinite(opd)  # . astype(np.float)
+        aperture = np.isfinite(opd)  # . astype(np.float_)
 
     # any pixels with zero or NaN in the aperture are outside the area
     apmask = (np.isfinite(aperture) & (aperture > 0))


### PR DESCRIPTION
Replacing `dtype=np.float` with` dtype=np.float_` to address deprecation in Numpy as described in [Issue 544](https://github.com/spacetelescope/poppy/issues/544).

Did a search of the following type:
`grep -n np.float */*.py`
`grep -n np.float */*/*.py`

Found that this only affects `poppy/geometry.py`. It also appears in a commented-out place in `poppy/zernike.py` which I also changed jik.

