### PR TITLE
[SCSB-205] `project.license.file` -> `project.license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ dynamic = [
     "version",
 ]
 readme = "README.rst"
-
-[project.license]
-text = "BSD-3-Clause"
+license-files = ["LICENSE.md"]
 
 [project.optional-dependencies]
 all = [

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,8 @@ conda_channels=
     mkl: conda-forge
 conda_install_args=
     mkl: --override-channels
+commands_pre=
+    pip list
 commands=
     test: pytest {posargs}
     cov: pytest {posargs} --cov-config=pyproject.toml --cov-report=xml --cov-report=term-missing --cov=poppy poppy/tests/


### PR DESCRIPTION
the `project.license` entry is changing to just use SPDX expressions; license files are moving to `project.license-files` ([PEP 639](https://peps.python.org/pep-0639/))