### PR TITLE
rename 'wedge' segment shame to 'keystone'

### DIFF
--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -21,7 +21,7 @@ if accel_math._NUMEXPR_AVAILABLE:
     import numexpr as ne
 
 __all__ = ['ContinuousDeformableMirror', 'HexSegmentedDeformableMirror', 'CircularSegmentedDeformableMirror',
-           'WedgeSegmentedDeformableMirror']
+           'KeystoneSegmentedDeformableMirror']
 
 
 # noinspection PyUnresolvedReferences
@@ -851,7 +851,7 @@ class CircularSegmentedDeformableMirror(SegmentedDeformableMirror, optics.MultiC
 
 
 # note, must inherit first from SegmentedDeformableMirror to get correct method resolution order
-class WedgeSegmentedDeformableMirror(SegmentedDeformableMirror, optics.WedgeSegmentedCircularAperture):
+class KeystoneSegmentedDeformableMirror(SegmentedDeformableMirror, optics.KeystoneSegmentedCircularAperture):
     """ Circularly segmented DM. Each actuator is controllable in piston, tip, and tilt (and any zernike term)
 
             Parameters
@@ -873,9 +873,9 @@ class WedgeSegmentedDeformableMirror(SegmentedDeformableMirror, optics.WedgeSegm
     def __init__(self, name='WedgeSegDM', radius=1.0 * u.m, rings=1, nsections=4, gap_radii=None, gap=0.01 * u.m,
                  include_factor_of_two=False, **kwargs):
         #FIXME ? using grey pixel does not work. something in the geometry module generate a true divide error
-        optics.WedgeSegmentedCircularAperture.__init__(self, name=name, radius=radius, rings=rings,
-                                              nsections=nsections, gap_radii=gap_radii,
-                                              gap=gap,   **kwargs)
+        optics.KeystoneSegmentedCircularAperture.__init__(self, name=name, radius=radius, rings=rings,
+                                                          nsections=nsections, gap_radii=gap_radii,
+                                                          gap=gap, **kwargs)
         SegmentedDeformableMirror.__init__(self, rings=rings, include_factor_of_two=include_factor_of_two)
 
 
@@ -884,4 +884,4 @@ class WedgeSegmentedDeformableMirror(SegmentedDeformableMirror, optics.WedgeSegm
         # edges of segments. This approach results in the DM segment maps covering the segment gaps better, to
         # accomodate 'gray' pixels in the transmission map
         super()._setup_arrays(npix, pixelscale, wave=wave)
-        self._transmission = optics.WedgeSegmentedCircularAperture.get_transmission(self, wave)
+        self._transmission = optics.KeystoneSegmentedCircularAperture.get_transmission(self, wave)

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -24,7 +24,8 @@ __all__ = ['AnalyticOpticalElement', 'ScalarTransmission', 'ScalarOpticalPathDif
            'BandLimitedCoron', 'BandLimitedCoronagraph', 'IdealFQPM', 'CircularPhaseMask', 'RectangularFieldStop', 'SquareFieldStop',
            'AnnularFieldStop', 'HexagonFieldStop',
            'CircularOcculter', 'BarOcculter', 'FQPM_FFT_aligner', 'CircularAperture',
-           'HexagonAperture', 'MultiHexagonAperture', 'NgonAperture', 'MultiCircularAperture', 'WedgeSegmentedCircularAperture', 'RectangleAperture',
+           'HexagonAperture', 'MultiHexagonAperture', 'NgonAperture', 'MultiCircularAperture',
+           'KeystoneSegmentedCircularAperture', 'RectangleAperture',
            'SquareAperture', 'SecondaryObscuration', 'LetterFAperture', 'AsymmetricSecondaryObscuration',
            'ThinLens',  'GaussianAperture', 'KnifeEdge', 'TiltOpticalPathDifference', 'CompoundAnalyticOptic', 'fixed_sampling_optic']
 
@@ -1588,7 +1589,7 @@ class MultiCircularAperture(MultiSegmentAperture):
         return self.transmission
 
 
-class WedgeSegmentedCircularAperture(MultiSegmentAperture, CircularAperture):
+class KeystoneSegmentedCircularAperture(MultiSegmentAperture, CircularAperture):
     @utils.quantity_input(radius=u.meter, gap=u.meter)
     def __init__(self, name=None, radius=1.0 * u.meter,
                  rings=2, nsections=4, gap_radii=None, gap=0.01 * u.meter,

--- a/poppy/tests/test_dms.py
+++ b/poppy/tests/test_dms.py
@@ -201,7 +201,7 @@ def test_basic_wedge_dm():
     """ A simple test for the circularly segmented deformable mirror code -
     can we move actuators, and does adding nonzero WFE result in decreased Strehl?"""
 
-    dm = dms.WedgeSegmentedDeformableMirror(rings=2, nsections=[1,6])
+    dm = dms.KeystoneSegmentedDeformableMirror(rings=2, nsections=[1, 6])
 
     osys = poppy_core.OpticalSystem(npix=256)
     osys.add_pupil(dm)

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -392,10 +392,10 @@ def test_NgonAperture(display=False):
 
 
 def test_WedgeSegmentedCircularAperture(plot=False):
-    """ test WedgeSegmentedCircularAperture """
+    """ test KeystoneSegmentedCircularAperture """
 
     ap_circ = optics.CircularAperture()
-    ap_wedge = optics.WedgeSegmentedCircularAperture(rings=3, nsections=[1, 6, 8])
+    ap_wedge = optics.KeystoneSegmentedCircularAperture(rings=3, nsections=[1, 6, 8])
     wave1 = poppy_core.Wavefront(npix=256, diam=2, wavelength=1e-6)  # 10x10 meter square
     wave2 = poppy_core.Wavefront(npix=256, diam=2, wavelength=1e-6)  # 10x10 meter square
 


### PR DESCRIPTION
Rename 'wedge' segmented circular mirror to 'keystone' segmented, for consistency with NASA HWO EAC nomenclature. 

This is a rename of the classes `WedgeSegmentedCircularAperture` and `WedgeSegmentedDeformableMirror`
 to  `KeystoneSegmentedCircularAperture` and `KeystoneSegmentedDeformableMirror`, respectively. No functional changes. 