### PR TITLE
trivial: remove comment text that mentions a deprecated astropy feature

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,7 +19,3 @@ PYTEST_HEADER_MODULES['synphot'] = 'synphot'
 
 TESTED_VERSIONS['poppy'] = __version__
 
-## Uncomment the following line to treat all DeprecationWarnings as
-## exceptions
-# from astropy.tests.helper import enable_deprecations_as_exceptions
-# enable_deprecations_as_exceptions()


### PR DESCRIPTION
The automated notification #571 was triggered by comment text that mentions a deprecated feature in astropy. This PR removes that comment text, with no change in functionality. 