### PR TITLE
fix float comparison bug for non-square subarrays

### DIFF
--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1184,7 +1184,7 @@ class Wavefront(BaseWavefront):
 
         if not np.isscalar(self.pixelscale.value):
             # check for rectangular arrays
-            if self.pixelscale[0] == self.pixelscale[1]:
+            if np.isclose(self.pixelscale[0], self.pixelscale[1]):
                 self.pixelscale = self.pixelscale[0]
                 # we're in a rectangular array with same scale in both directions, so treat pixelscale as a scalar
             else:


### PR DESCRIPTION
Fixes a floating comparison that can cause a bug under some circumstances when trying to make a PSF on a non-square subarray. 

**Currently:**
```
import webbpsf
miri = webbpsf.MIRI()
miri.set_position_from_aperture_name('MIRIM_TA1140_UR')   # Aperture used in some MIRI coron TAs

rect_psf = miri.calc_psf(nlambda=1, fov_pixels=(224, 288))   # Compute PSF with the shape of that subarray
--------------------------------------------
[... long trace of error text ]
NotImplementedError: Different pixel scales in X and Y directions (i.e. non-square pixels) not yet supported.
```
It's incorrect to trigger that error.  The pixel scale is the same in both dimensions (or should be), and it's just the dimension which is different.  Right now the check is being confused by a floating point precision issue. 

**With this PR:**
It works as intended, and makes a PSF on a rectangular subarray. 

![Unknown-1](https://github.com/user-attachments/assets/a3590c8b-abbd-4bfd-ad11-ef3a76c3a22e)


