### PR TITLE
 Move metadata from non-standard `setup.cfg` into `PEP 621`-compliant `pyproject.toml`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
 requires = ["setuptools >= 38.0.0",
-            "setuptools_scm >= 2.0.0",
+            "setuptools_scm[toml]>=7",
             "wheel"]
 build-backend = 'setuptools.build_meta'
+
+[tool.setuptools_scm]
+write_to = "poppy/version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,54 @@
 [build-system]
-requires = ["setuptools >= 38.0.0",
-            "setuptools_scm[toml]>=7",
-            "wheel"]
+requires = ["setuptools >= 61.2", "setuptools_scm[toml]>=7"]
 build-backend = 'setuptools.build_meta'
+
+[project]
+name = "poppy"
+description = "Physical optics propagation (wavefront diffraction) for optical simulations, particularly of telescopes."
+authors = [{name = "Marshall Perrin", email = "mperrin@stsci.edu"}]
+license = {text = "BSD-3-Clause"}
+requires-python = ">=3.9"
+dependencies = [
+    "numpy>=1.20.0",
+    "scipy>=1.5.0",
+    "matplotlib>=3.2.0",
+    "astropy>=4.3.0",
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+all = ["synphot"]
+test = [
+    "pytest",
+    "pytest-astropy",
+]
+docs = [
+    "nbsphinx",
+    "stsci_rtd_theme",
+    "sphinx-astropy",
+    "sphinx_rtd_theme",
+    "sphinx-automodapi",
+    "sphinx-issues",
+]
+
+[project.urls]
+Homepage = "https://github.com/spacetelescope/poppy"
+Documentation = "https://poppy-optics.readthedocs.io/"
+"Bug Tracker" = "https://github.com/spacetelescope/poppy/issues"
+
+[project.readme]
+text = '"POPPY (**P**\ hysical **O**\ ptics **P**\ ropagation in **Py**\ thon) is a Python package that simulates physical optical propagation including diffraction. It implements a flexible framework for modeling Fraunhofer and Fresnel diffraction and point spread function formation, particularly in the context of astronomical telescopes."'
+content-type = "text/markdown"
+
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools.packages]
+find = {namespaces = false}
+
+[tool.setuptools.package-data]
+"*" = ["*.fits", "*.csv"]
+"poppy.tests" = ["data/*"]
 
 [tool.setuptools_scm]
 write_to = "poppy/version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,48 +1,7 @@
-[metadata]
-name = poppy
-description = Physical optics propagation (wavefront diffraction) for optical simulations, particularly of telescopes.
-long_description = "POPPY (**P**\ hysical **O**\ ptics **P**\ ropagation in **Py**\ thon) is a Python package that simulates physical optical propagation including diffraction. It implements a flexible framework for modeling Fraunhofer and Fresnel diffraction and point spread function formation, particularly in the context of astronomical telescopes."
-author = Marshall Perrin
-author_email = mperrin@stsci.edu
-license = BSD
-license_file = LICENSE.md
-url = https://poppy-optics.readthedocs.io/
-edit_on_github = False
-github_project = spacetelescope/poppy
-
 # Python code quality checker
 [flake8]
 exclude: .git,__pycache__, test*
 max-line-length = 120
-
-[options]
-zip_safe = False
-packages = find:
-install_requires =
-    numpy>=1.20.0
-    scipy>=1.5.0
-    matplotlib>=3.2.0
-    astropy>=4.3.0
-python_requires = >=3.9
-setup_requires = setuptools_scm
-
-[options.extras_require]
-all =
-    synphot
-test =
-    pytest
-    pytest-astropy
-docs =
-    nbsphinx
-    stsci_rtd_theme
-    sphinx-astropy
-    sphinx_rtd_theme
-    sphinx-automodapi
-    sphinx-issues
-
-[options.package_data]
-* = *.fits, *.csv
-poppy.tests = data/*
 
 [tool:pytest]
 minversion = 2.2

--- a/setup.py
+++ b/setup.py
@@ -48,4 +48,4 @@ if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
     print(DOCS_HELP)
     sys.exit(1)
 
-setup(use_scm_version={'write_to': os.path.join('poppy', 'version.py')})
+setup()


### PR DESCRIPTION
Also fixes some metadata issues:
* license name is replaced with its SPDX id
* links to display in PyPI are fixed. The main link is now GitHub repo, and added a `Documentation` link