### PR TITLE
min pin numexpr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
+    "numexpr>=2.9.0",
     "numpy>=1.20.0",
     "scipy>=1.5.0",
     "matplotlib>=3.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 astropy==6.1.2
 matplotlib==3.9.1
+numexpr>=2.9.0
 numpy==2.0.1
 scipy==1.14.0


### PR DESCRIPTION
numexpr>=2.9.0 to avoid future bugs per webbpsf issue 902:
https://github.com/spacetelescope/webbpsf/issues/902
