### PR TITLE
Fix an issue with providing astropy Units to calc_datacube

### DIFF
--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -325,6 +325,10 @@ class Instrument(object):
             raise ValueError("Maximum number of wavelengths exceeded. "
                              "Cannot be more than 10,000.")
 
+        def wavelength_as_meters(wavelength):
+            """helper function to avoid trying to put a Quantity into a FITS header """
+            return wavelength.to_value(units.meter) if isinstance(wavelength, units.Quantity) else wavelength
+
         # Set up cube and initialize structure based on PSF at first wavelength
         poppy_core._log.info("Starting multiwavelength data cube calculation.")
         psf = self.calc_psf(*args, monochromatic=wavelengths[0], **kwargs)
@@ -333,7 +337,7 @@ class Instrument(object):
         for ext in range(len(psf)):
             cube[ext].data = np.zeros((nwavelengths, psf[ext].data.shape[0], psf[ext].data.shape[1]))
             cube[ext].data[0] = psf[ext].data
-            cube[ext].header[label_wl(0)] = wavelengths[0]
+            cube[ext].header[label_wl(0)] = wavelength_as_meters(wavelengths[0])
 
         iterate_wrapper = utils.get_progressbar_wrapper(progressbar, nwaves=nwavelengths)
         # iterate rest of wavelengths
@@ -342,7 +346,7 @@ class Instrument(object):
             psf = self.calc_psf(*args, monochromatic=wl, **kwargs)
             for ext in range(len(psf)):
                 cube[ext].data[i] = psf[ext].data
-                cube[ext].header[label_wl(i)] = wl
+                cube[ext].header[label_wl(i)] = wavelength_as_meters(wl)
                 cube[ext].header.add_history("--- Cube Plane {} ---".format(i))
                 for h in psf[ext].header['HISTORY']:
                     cube[ext].header.add_history(h)

--- a/poppy/tests/test_instrument.py
+++ b/poppy/tests/test_instrument.py
@@ -184,3 +184,17 @@ def test_instrument_calc_datacube():
         "Multi-wavelength PSF does not match weighted sum of individual wavelength PSFs"
 
     return psf
+
+
+def test_instrument_datacube_wavelengths_units():
+    """Test input of datacube wavelengths with and without astropy units """
+    inst = instrument.Instrument()
+
+    psf = inst.calc_datacube(WAVELENGTHS_ARRAY, fov_pixels=FOV_PIXELS,
+                       detector_oversample=2, fft_oversample=2, progressbar=True)
+
+    wavelengths_quantity = WAVELENGTHS_ARRAY * u.meter
+    psf2 = inst.calc_datacube(wavelengths_quantity, fov_pixels=FOV_PIXELS,
+                       detector_oversample=2, fft_oversample=2, progressbar=True)
+
+    assert np.allclose(psf[0].data, psf2[0].data), "Should get same outputs with/without units"


### PR DESCRIPTION
This fixes an issue I found with the calc_datacube function, which currently errors if provided wavelengths as astropy Quantities: 


```
>>> import numpy as np, webbpsf, astropy.units as u

>>> nrs = webbpsf.NIRSpec()
>>> nrs.calc_datacube(wavelengths=np.array([1,2,3])*u.micron)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)

[... long trace of error text from Astropy trying to write a Quantity into a FITS header]
```

This fix makes sure the wavelength is converted to a plain float in units of meters before being saved as a header keyword. 

No change is needed in `calc_psf` which already works correctly with units. This fix is just needed for `calc_datacube` which somehow slipped through the cracks for this. 