### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,6 @@ deps=
     pytest
     cov: pytest-astropy
     cov: pytest-cov
-    cov: coverage
-    cov: codecov
     syn: synphot
     legacy: numpy==1.20.0
     legacy: astropy==4.3.0
@@ -27,8 +25,7 @@ conda_install_args=
     mkl: --override-channels
 commands=
     test: pytest {posargs}
-    cov: pytest {posargs} --cov-config=setup.cfg --cov-report=xml --cov=poppy poppy/tests/
-    cov: codecov -F -e TOXENV
+    cov: pytest {posargs} --cov-config=setup.cfg --cov-report=xml --cov-report=term-missing --cov=poppy poppy/tests/
 
 [testenv:docbuild]
 basepython= python3.10


### PR DESCRIPTION
the `codecov` package is now deprecated and has been yanked from PyPI. Codecov upload is taken care of by the CI action