### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ test_outputs/
 
 # PyCharm
 .idea
+
+# misc
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,10 @@ all = [
     "synphot",
 ]
 test = [
-    "pytest",
+    "pytest>=9",
     "pytest-astropy",
+    "docutils",
+    "sphinx",
 ]
 docs = [
     "nbsphinx",
@@ -49,17 +51,14 @@ Homepage = "https://github.com/spacetelescope/poppy"
 Documentation = "https://poppy-optics.readthedocs.io/"
 "Bug Tracker" = "https://github.com/spacetelescope/poppy/issues"
 
-[tool.pytest.ini_options]
-minversion = "2.2"
-norecursedirs = [
-    "build",
-    "docs/_build",
-]
-testpaths = "poppy docs"
-astropy_header = "true"
+[tool.pytest]
+minversion = "9"
+norecursedirs = ["build", "docs/_build"]
+testpaths = ["poppy", "docs"]
+astropy_header = true
 doctest_plus = "enabled"
 text_file_format = "rst"
-addopts = "-p no:warnings"
+addopts = ["-p no:warnings"]
 
 [tool.setuptools]
 zip-safe = false


### PR DESCRIPTION
Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`