### PR TITLE
Update intel channel location

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps=
 conda_deps=
     mkl: mkl_fft
 conda_channels=
-    mkl: intel
+    mkl: https://software.repos.intel.com/python/conda/
 conda_install_args=
     mkl: --override-channels
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ conda_deps=
     mkl: mkl_fft
 conda_channels=
     mkl: https://software.repos.intel.com/python/conda/
+    mkl: conda-forge
 conda_install_args=
     mkl: --override-channels
 commands=


### PR DESCRIPTION
Github actions are currently failing because the `intel` channel returns 403 error

The intel channel is used for the `mkl_fft` library
This PR replaces `intel` channel that no longer exists in coda with the intel self hosted `https://software.repos.intel.com/python/conda/`