### PR TITLE
increment supported Python versions by 1. Minimum version now 3.9

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -21,28 +21,28 @@ jobs:
 
           - name: Check for Sphinx doc build errors
             os: ubuntu-latest
-            python: 3.9
+            python: 3.10
             toxenv: docbuild
 
           - name: Check accelerated math version
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-numexpr-mkl-cov
+            python: 3.10
+            toxenv: py310-numexpr-mkl-cov
 
           - name: Try Astropy development version
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-astropydev-test
+            python: 3.10
+            toxenv: py310-astropydev-test
 
           - name: Try latest versions of all dependencies
             os: ubuntu-latest
-            python: '3.10'
-            toxenv: py310-latest-test
+            python: '3.11'
+            toxenv: py311-latest-test
 
           - name: Try minimum supported versions
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-legacy-test
+            python: 3.9
+            toxenv: py39-legacy-test
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -21,17 +21,17 @@ jobs:
 
           - name: Check for Sphinx doc build errors
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: docbuild
 
           - name: Check accelerated math version
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-numexpr-mkl-cov
 
           - name: Try Astropy development version
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-astropydev-test
 
           - name: Try latest versions of all dependencies
@@ -41,7 +41,7 @@ jobs:
 
           - name: Try minimum supported versions
             os: ubuntu-latest
-            python: 3.9
+            python: '3.9'
             toxenv: py39-legacy-test
 
     steps:

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -5,6 +5,19 @@ Release Notes
 
 For a list of contributors, see :ref:`about`.
 
+
+1.1.0
+-----
+
+.. _rel1.1.0::
+
+*2023 date TBD*
+
+**Software Infrastructure Updates and Internals:**
+ * Increase all CI test versions by 1, removing Python 3.8 and adding Python 3.11. Update minimum supported versions of astropy and numpy as well. (PR TBD by :user:`mperrin`)
+ 
+
+
 1.0.3
 -----
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps=
     cov: codecov
     syn: synphot
     legacy: numpy==1.19.*
-    legacy: astropy==4.1.*
+    legacy: astropy==4.0.*
     latest: -rrequirements.txt
     astropydev: git+https://github.com/astropy/astropy
     numexpr: numexpr>=2.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{38,39,310}-test
-    py{38,39,310}-{astropydev,legacy,latest}-test
-    py{38,39,310}{,-syn}-cov
-    py39-numexpr-mkl-cov
+    py{39,310,311}-test
+    py{39,310,311}-{astropydev,legacy,latest}-test
+    py{39,310,311}{,-syn}-cov
+    py310-numexpr-mkl-cov
 
 [testenv]
 passenv = *
@@ -14,11 +14,11 @@ deps=
     cov: coverage
     cov: codecov
     syn: synphot
-    legacy: numpy==1.18.*
-    legacy: astropy==4.0.*
+    legacy: numpy==1.19.*
+    legacy: astropy==4.1.*
     latest: -rrequirements.txt
     astropydev: git+https://github.com/astropy/astropy
-    numexpr: numexpr>=2.0.0
+    numexpr: numexpr>=2.6.0
 conda_deps=
     mkl: mkl_fft
 conda_channels=
@@ -31,7 +31,7 @@ commands=
     cov: codecov -F -e TOXENV
 
 [testenv:docbuild]
-basepython= python3.9
+basepython= python3.10
 deps=
     sphinx
     sphinx_rtd_theme
@@ -48,7 +48,7 @@ commands=
     sphinx-build docs docs/_build
 
 [testenv:codestyle]
-basepython= python3.9
+basepython= python3.10
 skip_install = true
 description = check package code style
 deps =


### PR DESCRIPTION
Implements #535.  Drops support for Python 3.8. Astropy is dropping python 3.8 support as of this month so we should follow suite. 