### PR TITLE
Numpy 2.0 fixes:poly1d and NaN

### DIFF
--- a/poppy/accel_math.py
+++ b/poppy/accel_math.py
@@ -387,7 +387,7 @@ tmp = np.asarray(np.random.rand({npix},{npix}), np.{complextype})
         time_fftw = timer.timeit(number=iterations) / iterations
         print("  {:.3f} s".format(time_fftw))
     else:
-        time_fftw = np.NaN
+        time_fftw = np.nan
 
     if poppy.accel_math._NUMEXPR_AVAILABLE:
         print("Timing performance with Numexpr + FFTW:")
@@ -396,7 +396,7 @@ tmp = np.asarray(np.random.rand({npix},{npix}), np.{complextype})
         time_numexpr = timer.timeit(number=iterations) / iterations
         print("  {:.3f} s".format(time_numexpr))
     else:
-        time_numexpr = np.NaN
+        time_numexpr = np.nan
 
     if poppy.accel_math._MKLFFT_AVAILABLE:
         print("Timing performance with Numexpr + MKL:")
@@ -407,7 +407,7 @@ tmp = np.asarray(np.random.rand({npix},{npix}), np.{complextype})
         time_mkl = timer.timeit(number=iterations) / iterations
         print("  {:.3f} s".format(time_mkl))
     else:
-        time_mkl = np.NaN
+        time_mkl = np.nan
 
     if poppy.accel_math._OPENCL_AVAILABLE:
         print("Timing performance with OpenCL:")
@@ -416,7 +416,7 @@ tmp = np.asarray(np.random.rand({npix},{npix}), np.{complextype})
         time_opencl = timer.timeit(number=iterations) / iterations
         print("  {:.3f} s".format(time_opencl))
     else:
-        time_opencl = np.NaN
+        time_opencl = np.nan
 
 
     poppy.conf.use_mkl, poppy.conf.use_fftw, poppy.conf.use_numexpr, poppy.conf.use_cupy,\

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -566,7 +566,7 @@ class BandLimitedCoronagraph(AnalyticImagePlaneElement):
             else:
                 raise NotImplemented("No defined NIRCam wedge BLC mask for that wavelength?  ")
 
-            sigmas = scipy.poly1d(polyfitcoeffs)(scalefact)
+            sigmas = numpy.poly1d(polyfitcoeffs)(scalefact)
 
             sigmar = sigmas * np.abs(y)
             sigmar.clip(np.finfo(sigmar.dtype).tiny, out=sigmar)  # avoid divide by zero -> NaNs


### PR DESCRIPTION
It appears that development scipy is no longer providing numpy functions via scipy (see https://github.com/scipy/scipy/pull/19067).

With a current scipy (1.11.0) `numpy.poly1d` is available at `scipy.poly1d`. poppy currently uses `scipy.poly1d`. `scipy.poly1d` no longer exists in scipy main. This PR updates this call to use `numpy.poly1d`.

Numpy 2.0 also removes `NaN`. This PR switches uses of `NaN` to `nan`.