### PR TITLE
add pie wedge segmented aperture

### DIFF
--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -5,6 +5,7 @@ import astropy.units as u
 
 from .. import poppy_core
 from .. import optics
+from .. import utils
 
 from .. import accel_math
 import numpy as np
@@ -389,6 +390,24 @@ def test_NgonAperture(display=False):
         pl.subplot(133)
         optic.display()
 
+
+def test_WedgeSegmentedCircularAperture(plot=False):
+    """ test WedgeSegmentedCircularAperture """
+
+    ap_circ = optics.CircularAperture()
+    ap_wedge = optics.WedgeSegmentedCircularAperture(rings=3, nsections=[0, 6, 8])
+    wave1 = poppy_core.Wavefront(npix=256, diam=2, wavelength=1e-6)  # 10x10 meter square
+    wave2 = poppy_core.Wavefront(npix=256, diam=2, wavelength=1e-6)  # 10x10 meter square
+
+    wave1 *= ap_circ
+    wave2 *= ap_wedge
+
+    assert wave1.total_intensity * 0.95 < wave2.total_intensity < wave1.total_intensity, 'wedge segmented circle should have slightly less clear area than monolith circle'
+
+    if plot:
+        fig, axes = plt.subplots(figsize=(16, 9), ncols=2)
+        wave1.display(ax=axes[0])
+        wave2.display(ax=axes[1])
 
 
 def test_ObscuredCircularAperture_Airy(display=False):

--- a/poppy/tests/test_utils.py
+++ b/poppy/tests/test_utils.py
@@ -140,6 +140,10 @@ def test_radial_profile(plot=False):
     assert prof_stds.shape == prof.shape, "Radial profile and stddev array output sizes should match"
     assert prof_mads.shape == prof.shape, "Radial profile and median absolute deviation array output sizes should match"
 
+    # Test computing some arbitrary function
+    rad4, prof_max = poppy.radial_profile(psf, custom_function=np.max)
+    # compare, but ignore the 0th bin and last bin that have no pixels within that bin etc
+    assert np.all(prof_max[1:-1] >= prof[1:-1]), "Radial profile using max function should be >= profile using mean"
 
 def test_radial_profile_of_offset_source():
     """Test that we can compute the radial profile for a source slightly outside the FOV,


### PR DESCRIPTION
- Adds a `WedgeSegmentedCircularAperture` class, for defining pie-wedge or keystone-shaped apertures; some of the aperture geometries under consideration for HWO need this kind of aperture. 
- Also, minor enhancement to radial_profile function adding a `custom_function` parameter, which lets you compute an arbitrary function evaluated in over each radial bin, for instance the min or max at a given radius. This generalizes the prior approach used for computing std dev or median absolute deviation in each bin. \
- Tests for both the above are included. 

Example: 

![Unknown-26](https://github.com/spacetelescope/poppy/assets/1151745/6488f4db-d7f3-4c00-9753-23e8fa0273eb)

