### PR TITLE
[SCSB-145] require Python 3.10

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -41,8 +41,8 @@ jobs:
 
           - name: Try minimum supported versions
             os: ubuntu-latest
-            python: '3.9'
-            toxenv: py39-legacy-test
+            python: '3.10'
+            toxenv: py310-legacy-test
 
     steps:
     - name: Checkout code

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,7 @@ POPPY may be installed one of two different ways.
 Requirements
 --------------
 
-* Python 3.9, or more recent.
+* Python 3.10, or more recent.
 * The standard Python scientific stack: :py:mod:`numpy`, :py:mod:`scipy`,
   :py:mod:`matplotlib`
 * POPPY relies upon the `astropy

--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     __version__ = ""
 
-__minimum_python_version__ = "3.9"
+__minimum_python_version__ = "3.10"
 
 
 class UnsupportedPythonError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,35 @@
 [build-system]
-requires = ["setuptools >= 61.2",
-            "setuptools_scm[toml]>=7.1"]
-build-backend = 'setuptools.build_meta'
+requires = [
+    "setuptools >= 61.2",
+    "setuptools_scm[toml]>=7.1",
+]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "poppy"
 description = "Physical optics propagation (wavefront diffraction) for optical simulations, particularly of telescopes."
-authors = [{name = "Marshall Perrin", email = "mperrin@stsci.edu"}]
-license = {text = "BSD-3-Clause"}
-requires-python = ">=3.9"
+authors = [
+    { name = "Marshall Perrin", email = "mperrin@stsci.edu" },
+]
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.20.0",
     "scipy>=1.5.0",
     "matplotlib>=3.2.0",
     "astropy>=5.1.0",
 ]
-dynamic = ["version"]
+dynamic = [
+    "version",
+]
 readme = "README.rst"
 
+[project.license]
+text = "BSD-3-Clause"
+
 [project.optional-dependencies]
-all = ["synphot"]
+all = [
+    "synphot",
+]
 test = [
     "pytest",
     "pytest-astropy",
@@ -55,19 +65,26 @@ addopts = "-p no:warnings"
 zip-safe = false
 include-package-data = false
 
-[tool.setuptools.packages]
-find = {namespaces = false}
+[tool.setuptools.packages.find]
+namespaces = false
 
 [tool.setuptools.package-data]
-"*" = ["*.fits", "*.csv"]
-"poppy.tests" = ["data/*"]
+"*" = [
+    "*.fits",
+    "*.csv",
+]
+"poppy.tests" = [
+    "data/*",
+]
 
 [tool.setuptools_scm]
 write_to = "poppy/version.py"
 write_to_template = "__version__ = '{version}'\n"
 
 [tool.coverage.run]
-source = ["poppy",]
+source = [
+    "poppy",
+]
 omit = [
     "poppy/conftest*",
     "poppy/cython_version*",

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps=
     cov: pytest-astropy
     cov: pytest-cov
     syn: synphot
-    legacy: numpy==1.20.0
+    legacy: oldest-supported-numpy
     legacy: astropy==5.1.0
     legacy: scipy==1.10.1
     latest: -rrequirements.txt


### PR DESCRIPTION
resolves [SCSB-145](https://jira.stsci.edu/browse/SCSB-145)

propagate Astropy's deprecation of Python 3.9 to downstream packages


> [!NOTE]
> this PR was generated automatically by ``batchpr`` :robot: