### PR TITLE
TST: Use astropy dev from nightly wheel

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ envlist =
 isolated_build = true
 
 [testenv]
+setenv =
+    astropydev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple
 passenv = *
 deps=
     pytest
@@ -18,7 +20,7 @@ deps=
     legacy: astropy==5.1.0
     legacy: scipy==1.10.1
     latest: -rrequirements.txt
-    astropydev: git+https://github.com/astropy/astropy
+    astropydev: astropy>=0.0.dev0
     numexpr: numexpr>=2.6.0
 conda_deps=
     mkl: mkl_fft


### PR DESCRIPTION
No reason to install astropy dev from source. We provide nightly dev wheel.