### PR TITLE
use z-range for dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-astropy==6.1.2
-matplotlib==3.9.1
-numexpr>=2.9.0
-numpy==2.0.1
-scipy==1.14.1
+astropy>=6.1.2,<6.2.0
+matplotlib>=3.9.1,<3.10.0
+numexpr>=2.9.0,<2.10.0
+numpy>=2.1.0,<2.2.0
+scipy>=1.14.1,<1.15.0


### PR DESCRIPTION
Added ranges to allow install for z level enhancements(x.y.z) without needing push.