### PR TITLE
Minor: quiet two syntax warnings about string escape sequences

### DIFF
--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -1362,7 +1362,7 @@ class BackCompatibleQuantityInput(object):
         -----
 
         The checking of arguments inside variable arguments to a function is not
-        supported (i.e. \*arg or \**kwargs).
+        supported (i.e. *arg or **kwargs).
 
         Examples
         --------

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -100,9 +100,9 @@ def str_zernike(n, m):
         else:
             return "sqrt(%d)* ( %s ) " % (n + 1, outstr)
     elif signed_m > 0:
-        return "\sqrt{%d}* ( %s ) * \\cos(%d \\theta)" % (2 * (n + 1), outstr, m)
+        return "\\sqrt{%d}* ( %s ) * \\cos(%d \\theta)" % (2 * (n + 1), outstr, m)
     else:
-        return "\sqrt{%d}* ( %s ) * \\sin(%d \\theta)" % (2 * (n + 1), outstr, m)
+        return "\\sqrt{%d}* ( %s ) * \\sin(%d \\theta)" % (2 * (n + 1), outstr, m)
 
 
 def noll_indices(j):


### PR DESCRIPTION
Minor change in some string outputs; no functional change in code or math implementation.  This PR quiets those with some tiny edits that fix a couple bits of string formatting. 

Running in python 3.12 yielded some syntax warnings about invalid escape sequence. These are valid warnings about minor errors; it seems like somebody improved the string parser upstream to be more informative or check more. 

```
WARNING - /Users/mperrin/Dropbox/Documents/software/poppy/poppy/utils.py:1339: SyntaxWarning: invalid escape sequence '\*'
WARNING - /Users/mperrin/Dropbox/Documents/software/poppy/poppy/zernike.py:103: SyntaxWarning: invalid escape sequence '\s'
  return "\sqrt{%d}* ( %s ) * \\cos(%d \\theta)" % (2 * (n + 1), outstr, m)
WARNING - /Users/mperrin/Dropbox/Documents/software/poppy/poppy/zernike.py:105: SyntaxWarning: invalid escape sequence '\s'
  return "\sqrt{%d}* ( %s ) * \\sin(%d \\theta)" % (2 * (n + 1), outstr, m)
```