### PR TITLE
Code linting and formatting with Ruff

### DIFF
--- a/poppy/__init__.py
+++ b/poppy/__init__.py
@@ -16,6 +16,7 @@ Documentation can be found online at https://poppy-optics.readthedocs.io/
 # Enforce Python version check during package import.
 # This is the same check as the one at the top of setup.py
 import sys
+
 from astropy import config as _config
 
 try:
@@ -31,10 +32,10 @@ class UnsupportedPythonError(Exception):
 
 
 if sys.version_info < tuple(
-    (int(val) for val in __minimum_python_version__.split("."))
+    int(val) for val in __minimum_python_version__.split(".")
 ):
     raise UnsupportedPythonError(
-        "poppy does not support Python < {}".format(__minimum_python_version__)
+        f"poppy does not support Python < {__minimum_python_version__}"
     )
 
 

--- a/poppy/accel_math.py
+++ b/poppy/accel_math.py
@@ -2,14 +2,16 @@
 #
 # Various functions related to accelerated computations using FFTW, CUPY, numexpr, and related.
 #
+import logging
+import multiprocessing
+import time
+
+import matplotlib.pyplot as plt
 import numpy as np
 import scipy
-import multiprocessing
-import matplotlib.pyplot as plt
+
 from . import conf
 
-import time
-import logging
 _log = logging.getLogger('poppy')
 
 try:
@@ -42,9 +44,9 @@ except ImportError:
 
 try:
     # try to import OpenCL packages to see if they are is available
+    import gpyfft
     import pyopencl
     import pyopencl.array
-    import gpyfft
     _OPENCL_AVAILABLE = True
     _OPENCL_STATE = dict()
 except ImportError:
@@ -266,8 +268,7 @@ def fft_2d(wavefront, forward=True, normalization=None, fftshift=True):
             # The first time you run FFTW to transform a given size, it does a speed test to
             # determine optimal algorithm that is destructive to your chosen array.
             # So only do that test on a copy, not the real array:
-            _log.info("Measuring pyfftw optimal plan for %s, direction=%s" % (
-                str(wavefront.shape), FFT_direction))
+            _log.info(f"Measuring pyfftw optimal plan for {str(wavefront.shape)}, direction={FFT_direction}")
 
             pyfftw.interfaces.cache.enable()
             pyfftw.interfaces.cache.set_keepalive_time(30)
@@ -294,7 +295,7 @@ def fft_2d(wavefront, forward=True, normalization=None, fftshift=True):
 
     wavefront *= normalization
     t3 = time.time()
-    _log.debug("    FFT_2D: FFT in {:3f} s, full function  in {:.3f} s".format(t2-t1, t3-t0))
+    _log.debug(f"    FFT_2D: FFT in {t2-t1:3f} s, full function  in {t3-t0:.3f} s")
 
     return wavefront
 
@@ -354,19 +355,19 @@ def benchmark_fft(npix=2048, iterations=20, double_precision=True):
     """ Performance benchmark function for standard imaging """
     #import poppy
     import timeit
+
     import poppy
 
 
     complextype = 'complex128' if double_precision else 'complex64'
 
     timer = timeit.Timer("tmp2 = poppy.accel_math.fft_2d(tmp, fftshift=False)",
-            setup="""
+            setup=f"""
 import poppy
 import numpy as np
 tmp = np.asarray(np.random.rand({npix},{npix}), np.{complextype})
-            """.format(npix=npix, complextype=complextype))
-    print("Timing performance of FFT for {npix} x {npix}, {complextype}, with {iterations} iterations".format(
-        npix=npix, iterations=iterations, complextype=complextype))
+            """)
+    print(f"Timing performance of FFT for {npix} x {npix}, {complextype}, with {iterations} iterations")
 
     defaults = (poppy.conf.use_mkl, poppy.conf.use_fftw, poppy.conf.use_numexpr, poppy.conf.use_cupy,
             poppy.conf.use_opencl, poppy.conf.double_precision)
@@ -378,14 +379,14 @@ tmp = np.asarray(np.random.rand({npix},{npix}), np.{complextype})
     poppy.conf.use_mkl, poppy.conf.use_fftw, poppy.conf.use_numexpr, poppy.conf.use_cupy, poppy.conf.use_opencl = (False, False, False, False, False)
     update_math_settings()
     time_numpy = timer.timeit(number=iterations) / iterations
-    print("  {:.3f} s".format(time_numpy))
+    print(f"  {time_numpy:.3f} s")
 
     if poppy.accel_math._FFTW_AVAILABLE:
         print("Timing performance with FFTW:")
         poppy.conf.use_fftw = True
         update_math_settings()
         time_fftw = timer.timeit(number=iterations) / iterations
-        print("  {:.3f} s".format(time_fftw))
+        print(f"  {time_fftw:.3f} s")
     else:
         time_fftw = np.nan
 
@@ -394,7 +395,7 @@ tmp = np.asarray(np.random.rand({npix},{npix}), np.{complextype})
         poppy.conf.use_numexpr = True
         update_math_settings()
         time_numexpr = timer.timeit(number=iterations) / iterations
-        print("  {:.3f} s".format(time_numexpr))
+        print(f"  {time_numexpr:.3f} s")
     else:
         time_numexpr = np.nan
 
@@ -405,7 +406,7 @@ tmp = np.asarray(np.random.rand({npix},{npix}), np.{complextype})
         poppy.conf.use_mkl = True
         update_math_settings()
         time_mkl = timer.timeit(number=iterations) / iterations
-        print("  {:.3f} s".format(time_mkl))
+        print(f"  {time_mkl:.3f} s")
     else:
         time_mkl = np.nan
 
@@ -414,7 +415,7 @@ tmp = np.asarray(np.random.rand({npix},{npix}), np.{complextype})
         poppy.conf.use_opencl = True
         update_math_settings()
         time_opencl = timer.timeit(number=iterations) / iterations
-        print("  {:.3f} s".format(time_opencl))
+        print(f"  {time_opencl:.3f} s")
     else:
         time_opencl = np.nan
 
@@ -434,7 +435,10 @@ def get_processor_name():
 
     With thanks to https://stackoverflow.com/a/20161999
     """
-    import os, platform, subprocess, re
+    import os
+    import platform
+    import re
+    import subprocess
 
     if platform.system() == "Windows":
         return platform.processor()
@@ -458,7 +462,9 @@ def get_physical_cpu_count():
     Hyperthreading makes that number harder to interpret.
 
     """
-    import os, platform, subprocess, re
+    import os
+    import platform
+    import subprocess
 
     if platform.system() == "Darwin":
         os.environ['PATH'] = os.environ['PATH'] + os.pathsep + '/usr/sbin'
@@ -548,7 +554,7 @@ def benchmark_2d_ffts(mode='poppy', max_pow=13, verbose=False, savefig=False):
                             poppy_mklfft: "poppy using MKL FFT"}
         title = 'full poppy.accel_math.fft_2d'
     else:
-        raise ValueError(f"Unknown/invalid value for 'base' parameter: {base}")
+        raise ValueError(f"Unknown/invalid value for 'mode' parameter: {mode}")
 
     def shp(len):
         return (len, len)
@@ -595,9 +601,10 @@ def benchmark_2d_mfts(max_pow=13, savefig=False):
     """
 
     # modified based on https://github.com/numpy/numpy/issues/17839#issuecomment-733543850
+    import functools
+
     from simple_benchmark import benchmark
 
-    import functools
     import poppy
 
     def shp(len):
@@ -638,7 +645,7 @@ def benchmark_2d_mfts(max_pow=13, savefig=False):
     plt.title(f"Matrix Fourier Transform timings\n{cpu_label}", fontweight='bold')
 
     if savefig:
-        plt.savefig(f"bench_mfts.png")
+        plt.savefig("bench_mfts.png")
 
 
 def is_on_gpu(array):

--- a/poppy/active_optics.py
+++ b/poppy/active_optics.py
@@ -1,5 +1,5 @@
-import numpy as np
 import astropy.units as u
+
 import poppy
 
 # active optics classes

--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -1,19 +1,18 @@
 # Code for modeling deformable mirrors
 # By Neil Zimmerman based on Marshall's dms.py in the gpipsfs repo
 
-import numpy as np
-import matplotlib.pyplot as plt
-import scipy.ndimage.interpolation
-import scipy.signal
+import logging
+from abc import ABC
+
 import astropy.io.fits as fits
 import astropy.units as u
-from abc import ABC, abstractmethod
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.ndimage.interpolation
+import scipy.signal
 
-from . import utils, accel_math, poppy_core, optics
-
-from .accel_math import xp, _scipy
-
-import logging
+from . import accel_math, optics, poppy_core, utils
+from .accel_math import _scipy, xp
 
 _log = logging.getLogger('poppy')
 
@@ -236,7 +235,7 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
         if xp.isscalar(new_surface.value):
             self._surface[:] = new_surface.to(u.meter).value
         else:
-            assert new_surface.shape == self._surface.shape, "Supplied surface shape doesn't match DM. Must be {}".format(self._surface.shape)
+            assert new_surface.shape == self._surface.shape, f"Supplied surface shape doesn't match DM. Must be {self._surface.shape}"
             self._surface[:] = xp.asarray(new_surface.to(u.meter).value, dtype=float)
 
     @utils.quantity_input(new_value=u.meter)
@@ -259,7 +258,7 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
 
         if self.include_actuator_mask:
             if not self.actuator_mask[acty, actx]:
-                raise RuntimeError("Actuator ({}, {}) is masked out for that DM.".format(actx, acty))
+                raise RuntimeError(f"Actuator ({actx}, {acty}) is masked out for that DM.")
 
         if actx < 0 or actx > self.dm_shape[1] - 1:
             raise ValueError("X axis coordinate is out of range")
@@ -401,7 +400,7 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
         interpolated_surface = xp.zeros(wave.shape)
 
         crosstalk = 0.15  # amount of crosstalk on adjacent actuator
-        sigma = self.actuator_spacing.to(u.meter).value / np.sqrt((-np.log(crosstalk)))
+        sigma = self.actuator_spacing.to(u.meter).value / np.sqrt(-np.log(crosstalk))
 
         pixelscale = x[0, 1] - x[0, 0]  # scale of x,y
 
@@ -676,7 +675,7 @@ class ContinuousDeformableMirror(optics.AnalyticOpticalElement):
             act_space_m = self.actuator_spacing.to(u.meter).value
             r = np.linspace(0, 4 * act_space_m, 50)
             crosstalk = 0.15  # amount of crosstalk on adjacent actuator
-            sigma = act_space_m / np.sqrt((-np.log(crosstalk)))
+            sigma = act_space_m / np.sqrt(-np.log(crosstalk))
             plt.plot(r, np.exp(- (r / sigma) ** 2))
             plt.xlabel('Separation [m]')
             for i in range(4):
@@ -739,7 +738,7 @@ class SegmentedDeformableMirror(ABC):
         """
 
         if segnum not in self.segmentlist:
-            raise ValueError("Segment {} is not present for this DM instance.".format(segnum))
+            raise ValueError(f"Segment {segnum} is not present for this DM instance.")
         self._surface[segnum] = xp.array([piston.to(u.meter).value,
                                           tip.to(u.radian).value,
                                           tilt.to(u.radian).value])
@@ -769,7 +768,7 @@ class SegmentedDeformableMirror(ABC):
         self._seg_mask = self.transmission
         self._transmission = xp.asarray(self._seg_mask != 0, dtype=float)
 
-        y, x = self.get_coordinates((wave))
+        y, x = self.get_coordinates(wave)
 
         for i in self.segmentlist:
             wseg = xp.where(self._seg_mask == i+1)

--- a/poppy/fresnel.py
+++ b/poppy/fresnel.py
@@ -1,13 +1,14 @@
-import numpy as np
-import matplotlib.pyplot as plt
-import astropy.units as u
 import logging
 import time
 
+import astropy.units as u
+import matplotlib.pyplot as plt
+import numpy as np
+
 import poppy
-from poppy.poppy_core import PlaneType, Wavefront, BaseWavefront, BaseOpticalSystem, FITSOpticalElement
-from . import utils
-from . import accel_math
+from poppy.poppy_core import BaseOpticalSystem, BaseWavefront, FITSOpticalElement, PlaneType, Wavefront
+
+from . import accel_math, utils
 from .accel_math import xp
 
 if accel_math._NUMEXPR_AVAILABLE:
@@ -64,8 +65,8 @@ class QuadPhase(poppy.optics.AnalyticOpticalElement):
         """
 
         y, x = self.get_coordinates(wave)
-        _log.debug("Applying spherical phase curvature ={0:0.2e}".format(self.z))
-        _log.debug("Applying spherical lens phase ={0:0.2e}".format(1.0 / self.z))
+        _log.debug(f"Applying spherical phase curvature ={self.z:0.2e}")
+        _log.debug(f"Applying spherical lens phase ={1.0 / self.z:0.2e}")
         z = self._z_m  # numexpr can't evaluate self.
         if (z == np.inf) | (z == -np.inf):
             # Phasor should be 1
@@ -99,7 +100,7 @@ class _QuadPhaseShifted(QuadPhase):
         wave : object
             FresnelWavefront instance
         """
-        return accel_math._fftshift(super(_QuadPhaseShifted, self).get_phasor(wave))
+        return accel_math._fftshift(super().get_phasor(wave))
 
 
 class QuadraticLens(QuadPhase):
@@ -131,10 +132,10 @@ class QuadraticLens(QuadPhase):
                            name=name,
                            **kwargs)
         self.fl = f_lens.to(u.m)
-        _log.debug("Initialized: " + self.name + ", fl ={0:0.2e}".format(self.fl))
+        _log.debug("Initialized: " + self.name + f", fl ={self.fl:0.2e}")
 
     def __str__(self):
-        return "Lens: {0}, with focal length {1}".format(self.name, self.fl)
+        return f"Lens: {self.name}, with focal length {self.fl}"
 
 
 class ConicLens(poppy.optics.CircularAperture):
@@ -162,7 +163,7 @@ class ConicLens(poppy.optics.CircularAperture):
         planetype : poppy.PlaneType, optional
             Optional optical plane type specifier
         """
-        super(ConicLens, self).__init__(name=name, radius=radius.to(u.m).value, planetype=planetype, **kwargs)
+        super().__init__(name=name, radius=radius.to(u.m).value, planetype=planetype, **kwargs)
         self.f_lens = f_lens
         self.K = K
 
@@ -242,11 +243,11 @@ class FixedSamplingImagePlaneElement(FITSOpticalElement):
         self.pixelscale_lamD = self.pixelscale.to(u.radian/u.pix).value/(self.wavelength_c/self.entrance_pupil_diam)
 
         _log.debug(
-            "FixedSamplingImagePlaneElement {} initialized:"
-            "centering style {}, "
-            "central wavelength for operation {}, "
-            "entrance pupil diameter of system {}, "
-            "pixelscale of {} arcsec/pix.".format(self.name, self.centering, self.wavelength_c, self.entrance_pupil_diam, self.pixelscale.value)
+            f"FixedSamplingImagePlaneElement {self.name} initialized:"
+            f"centering style {self.centering}, "
+            f"central wavelength for operation {self.wavelength_c}, "
+            f"entrance pupil diameter of system {self.entrance_pupil_diam}, "
+            f"pixelscale of {self.pixelscale.value} arcsec/pix."
         )
 
 
@@ -299,7 +300,7 @@ class FresnelWavefront(BaseWavefront):
         - Andersen, T., and A. Enmark (2011), Integrated Modeling of Telescopes, Springer Science & Business Media.
 
         """
-        super(FresnelWavefront, self).__init__(
+        super().__init__(
             diam=beam_radius.to(u.m).value * 2.0,
             oversample=oversample,
             **kwargs
@@ -335,10 +336,7 @@ class FresnelWavefront(BaseWavefront):
         if self.oversample > 1 and not self.ispadded:  # add padding for oversampling, if necessary
             self.wavefront = utils.pad_to_oversample(self.wavefront, self.oversample)
             self.ispadded = True
-            logmsg = "Padded WF array for oversampling by {0:.3f}, to {1}.".format(
-                self.oversample,
-                self.wavefront.shape
-            )
+            logmsg = f"Padded WF array for oversampling by {self.oversample:.3f}, to {self.wavefront.shape}."
             _log.debug(logmsg)
 
             self.history.append(logmsg)
@@ -366,7 +364,7 @@ class FresnelWavefront(BaseWavefront):
     def display(self, *args, **kwargs):
         if 'use_angular_coordinates' not in kwargs:
             # Is this FresnelWavefront in angular units?
-            return super(FresnelWavefront, self).display(
+            return super().display(
                 *args,
                 use_angular_coordinates=self.angular_coordinates,
                 **kwargs
@@ -378,7 +376,7 @@ class FresnelWavefront(BaseWavefront):
             # appropriate for displaying that type.
             tmp = self.angular_coordinates
             self.angular_coordinates = kwargs['use_angular_coordinates']
-            retval = super(FresnelWavefront, self).display(
+            retval = super().display(
                 *args, **kwargs
             )
             self.angular_coordinates = tmp
@@ -415,8 +413,8 @@ class FresnelWavefront(BaseWavefront):
         """
         Formatted string of gaussian beam parameters.
         """
-        string = "w_0:{0:0.3e},".format(self.w_0) + " z_w0={0:0.3e}".format(self.z_w0) + "\n" + \
-                 "z={0:0.3e},".format(self.z) + " z_r={0:0.3e}".format(self.z_r)
+        string = f"w_0:{self.w_0:0.3e}," + f" z_w0={self.z_w0:0.3e}" + "\n" + \
+                 f"z={self.z:0.3e}," + f" z_r={self.z_r:0.3e}"
         return string
 
     @property
@@ -549,7 +547,7 @@ class FresnelWavefront(BaseWavefront):
             if not np.isfinite(self.focal_length.value):
                 raise ValueError("Cannot convert to angular units for a beam with infinite focal length")
             platescale = (1 * u.radian / self.focal_length).to(u.arcsec / u.m)
-            _log.debug("Converting to angular coords using plate scale = {}".format(platescale))
+            _log.debug(f"Converting to angular coords using plate scale = {platescale}")
             y *= platescale.value
             x *= platescale.value
 
@@ -601,7 +599,7 @@ class FresnelWavefront(BaseWavefront):
         k = np.pi * 2.0 / self.wavelength.to(u.meter).value
         s = self.n * u.pix * self.pixelscale  # S is "simulation size" and has length of meters
         _log.debug(
-            "Propagation Parameters: k={0:0.2e},".format(k) + "S={0:0.2e},".format(s) + "z={0:0.2e},".format(z_direct))
+            f"Propagation Parameters: k={k:0.2e}," + f"S={s:0.2e}," + f"z={z_direct:0.2e},")
 
         # TODO the following exponential code could be accelerated with numexpr
         quadphase_1st = xp.exp(1.0j * k * (x ** 2 + y ** 2) / (2 * z_direct))  # eq. 6.68
@@ -627,7 +625,7 @@ class FresnelWavefront(BaseWavefront):
 
         self.pixelscale = self.wavelength * abs(z) / s / u.pix
         self.wavefront = result
-        self.history.append("Direct propagation to z= {0:0.2e}".format(z))
+        self.history.append(f"Direct propagation to z= {z:0.2e}")
         self.z += z
 
     @utils.quantity_input(distance=u.meter)
@@ -651,7 +649,7 @@ class FresnelWavefront(BaseWavefront):
         distance : astropy.Quantity of dimension length
             separation distance of this optic relative to the prior optic in the system.
         """
-        msg = "  Propagating wavefront to {0} after distance {1} ".format(str(optic), distance)
+        msg = f"  Propagating wavefront to {str(optic)} after distance {distance} "
         _log.debug(msg)
         self.history.append(msg)
         self.angular_coordinates = False  # coordinates must be in meters for propagation
@@ -704,7 +702,7 @@ class FresnelWavefront(BaseWavefront):
         if isinstance(dz, u.quantity.Quantity):
             z_direct = dz.to(u.m).value  # convert to meters.
         else:
-            _log.warning("z= {0:0.2e}, has no units, assuming meters ".format(dz))
+            _log.warning(f"z= {dz:0.2e}, has no units, assuming meters ")
             z_direct = dz
 
         if abs(dz) < 1 * u.Angstrom:
@@ -860,12 +858,12 @@ class FresnelWavefront(BaseWavefront):
             if self.planar_range(z):
                 # Plane waves inside planar range:  use plane-to-plane
                 _log.debug('  Plane to Plane Regime, dz=' + str(delta_z))
-                _log.debug('  Constant Pixelscale: {}'.format(self.pixelscale))
+                _log.debug(f'  Constant Pixelscale: {self.pixelscale}')
                 self._propagate_ptp(delta_z)
             else:
                 # Plane wave to spherical. First use PTP to the waist, then WTS to Spherical
                 _log.debug('  Plane to Spherical Regime, inside Z_R to outside Z_R')
-                _log.debug('  Starting Pixelscale: {}'.format(self.pixelscale))
+                _log.debug(f'  Starting Pixelscale: {self.pixelscale}')
                 self._propagate_ptp(self.z_w0 - self.z)
                 if display_intermed:
                     plt.figure()
@@ -883,9 +881,9 @@ class FresnelWavefront(BaseWavefront):
             else:
                 # Spherical to Spherical. First STW to the waist, then WTS to the desired spherical surface
                 _log.debug('  Spherical to Spherical, Outside Z_R to waist (z_w0) to outside Z_R')
-                _log.debug('  Starting Pixelscale: {}'.format(self.pixelscale))
+                _log.debug(f'  Starting Pixelscale: {self.pixelscale}')
                 self._propagate_stw(self.z_w0 - self.z)
-                _log.debug('  Intermediate Pixelscale: {}'.format(self.pixelscale))
+                _log.debug(f'  Intermediate Pixelscale: {self.pixelscale}')
 
                 if display_intermed:
                     plt.figure()
@@ -897,7 +895,7 @@ class FresnelWavefront(BaseWavefront):
 
         self.wavefront = accel_math._fftshift(self.wavefront)
         self.planetype = PlaneType.intermediate
-        _log.debug("------ Propagated to plane of type " + str(self.planetype) + " at z = {0:0.2e} ------".format(z))
+        _log.debug("------ Propagated to plane of type " + str(self.planetype) + f" at z = {z:0.2e} ------")
 
     def __imul__(self, optic):
         """Multiply a Wavefront by an OpticalElement or scalar"""
@@ -914,7 +912,7 @@ class FresnelWavefront(BaseWavefront):
             return self
         else:
             # Otherwise fall back to the parent class
-            return super(FresnelWavefront, self).__imul__(optic)
+            return super().__imul__(optic)
 
     def apply_lens_power(self, optic, ignore_wavefront=False):
         """
@@ -938,7 +936,7 @@ class FresnelWavefront(BaseWavefront):
 
         # calculate beam radius at current surface
         spot_radius = self.spot_radius()
-        _log.debug("  Beam radius at " + str(optic.name) + " ={0:0.2e}".format(spot_radius))
+        _log.debug("  Beam radius at " + str(optic.name) + f" ={spot_radius:0.2e}")
 
         # Is the incident beam planar or spherical?
         # We decided based on whether the last waist is outside the rayleigh distance.
@@ -950,15 +948,13 @@ class FresnelWavefront(BaseWavefront):
             r_input_beam = self.z - self.z_w0
             r_output_beam = 1.0 / (1.0 / self.r_c() - 1.0 / optic.fl)
             _log.debug(
-                " input curved wavefront and " + str(optic.name) + " has output beam curvature of ={0:0.2e}".format(
-                    r_output_beam))
+                " input curved wavefront and " + str(optic.name) + f" has output beam curvature of ={r_output_beam:0.2e}")
         else:
             r_input_beam = np.inf * u.m
             # we are at a focus or pupil, so the new optic is the only curvature of the beam
             r_output_beam = -1 * optic.fl
             _log.debug(
-                " input flat wavefront and " + str(optic.name) + " has output beam curvature of ={0:0.2e}".format(
-                    r_output_beam))
+                " input flat wavefront and " + str(optic.name) + f" has output beam curvature of ={r_output_beam:0.2e}")
 
         # update the wavefront parameters to the post-lens beam waist
         if self.r_c() == optic.fl:
@@ -969,8 +965,8 @@ class FresnelWavefront(BaseWavefront):
             self.z_w0 = -r_output_beam / (
                 1.0 + (self.wavelength * r_output_beam / (np.pi * spot_radius ** 2)) ** 2) + self.z
             self.w_0 = spot_radius / np.sqrt(1.0 + (np.pi * spot_radius ** 2 / (self.wavelength * r_output_beam)) ** 2)
-            _log.debug(str(optic.name) + " has a curvature of ={0:0.2e}".format(r_output_beam))
-            _log.debug(str(optic.name) + " has a curved output wavefront, with waist at {}".format(self.z_w0))
+            _log.debug(str(optic.name) + f" has a curvature of ={r_output_beam:0.2e}")
+            _log.debug(str(optic.name) + f" has a curved output wavefront, with waist at {self.z_w0}")
 
         _log.debug("Post Optic Parameters:" + self.param_str)
 
@@ -979,13 +975,13 @@ class FresnelWavefront(BaseWavefront):
         # of coordinates to angular units.
         if not np.isfinite(self.focal_length):
             self.focal_length = 1 * optic.fl
-            _log.debug("Set output beam focal length to {}".format(self.focal_length))
+            _log.debug(f"Set output beam focal length to {self.focal_length}")
         else:
             # determine magnification as the change in curvature of this optic
             mag = r_output_beam / r_input_beam
             self.focal_length *= mag
-            _log.debug("Magnification: {}  from R_in = {}, R_out = {}".format(mag, r_input_beam, r_output_beam))
-            _log.debug("Output beam focal length is now {}".format(self.focal_length))
+            _log.debug(f"Magnification: {mag}  from R_in = {r_input_beam}, R_out = {r_output_beam}")
+            _log.debug(f"Output beam focal length is now {self.focal_length}")
 
         self.waists_z.append(self.z_w0.to(u.m).value)
         self.waists_w0.append(self.w_0.to(u.m).value)
@@ -1021,9 +1017,9 @@ class FresnelWavefront(BaseWavefront):
         else:  # spherical input wavefront
             if abs(self.z_w0 - self.z) > self.z_r:
                 _log.debug('Spherical to Spherical wavefront propagation.')
-                _log.debug("1/fl={0:0.4e}".format(1.0 / optic.fl))
-                _log.debug("1.0/(R_input_beam)={0:0.4e}".format(1.0 / r_input_beam))
-                _log.debug("1.0/(self.z-self.z_w0)={0:0.4e}".format(1.0 / (self.z - self.z_w0)))
+                _log.debug(f"1/fl={1.0 / optic.fl:0.4e}")
+                _log.debug(f"1.0/(R_input_beam)={1.0 / r_input_beam:0.4e}")
+                _log.debug(f"1.0/(self.z-self.z_w0)={1.0 / (self.z - self.z_w0):0.4e}")
 
                 if (self.z - self.z_w0) == 0:
                     z_eff = 1.0 / (1.0 / optic.fl + 1.0 / (self.z - self.z_w0))
@@ -1060,8 +1056,8 @@ class FresnelWavefront(BaseWavefront):
         scale = 2. * np.pi / self.wavelength.to(u.meter).value
         if accel_math._USE_NUMEXPR:
             _log.debug("Calculating FPM phasor from numexpr.")
-            trans = optic.get_transmission(self)
-            opd = optic.get_opd(self)
+            trans = optic.get_transmission(self)  # noqa: F841
+            opd = optic.get_opd(self)   # noqa: F841
             fpm_phasor = ne.evaluate("trans * exp(1j * opd * scale)")
         else:
             _log.debug("Calculating FPM phasor with Numpy/CuPy.")
@@ -1109,11 +1105,11 @@ class FresnelWavefront(BaseWavefront):
 
         if np.abs(pixscale_ratio - 1.0) < 1e-3:
             _log.debug("Wavefront is already at desired pixel scale "
-                       "{:.4g}.  No resampling needed.".format(self.pixelscale))
+                       f"{self.pixelscale:.4g}.  No resampling needed.")
             self.wavefront = utils.pad_or_crop_to_shape(self.wavefront, detector.shape)
             return
 
-        super(FresnelWavefront, self)._resample_wavefront_pixelscale(detector)
+        super()._resample_wavefront_pixelscale(detector)
 
         self.n = detector.shape[0]
 
@@ -1149,7 +1145,7 @@ class FresnelWavefront(BaseWavefront):
         # Deal with metadata
         new_wf.history = wf.history.copy()
         new_wf.history.append("Converted to Fresnel propagation")
-        new_wf.history.append("  Fresnel array pixel scale = {:.4g}, oversample = {}".format(new_wf.pixelscale, new_wf.oversample))
+        new_wf.history.append(f"  Fresnel array pixel scale = {new_wf.pixelscale:.4g}, oversample = {new_wf.oversample}")
         # Copy over the contents of the array
         new_wf.wavefront = utils.pad_to_size(wf.wavefront, new_wf.shape)
         # Copy over misc internal info
@@ -1187,7 +1183,7 @@ class FresnelOpticalSystem(BaseOpticalSystem):
     @u.quantity_input(pupil_diameter=u.m)
     def __init__(self, name="unnamed system", pupil_diameter=1 * u.m,
                  npix=1024, beam_ratio=0.5, verbose=True):
-        super(FresnelOpticalSystem, self).__init__(name=name, verbose=verbose)
+        super().__init__(name=name, verbose=verbose)
         self.pupil_diameter = pupil_diameter
         self.beam_ratio = beam_ratio
         del self.oversample  # use beam_ratio instead for fresnel systems
@@ -1219,7 +1215,7 @@ class FresnelOpticalSystem(BaseOpticalSystem):
             self.distances.insert(index, distance.to(u.m))
 
         if self.verbose:
-            _log.info("Added optic: {0} after separation: {1:.2e} ".format(self.planes[-1].name, distance))
+            _log.info(f"Added optic: {self.planes[-1].name} after separation: {distance:.2e} ")
 
         return optic
 
@@ -1238,10 +1234,10 @@ class FresnelOpticalSystem(BaseOpticalSystem):
             separation distance of this optic relative to the prior optic in the system.
 
         """
-        super(FresnelOpticalSystem, self).add_detector(pixelscale=pixelscale, fov_pixels=fov_pixels)
+        super().add_detector(pixelscale=pixelscale, fov_pixels=fov_pixels)
         self.distances.append(distance)
         if self.verbose:
-            _log.info("Added detector: {0} after separation: {1:.2e} ".format(self.planes[-1].name, distance))
+            _log.info(f"Added detector: {self.planes[-1].name} after separation: {distance:.2e} ")
 
     @utils.quantity_input(wavelength=u.meter)
     def input_wavefront(self, wavelength=1e-6 * u.meter, inwave=None):
@@ -1270,8 +1266,7 @@ class FresnelOpticalSystem(BaseOpticalSystem):
         else:
             raise ValueError("Input wavefront must be a FresnelWavefront() object or None, when using FresnelOpticalSystem().")
 
-        _log.debug("Input wavefront has wavelength={0} microns, npix={1}, diam={3}, pixel scale={2}".format(
-            wavelength.to(u.micron).value, self.npix, self.pupil_diameter / (self.npix * u.pixel), self.pupil_diameter))
+        _log.debug(f"Input wavefront has wavelength={wavelength.to(u.micron).value} microns, npix={self.npix}, diam={self.pupil_diameter}, pixel scale={self.pupil_diameter / (self.npix * u.pixel)}")
         inwave._display_hint_expected_nplanes = len(self)     # For displaying a multi-step calculation nicely
         return inwave
 
@@ -1310,7 +1305,7 @@ class FresnelOpticalSystem(BaseOpticalSystem):
                 if wavefront.current_plane_index == last_pupil_plane_index:
                     wavefront.normalize()
                     _log.debug(
-                        "normalizing at exit pupil (plane {0}) to 1.0 total intensity".format(wavefront.current_plane_index))
+                        f"normalizing at exit pupil (plane {wavefront.current_plane_index}) to 1.0 total intensity")
             elif normalize.lower() == 'last' and wavefront.current_plane_index == len(self.planes):
                 wavefront.normalize()
                 _log.debug("normalizing at last plane to 1.0 total intensity")
@@ -1348,12 +1343,11 @@ class FresnelOpticalSystem(BaseOpticalSystem):
     def describe(self):
         """ Print out a string table describing all planes in an optical system"""
         res = (str(self) +
-               "\n\tEntrance pupil diam:  {0}\tnpix: {1}\tBeam ratio:{2}".format(self.pupil_diameter, self.npix,
-                                                                                 self.beam_ratio))
+               f"\n\tEntrance pupil diam:  {self.pupil_diameter}\tnpix: {self.npix}\tBeam ratio:{self.beam_ratio}")
 
         for optic, distance in zip(self.planes, self.distances):
             if distance != 0:
-                res += "\n\tPropagation distance:  {0}".format(distance)
+                res += f"\n\tPropagation distance:  {distance}"
             res += "\n\t" + str(optic)
 
         print(res)

--- a/poppy/fwcentroid.py
+++ b/poppy/fwcentroid.py
@@ -80,7 +80,7 @@ def fwcentroid(image, checkbox=1, maxiterations=20, threshold=1e-4, halfwidth=5,
         # just use brightest pixel
         w = np.where(image == image.max())
         YPEAK, XPEAK = w[0][0], w[1][0]
-        if verbose: print("Peak pixels are {0}, {1}".format(XPEAK, YPEAK))
+        if verbose: print(f"Peak pixels are {XPEAK}, {YPEAK}")
 
     # Calculate centroid for first iteration
 
@@ -123,7 +123,7 @@ def fwcentroid(image, checkbox=1, maxiterations=20, threshold=1e-4, halfwidth=5,
     oldXCEN = XCEN
     oldYCEN = YCEN
 
-    if verbose: print("After initial calc, cent pos is  ({0:f}, {1:f})".format(XCEN, YCEN))
+    if verbose: print(f"After initial calc, cent pos is  ({XCEN:f}, {YCEN:f})")
 
     # Iteratively calculate centroid until solution converges,
     # use more neighboring pixels and apply weighting:
@@ -185,7 +185,7 @@ def fwcentroid(image, checkbox=1, maxiterations=20, threshold=1e-4, halfwidth=5,
         # XCEN += oldXCEN -XHW-1
         # YCEN += oldYCEN -YHW-1   #this would be equivalent to removing the XLOC lines?
 
-        if verbose: print("After iter {0} , cent pos is  ({1:f}, {2:f})".format(k, XCEN, YCEN))
+        if verbose: print(f"After iter {k} , cent pos is  ({XCEN:f}, {YCEN:f})")
         # Check for convergence:
         if (np.abs(XCEN - oldXCEN) <= threshold and
                 np.abs(YCEN - oldYCEN) <= threshold):
@@ -225,9 +225,7 @@ def test_fwcentroid(n=100, width=5, halfwidth=5, verbose=True, **kwargs):
     maxhalfwidth = np.max(halfwidth)  # allows both scalars and tuples
 
     if verbose: print(
-        "Performing {0} tests using Gaussian PSF with width={1:.1f}, centroid halfwidth= {2:s}".format(n,
-                                                                                                       width,
-                                                                                                       str(halfwidth)))
+        f"Performing {n} tests using Gaussian PSF with width={width:.1f}, centroid halfwidth= {str(halfwidth):s}")
 
     diffx = np.zeros(n)
     diffy = np.zeros(n)
@@ -240,13 +238,11 @@ def test_fwcentroid(n=100, width=5, halfwidth=5, verbose=True, **kwargs):
         diffx[i] = coords[0] - measx
         diffy[i] = coords[1] - measy
 
-        if verbose: print("True: {0},{1}     Meas: {2},{3}    Diff:{4},{5}".format(coords[0], coords[1],
-                                                                                   measx, measy,
-                                                                                   diffx[i], diffy[i]))
+        if verbose: print(f"True: {coords[0]},{coords[1]}     Meas: {measx},{measy}    Diff:{diffx[i]},{diffy[i]}")
 
     if verbose:
-        print("RMS measured position error, X: {0} pixels".format(diffx.std()))
-        print("RMS measured position error, Y: {0} pixels".format(diffy.std()))
+        print(f"RMS measured position error, X: {diffx.std()} pixels")
+        print(f"RMS measured position error, Y: {diffy.std()} pixels")
 
     assert np.sqrt(np.mean(diffx ** 2 + diffy ** 2)) < 5e-3
 

--- a/poppy/geometry.py
+++ b/poppy/geometry.py
@@ -8,10 +8,12 @@ import numpy as np
 
 from . import accel_math
 from .accel_math import xp
+
 if accel_math._NUMEXPR_AVAILABLE:
     import numexpr as ne
 
 import logging
+
 _log = logging.getLogger('poppy')
 
 

--- a/poppy/instrument.py
+++ b/poppy/instrument.py
@@ -3,7 +3,9 @@ import os
 import platform
 import re
 import time
+
 import astropy.io.fits as fits
+import astropy.time
 import astropy.units as units
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,19 +19,16 @@ except ImportError:
     synphot = None
     _HAS_SYNPHOT = False
 
-from . import poppy_core
-from . import optics
-from . import utils
-from . import conf
-
 import logging
+
+from . import conf, optics, poppy_core, utils
 
 _log = logging.getLogger('poppy')
 
 __all__ = ['Instrument']
 
 
-class Instrument(object):
+class Instrument:
     """ A generic astronomical instrument, composed of
         (1) an optical system implemented using POPPY, optionally with several configurations such as
             selectable image plane or pupil plane stops, and
@@ -131,7 +130,7 @@ class Instrument(object):
     def filter(self, value):
         value = value.upper()  # force to uppercase
         if value not in self.filter_list:
-            raise ValueError("Instrument %s doesn't have a filter called %s." % (self.name, value))
+            raise ValueError(f"Instrument {self.name} doesn't have a filter called {value}.")
         self._filter = value
 
     # ----- actual optical calculations follow here -----
@@ -215,15 +214,15 @@ class Instrument(object):
             fov_arcsec = self._get_default_fov()
         if fov_pixels is not None:
             if np.isscalar(fov_pixels):
-                fov_spec = 'pixels = %d' % fov_pixels
+                fov_spec = f'pixels = {fov_pixels}'
             else:
-                fov_spec = 'pixels = (%d, %d)' % (fov_pixels[0], fov_pixels[1])
+                fov_spec = f'pixels = ({fov_pixels[0]}, {fov_pixels[1]})'
             local_options['fov_pixels'] = fov_pixels
         elif fov_arcsec is not None:
             if np.isscalar(fov_arcsec):
-                fov_spec = 'arcsec = %f' % fov_arcsec
+                fov_spec = f'arcsec = {fov_arcsec:f}'
             else:
-                fov_spec = 'arcsec = (%.3f, %.3f)' % (fov_arcsec[0], fov_arcsec[1])
+                fov_spec = f'arcsec = ({fov_arcsec[0]:.3f}, {fov_arcsec[1]:.3f})'
             local_options['fov_arcsec'] = fov_arcsec
         local_options['fov_spec'] = fov_spec
 
@@ -250,9 +249,7 @@ class Instrument(object):
         # Validate that the calculation we're about to do makes sense with this instrument config
         self._validate_config(wavelengths=wavelens)
         poppy_core._log.info(
-            "PSF calc using fov_%s, oversample = %d, number of wavelengths = %d" % (
-                local_options['fov_spec'], local_options['detector_oversample'], len(wavelens)
-            )
+            f"PSF calc using fov_{local_options['fov_spec']}, oversample = {local_options['detector_oversample']}, number of wavelengths = {len(wavelens)}"
         )
 
         # ---- now at last, actually do the PSF calc:
@@ -278,13 +275,12 @@ class Instrument(object):
 
         if display:
             f = plt.gcf()
-            plt.suptitle("%s, filter= %s" % (self.name, self.filter), size='xx-large')
+            plt.suptitle(f"{self.name}, filter= {self.filter}", size='xx-large')
 
             if monochromatic is not None:
-                labeltext = "Monochromatic calculation at {:.3f} um".format(monochromatic * 1e6)
+                labeltext = f"Monochromatic calculation at {monochromatic * 1e6:.3f} um"
             else:
-                labeltext = "Calculation with %d wavelengths (%g - %g um)" % (
-                    nlambda, wavelens[0] * 1e6, wavelens[-1] * 1e6)
+                labeltext = f"Calculation with {nlambda} wavelengths ({wavelens[0] * 1e6:g} - {wavelens[-1] * 1e6:g} um)" 
             plt.text(0.99, 0.04, labeltext,
                      transform=f.transFigure, horizontalalignment='right')
 
@@ -323,9 +319,9 @@ class Instrument(object):
         # header keys can only have up to 8 characters. Backward-compatible.
         nwavelengths = len(wavelengths)
         if nwavelengths < 100:
-            label_wl = lambda i: 'WAVELN{:02d}'.format(i)
+            label_wl = lambda i: f'WAVELN{i:02d}'
         elif nwavelengths < 10000:
-            label_wl = lambda i: 'WVLN{:04d}'.format(i)
+            label_wl = lambda i: f'WVLN{i:04d}'
         else:
             raise ValueError("Maximum number of wavelengths exceeded. "
                              "Cannot be more than 10,000.")
@@ -355,7 +351,7 @@ class Instrument(object):
             for ext in range(len(psf)):
                 cube[ext].data[i] = psf[ext].data
                 cube[ext].header[label_wl(i)] = wavelength_as_meters(wl)
-                cube[ext].header.add_history("--- Cube Plane {} ---".format(i))
+                cube[ext].header.add_history(f"--- Cube Plane {i} ---")
                 for h in psf[ext].header['HISTORY']:
                     cube[ext].header.add_history(h)
 
@@ -389,14 +385,14 @@ class Instrument(object):
         if (output_mode == 'Oversampled image') or ('oversampled' in output_mode.lower()):
             # we just want to output the oversampled image as
             # the primary HDU. Nothing special needs to be done.
-            poppy_core._log.info(" Returning only the oversampled data. Oversampled by {}".format(detector_oversample))
+            poppy_core._log.info(f" Returning only the oversampled data. Oversampled by {detector_oversample}")
             return
 
         elif (output_mode == 'Detector sampled image') or ('detector' in output_mode.lower()):
             # output only the detector sampled image as primary HDU.
             # need to downsample it and replace the existing primary HDU
             if options['detector_oversample'] > 1:
-                poppy_core._log.info(" Downsampling to detector pixel scale, by {}".format(detector_oversample))
+                poppy_core._log.info(f" Downsampling to detector pixel scale, by {detector_oversample}")
                 for ext in range(len(result)):
                     result[ext].data = utils.rebin_array(result[ext].data,
                                                          rc=(detector_oversample, detector_oversample))
@@ -420,7 +416,7 @@ class Instrument(object):
             for ext in np.arange(len(result)):
                 rebinned_result = result[ext].copy()
                 if options['detector_oversample'] > 1:
-                    poppy_core._log.info(" Downsampling to detector pixel scale, by {}".format(detector_oversample))
+                    poppy_core._log.info(f" Downsampling to detector pixel scale, by {detector_oversample}")
                     rebinned_result.data = utils.rebin_array(rebinned_result.data,
                                                              rc=(detector_oversample, detector_oversample))
 
@@ -485,7 +481,7 @@ class Instrument(object):
             opdfile = str(self.pupilopd)
             opdslice = 0
         else:  # tuple?
-            opdstring = "%s slice %d" % (os.path.basename(self.pupilopd[0]), self.pupilopd[1])
+            opdstring = f"{os.path.basename(self.pupilopd[0])} slice {self.pupilopd[1]}"
             opdfile = os.path.basename(self.pupilopd[0])
             opdslice = self.pupilopd[1]
         result[0].header['PUPILOPD'] = (opdstring, 'Pupil OPD source')
@@ -503,13 +499,11 @@ class Instrument(object):
             result[0].header['DET_SAMP'] = (
                 options['detector_oversample'], 'Oversampling factor for MFT to detector plane')
 
-        (year, month, day, hour, minute, second, weekday, doy, dst) = time.gmtime()
-        result[0].header["DATE"] = (
-            "%4d-%02d-%02dT%02d:%02d:%02d" % (year, month, day, hour, minute, second), "Date of calculation")
+        result[0].header["DATE"] = (astropy.time.Time.now().isot, "Date of calculation")
         # get username and hostname in a cross-platform way
         username = getpass.getuser()
         hostname = platform.node()
-        result[0].header["AUTHOR"] = ("%s@%s" % (username, hostname), "username@host for calculation")
+        result[0].header["AUTHOR"] = (f"{username}@{hostname}", "username@host for calculation")
 
     def _validate_config(self, wavelengths=None):
         """Determine if a provided instrument configuration is valid.
@@ -562,7 +556,7 @@ class Instrument(object):
         if options is None:
             options = dict()
 
-        poppy_core._log.debug("Oversample: %d  %d " % (fft_oversample, detector_oversample))
+        poppy_core._log.debug(f"Oversample: {fft_oversample}  {detector_oversample} ")
         optsys = poppy_core.OpticalSystem(name=self.name, oversample=fft_oversample)
 
         if 'source_offset_x' in options or 'source_offset_y' in options:
@@ -573,15 +567,13 @@ class Instrument(object):
             offy = options.get('source_offset_y', 0)
             optsys.source_offset_r = np.sqrt(offx ** 2 + offy ** 2)
             optsys.source_offset_theta = np.rad2deg(np.arctan2(-offx, offy))
-            _log.debug("Source offset from X,Y = ({}, {}) is (r,theta) = {},{}".format(
-                offx, offy, optsys.source_offset_r, optsys.source_offset_theta))
+            _log.debug(f"Source offset from X,Y = ({offx}, {offy}) is (r,theta) = {optsys.source_offset_r},{optsys.source_offset_theta}")
         else:
             if 'source_offset_r' in options:
                 optsys.source_offset_r = options['source_offset_r']
             if 'source_offset_theta' in options:
                 optsys.source_offset_theta = options['source_offset_theta']
-            _log.debug("Source offset is (r,theta) = {},{}".format(
-                optsys.source_offset_r, optsys.source_offset_theta))
+            _log.debug(f"Source offset is (r,theta) = {optsys.source_offset_r},{optsys.source_offset_theta}")
 
         # ---- set pupil intensity
         pupil_optic = None  # no optic yet defined
@@ -592,7 +584,7 @@ class Instrument(object):
             if os.path.exists(self.pupil):
                 full_pupil_path = self.pupil
             else:
-                raise IOError("File not found: " + self.pupil)
+                raise OSError("File not found: " + self.pupil)
         elif isinstance(self.pupil, fits.HDUList):  # pupil supplied as FITS HDUList object
             full_pupil_path = self.pupil
         else:
@@ -750,13 +742,13 @@ class Instrument(object):
 
             # that will be in arcseconds, we need to convert to pixels:
 
-            poppy_core._log.info("Jitter: Convolving with Gaussian with sigma={0:.3f} arcsec".format(sigma))
+            poppy_core._log.info(f"Jitter: Convolving with Gaussian with sigma={sigma:.3f} arcsec")
             out = scipy.ndimage.gaussian_filter(result[0].data, sigma / result[0].header['PIXELSCL'])
             peak = result[0].data.max()
             newpeak = out.max()
             strehl = newpeak / peak  # not really the whole Strehl ratio, just the part due to jitter
 
-            poppy_core._log.info("        resulting image peak drops to {0:.3f} of its previous value".format(strehl))
+            poppy_core._log.info(f"        resulting image peak drops to {strehl:.3f} of its previous value")
             result[0].header['JITRTYPE'] = ('Gaussian convolution', 'Type of jitter applied')
             result[0].header['JITRSIGM'] = (sigma, 'Gaussian sigma for jitter, per axis [arcsec]')
             result[0].header['JITRSTRL'] = (strehl, 'Strehl reduction from jitter ')
@@ -767,7 +759,7 @@ class Instrument(object):
 
         if conf.enable_speed_tests: # pragma: no cover
             t1 = time.time()
-            _log.debug("\tTIME %f s\t for jitter model" % (t1 - t0))
+            _log.debug(f"\tTIME {t1 - t0} s\t for jitter model")
 
 
     #####################################################
@@ -892,11 +884,10 @@ class Instrument(object):
             Because this calculation is kind of slow, cache results for reuse in the frequent
             case where one is computing many PSFs for the same spectral source.
             """
-            from synphot import SpectralElement, Observation
-            from synphot.models import Box1D, BlackBodyNorm1D, Empirical1D
+            from synphot import Observation, SpectralElement
+            from synphot.models import BlackBodyNorm1D, Box1D, Empirical1D
 
-            poppy_core._log.debug(
-                "Calculating spectral weights using synphot, nlambda=%d, source=%s" % (nlambda, str(source)))
+            poppy_core._log.debug( f"Calculating spectral weights using synphot, nlambda={nlambda}, source={source!s}")
             if source is None:
                 source = synphot.SourceSpectrum(BlackBodyNorm1D, temperature=5700 * units.K)
                 poppy_core._log.info("No source spectrum supplied, therefore defaulting to 5700 K blackbody")
@@ -910,7 +901,7 @@ class Instrument(object):
             except KeyError:
                 pass  # in case sourcespectrum lacks a name element so the above lookup fails - just do the below calc.
 
-            poppy_core._log.info("Computing wavelength weights using synthetic photometry for %s..." % self.filter)
+            poppy_core._log.info(f"Computing wavelength weights using synthetic photometry for {self.filter}...")
             band = self._get_synphot_bandpass(self.filter)
             band_wave = band.waveset
             band_thru = band(band_wave)
@@ -929,8 +920,7 @@ class Instrument(object):
 
             minwave = band_wave[w_above10].min()
             maxwave = band_wave[w_above10].max()
-            poppy_core._log.debug("Min, max wavelengths = %f, %f" % (
-                minwave.to_value(units.micron), maxwave.to_value(units.micron)))
+            poppy_core._log.debug(f"Min, max wavelengths = {minwave.to_value(units.micron):f}, {maxwave.to_value(units.micron):f}")
 
             wave_bin_edges = np.linspace(minwave, maxwave, nlambda + 1)
             wavesteps = (wave_bin_edges[:-1] + wave_bin_edges[1:]) / 2
@@ -983,21 +973,20 @@ class Instrument(object):
             except AttributeError:
                 raise ValueError(
                     "The supplied file, {0}, does not appear to be a FITS table with WAVELENGTH and " +
-                    "THROUGHPUT columns.".format(filterfile))
+                    "THROUGHPUT columns.")
             if 'WAVEUNIT' in filterheader:
                 waveunit = filterheader['WAVEUNIT'].lower()
                 if re.match(r'[Aa]ngstroms?', waveunit) is None:
                     raise ValueError(
                         "The supplied file, {0}, has WAVEUNIT='{1}'. Only WAVEUNIT = Angstrom supported " +
-                        "when synphot is not installed.".format(filterfile, waveunit))
+                        "when synphot is not installed.")
             else:
                 waveunit = 'Angstrom'
                 poppy_core._log.warning(
-                    "CAUTION: no WAVEUNIT keyword found in filter file {0}. Assuming = {1} by default".format(
-                        filterfile, waveunit))
+                    f"CAUTION: no WAVEUNIT keyword found in filter file {filterfile}. Assuming = {waveunit} by default")
 
             poppy_core._log.warning(
-                "CAUTION: Just interpolating rather than integrating filter profile, over {0} steps".format(nlambda))
+                f"CAUTION: Just interpolating rather than integrating filter profile, over {nlambda} steps")
             wavelengths = wavelengths * units.Unit(waveunit)
             lrange = wavelengths[throughputs > 0.4].to_value(units.m)  # convert from Angstroms to Meters
             # get evenly spaced points within the range of allowed lambdas, centered on each bin

--- a/poppy/matrixDFT.py
+++ b/poppy/matrixDFT.py
@@ -55,13 +55,15 @@
 __all__ = ['MatrixFourierTransform']
 
 import numpy as np
-from . import conf
-from . import accel_math
+
+from . import accel_math, conf
 from .accel_math import xp
+
 if accel_math._NUMEXPR_AVAILABLE:
     import numexpr as ne
 
 import logging
+
 _log = logging.getLogger('poppy')
 
 FFTSTYLE = 'FFTSTYLE'
@@ -316,18 +318,18 @@ def matrix_dft_numexpr(plane, nlamD, npix,
         dU = 1.0 / float(npixX)
         dV = 1.0 / float(npixY)
     else:
-        dU = nlamDX / float(npixX)
-        dV = nlamDY / float(npixY)
-        dX = 1.0 / float(npupX)
-        dY = 1.0 / float(npupY)
+        dU = nlamDX / float(npixX)   # noqa: F841
+        dV = nlamDY / float(npixY)   # noqa: F841
+        dX = 1.0 / float(npupX)   # noqa: F841
+        dY = 1.0 / float(npupY)   # noqa: F841
 
 
     # Setup arrays since numexpr can't call arange directly
     float = accel_math._float()
-    ar_npupX = np.arange(npupX, dtype=float)
-    ar_npupY = np.arange(npupY, dtype=float)
-    ar_npixX = np.arange(npixX, dtype=float)
-    ar_npixY = np.arange(npixY, dtype=float)
+    ar_npupX = np.arange(npupX, dtype=float)   # noqa: F841
+    ar_npupY = np.arange(npupY, dtype=float)   # noqa: F841
+    ar_npixX = np.arange(npixX, dtype=float)   # noqa: F841
+    ar_npixY = np.arange(npixY, dtype=float)   # noqa: F841
 
     if centering == FFTSTYLE:
         Xs = ne.evaluate("(ar_npupX - (npupX / 2)) * dX")
@@ -338,10 +340,10 @@ def matrix_dft_numexpr(plane, nlamD, npix,
 
     elif centering == ADJUSTABLE:
         if offset is None:
-            offsetY, offsetX = 0.0, 0.0
+            offsetY, offsetX = 0.0, 0.0   # noqa: F841
         else:
             try:
-                offsetY, offsetX = tuple(np.asarray(offset, dtype=float))
+                offsetY, offsetX = tuple(np.asarray(offset, dtype=float))   # noqa: F841
             except ValueError:
                 raise ValueError(
                     "'offset' must be supplied as a 2-tuple with "
@@ -365,7 +367,7 @@ def matrix_dft_numexpr(plane, nlamD, npix,
     XU = np.outer(Xs, Us)
     YV = np.outer(Ys, Vs)
 
-    two_pi_i = 2*np.pi*1j
+    two_pi_i = 2 * np.pi * 1j
     # SIGN CONVENTION: plus signs in exponent for basic forward propagation, with
     # phase increasing with time. This convention differs from prior poppy version < 1.0
     if inverse:
@@ -443,20 +445,20 @@ class MatrixFourierTransform:
             )
         self.centering = centering
         _log.debug("MatrixFourierTransform initialized using centering "
-                   "type = {0}".format(centering))
+                   f"type = {centering}")
 
     def _validate_args(self, nlamD, npix, offset):
         if self.centering == SYMMETRIC:
             if not np.isscalar(nlamD) or not np.isscalar(npix):
                 raise RuntimeError(
-                    'The selected centering mode, {}, does not support '
-                    'rectangular arrays.'.format(self.centering)
+                    f'The selected centering mode, {self.centering}, does not support '
+                    'rectangular arrays.'
                 )
         if self.centering == FFTSTYLE or self.centering == SYMMETRIC:
             if offset is not None:
                 raise RuntimeError(
-                    'The selected centering mode, {}, does not support '
-                    'position offsets.'.format(self.centering)
+                    f'The selected centering mode, {self.centering}, does not support '
+                    'position offsets.'
                 )
 
     def perform(self, pupil, nlamD, npix, offset=None):
@@ -491,11 +493,11 @@ class MatrixFourierTransform:
         """
         self._validate_args(nlamD, npix, offset)
         _log.debug(
-            "Forward MatrixFourierTransform: array shape {}, "
-            "centering style {}, "
-            "output region size {} in lambda / D units, "
-            "output array size {} pixels, "
-            "offset {}".format(pupil.shape, self.centering, nlamD, npix, offset)
+            f"Forward MatrixFourierTransform: array shape {pupil.shape}, "
+            f"centering style {self.centering}, "
+            f"output region size {nlamD} in lambda / D units, "
+            f"output array size {npix} pixels, "
+            f"offset {offset}"
         )
         return matrix_dft(pupil, nlamD, npix,
                           centering=self.centering, offset=offset)
@@ -533,11 +535,11 @@ class MatrixFourierTransform:
         """
         self._validate_args(nlamD, npix, offset)
         _log.debug(
-            "Inverse MatrixFourierTransform: array shape {}, "
-            "centering style {}, "
-            "output region size {} in lambda / D units, "
-            "output array size {} pixels, "
-            "offset {}".format(image.shape, self.centering, nlamD, npix, offset)
+            f"Inverse MatrixFourierTransform: array shape {image.shape}, "
+            f"centering style {self.centering}, "
+            f"output region size {nlamD} in lambda / D units, "
+            f"output array size {npix} pixels, "
+            f"offset {offset}"
         )
         return matrix_idft(image, nlamD, npix,
                            centering=self.centering, offset=offset)

--- a/poppy/misc.py
+++ b/poppy/misc.py
@@ -6,7 +6,7 @@
 
 import matplotlib.pyplot as plt
 
-from poppy.accel_math import xp, _scipy
+from poppy.accel_math import _scipy, xp
 
 _RADtoARCSEC = 180. * 60 * 60 / xp.pi  # ~ 206265
 _ARCSECtoRAD = xp.pi / (180. * 60 * 60)

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -1,20 +1,18 @@
-import numpy as np
-import scipy.special
-import scipy.ndimage.interpolation
-import matplotlib
-import astropy.io.fits as fits
-import astropy.units as u
-import warnings
 import logging
+import warnings
 from abc import ABC, abstractmethod
 
-from . import utils
-from . import conf
-from .poppy_core import OpticalElement, Wavefront, BaseWavefront, PlaneType, _RADIANStoARCSEC
-from . import geometry
+import astropy.io.fits as fits
+import astropy.units as u
+import matplotlib
+import numpy as np
+import scipy.ndimage.interpolation
+import scipy.special
 
-from . import accel_math
-from .accel_math import xp, _scipy, _exp, _r, _float, _complex
+from . import accel_math, conf, geometry, utils
+from .accel_math import _complex, _float, _r, _scipy, xp
+from .poppy_core import BaseWavefront, OpticalElement, PlaneType, Wavefront
+
 if accel_math._NUMEXPR_AVAILABLE:
     import numexpr as ne
 
@@ -191,7 +189,7 @@ class AnalyticOpticalElement(OpticalElement):
             pixel_scale = fov / (npix * u.pixel)
             w = Wavefront(wavelength=wavelength, npix=npix, pixelscale=pixel_scale)
 
-        _log.info("Computing {0} for {1} sampled onto {2} pixel grid with pixelscale {3}".format(what, self.name, npix, pixel_scale))
+        _log.info(f"Computing {what} for {self.name} sampled onto {npix} pixel grid with pixelscale {pixel_scale}")
         if what == 'amplitude':
             output_array = self.get_transmission(w)
         elif what == 'intensity':
@@ -208,15 +206,15 @@ class AnalyticOpticalElement(OpticalElement):
             else:
                 warnings.warn("'phase_unit' parameter has been deprecated. Use what='opd' instead.",
                               category=DeprecationWarning)
-                raise ValueError('Invalid/unknown phase_unit: {}. Must be one of '
-                                 '[radians, waves, meters]'.format(phase_unit))
+                raise ValueError(f'Invalid/unknown phase_unit: {phase_unit}. Must be one of '
+                                 '[radians, waves, meters]')
         elif what == 'opd':
             output_array = self.get_opd(w)
         elif what == 'complex':
             output_array = self.get_phasor(w)
         else:
-            raise ValueError('Invalid/unknown what to sample: {}. Must be one of '
-                             '[amplitude, intensity, phase, opd, complex]'.format(what))
+            raise ValueError(f'Invalid/unknown what to sample: {what}. Must be one of '
+                             '[amplitude, intensity, phase, opd, complex]')
 
         if return_scale:
             return output_array, pixel_scale
@@ -354,7 +352,7 @@ class ScalarTransmission(AnalyticOpticalElement):
     def __init__(self, name=None, transmission=1.0, **kwargs):
         if name is None:
             name = ("-empty-" if transmission == 1.0 else
-                    "Scalar Transmission of {0}".format(transmission))
+                    f"Scalar Transmission of {transmission}")
         AnalyticOpticalElement.__init__(self, name=name, **kwargs)
         self.transmission = float(transmission)
         self.wavefront_display_hint = 'intensity'
@@ -391,7 +389,7 @@ class InverseTransmission(AnalyticOpticalElement):
     """
 
     def __init__(self, optic=None):
-        super(InverseTransmission, self).__init__()
+        super().__init__()
         if optic is None or not hasattr(optic, 'get_transmission'):
             raise ValueError("Need to supply an valid optic to invert!")
         self.uninverted_optic = optic
@@ -565,7 +563,7 @@ class BandLimitedCoronagraph(AnalyticImagePlaneElement):
                                           -4.59674047e-01, 2.60963397e+00, -9.70881273e+00,
                                           2.36585911e+01, -3.63978587e+01, 3.20703511e+01])
             else:
-                raise NotImplemented("No defined NIRCam wedge BLC mask for that wavelength?  ")
+                raise NotImplementedError("No defined NIRCam wedge BLC mask for that wavelength?  ")
 
             sigmas = numpy.poly1d(polyfitcoeffs)(scalefact)
 
@@ -671,7 +669,7 @@ class CircularPhaseMask(AnalyticImagePlaneElement):
     def __init__(self, name=None, radius=1*u.arcsec, wavelength=1e-6 * u.meter, retardance=0.5,
                  **kwargs):
         if name is None:
-            name = "Phase mask r={:.3g}".format(radius)
+            name = f"Phase mask r={radius:.3g}"
         AnalyticImagePlaneElement.__init__(self, name=name, **kwargs)
         self.wavefront_display_hint = 'phase'  # preferred display for wavefronts at this plane
         self._default_display_size = 4*radius
@@ -699,8 +697,8 @@ class CircularPhaseMask(AnalyticImagePlaneElement):
         npix = (r <= radius).sum()
         if npix < 50:  # pragma: no cover
             import warnings
-            errmsg = "Phase mask is very coarsely sampled: only {} pixels. "\
-                     "Improve sampling for better precision!".format(npix)
+            errmsg = f"Phase mask is very coarsely sampled: only {npix} pixels. "\
+                     "Improve sampling for better precision!"
             warnings.warn(errmsg)
             _log.warn(errmsg)
         return self.opd
@@ -798,7 +796,7 @@ class HexagonFieldStop(AnalyticImagePlaneElement):
             self.side = flattoflat / np.sqrt(3.)
 
         if name is None:
-            name = "Hexagon, side length= {}".format(self.side)
+            name = f"Hexagon, side length= {self.side}"
 
         AnalyticImagePlaneElement.__init__(self, name=name, **kwargs)
 
@@ -908,7 +906,7 @@ class CircularOcculter(AnnularFieldStop):
 
     @utils.quantity_input(radius=u.arcsec)
     def __init__(self, name="unnamed occulter", radius=1.0, **kwargs):
-        super(CircularOcculter, self).__init__(name=name, radius_inner=radius, radius_outer=0.0, **kwargs)
+        super().__init__(name=name, radius_inner=radius, radius_outer=0.0, **kwargs)
         self._default_display_size = 10 * u.arcsec
 
 
@@ -976,8 +974,8 @@ class FQPM_FFT_aligner(AnalyticOpticalElement):
         AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil, **kwargs)
         direction = direction.lower()
         if direction != 'forward' and direction != 'backward':
-            raise ValueError("Invalid direction %s, must be either"
-                             "forward or backward." % direction)
+            raise ValueError(f"Invalid direction {direction}, must be either"
+                             "forward or backward.")
         self.direction = direction
         self._suppress_display = True
         self.wavefront_display_hint = 'phase'  # preferred display for wavefronts at this plane
@@ -1028,7 +1026,7 @@ class ParityTestAperture(AnalyticOpticalElement):
 
     @utils.quantity_input(radius=u.meter)
     def __init__(self, name=None, radius=1.0 * u.meter, pad_factor=1.0, **kwargs):
-        if name is None: name = "Asymmetric Parity Test Aperture, radius={}".format(radius)
+        if name is None: name = f"Asymmetric Parity Test Aperture, radius={radius}"
         AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil, **kwargs)
         self.radius = radius
         # for creating input wavefronts - let's pad a bit:
@@ -1159,8 +1157,8 @@ class CircularAperture(AnalyticOpticalElement):
                  gray_pixel=True, **kwargs):
 
         if name is None:
-            name = "Circle, radius={}".format(radius)
-        super(CircularAperture, self).__init__(name=name, planetype=planetype, **kwargs)
+            name = f"Circle, radius={radius}"
+        super().__init__(name=name, planetype=planetype, **kwargs)
         if radius <= 0*u.meter:
             raise ValueError("radius must be a positive nonzero number.")
         self.radius = radius
@@ -1221,7 +1219,7 @@ class HexagonAperture(AnalyticOpticalElement):
         self.pupil_diam = 2 * self.side  # for creating input wavefronts
         self._default_display_size = 3 * self.side
         if name is None:
-            name = "Hexagon, side length= {}".format(self.side)
+            name = f"Hexagon, side length= {self.side}"
 
         AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil, **kwargs)
 
@@ -1493,7 +1491,7 @@ class NgonAperture(AnalyticOpticalElement):
         self.nsides = nsides
         self.pupil_diam = 2 * self.radius  # for creating input wavefronts
         if name is None:
-            name = "{}-gon, radius= {}".format(self.nsides, self.radius)
+            name = f"{self.nsides}-gon, radius= {self.radius}"
         AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil, rotation=rotation, **kwargs)
 
     def get_transmission(self, wave):
@@ -1629,7 +1627,7 @@ class KeystoneSegmentedCircularAperture(MultiSegmentAperture, CircularAperture):
         """
 
         if name is None:
-            name = "Circle of Wedge Sections, radius={}".format(radius)
+            name = f"Circle of Wedge Sections, radius={radius}"
         CircularAperture.__init__(self, name=name, radius=radius, rotation=rotation,
                                   gray_pixel=gray_pixel, **kwargs)
 
@@ -1788,7 +1786,7 @@ class RectangleAperture(AnalyticOpticalElement):
         self.width = width
         self.height = height
         if name is None:
-            name = "Rectangle, size= {s.width:.1f} wide * {s.height:.1f} high".format(s=self)
+            name = f"Rectangle, size= {self.width:.1f} wide * {self.height:.1f} high"
         AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil, rotation=rotation, **kwargs)
         # for creating input wavefronts:
         self.pupil_diam = np.sqrt(self.height ** 2 + self.width ** 2)
@@ -1829,7 +1827,7 @@ class SquareAperture(RectangleAperture):
     def __init__(self, name=None, size=1.0 * u.meter, **kwargs):
         self._size = size
         if name is None:
-            name = "Square, side length= {}".format(size)
+            name = f"Square, side length= {size}"
         RectangleAperture.__init__(self, name=name, width=size, height=size, **kwargs)
         self.size = size
         self.pupil_diam = 2 * self.size  # for creating input wavefronts
@@ -1871,7 +1869,7 @@ class SecondaryObscuration(AnalyticOpticalElement):
     def __init__(self, name=None, secondary_radius=0.5 * u.meter, n_supports=4, support_width=0.01 * u.meter,
                  support_angle_offset=0.0, **kwargs):
         if name is None:
-            name = "Secondary Obscuration with {0} supports".format(n_supports)
+            name = f"Secondary Obscuration with {n_supports} supports"
         AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil, **kwargs)
         self.secondary_radius = secondary_radius
         self.n_supports = n_supports
@@ -2086,7 +2084,7 @@ class GaussianAperture(AnalyticOpticalElement):
             pupil_diam = 3 * self.fwhm  # for creating input wavefronts
         self.pupil_diam = pupil_diam
         if name is None:
-            name = "Gaussian aperture with fwhm ={0:.2f}".format(self.fwhm)
+            name = f"Gaussian aperture with fwhm ={self.fwhm:.2f}"
         AnalyticOpticalElement.__init__(self, name=name, planetype=PlaneType.pupil, **kwargs)
 
     @property
@@ -2102,7 +2100,7 @@ class GaussianAperture(AnalyticOpticalElement):
 
         r = xp.sqrt(x ** 2 + y ** 2)
 
-        transmission = np.exp((- (r / self.w.to(u.meter).value) ** 2))
+        transmission = np.exp(- (r / self.w.to(u.meter).value) ** 2)
 
         return transmission
 
@@ -2155,7 +2153,7 @@ class KnifeEdge(AnalyticOpticalElement):
     """
     def __init__(self, name=None, rotation=0, **kwargs):
         if name is None:
-            name = "Knife edge at {} deg".format(rotation)
+            name = f"Knife edge at {rotation} deg"
         AnalyticOpticalElement.__init__(self, name=name, rotation=rotation, **kwargs)
 
     def get_transmission(self, wave):
@@ -2323,8 +2321,7 @@ def fixed_sampling_optic(optic, wavefront, oversample=2):
     from .poppy_core import ArrayOpticalElement
     npix = wavefront.shape[0]
     grid_size = npix*u.pixel*wavefront.pixelscale
-    _log.debug("Converting {} to fixed sampling with grid_size={}, npix={}, oversample={}".format(
-        optic.name, grid_size, npix, oversample))
+    _log.debug(f"Converting {optic.name} to fixed sampling with grid_size={grid_size}, npix={npix}, oversample={oversample}")
 
     if oversample > 1:
         _log.debug("retrieving oversampled opd and transmission arrays")

--- a/poppy/physical_wavefront.py
+++ b/poppy/physical_wavefront.py
@@ -1,17 +1,17 @@
-# -*- coding: utf-8 -*-
 
-import numpy as np
-import scipy.constants as const
-import astropy.units as u
 from copy import deepcopy
+
+import astropy.units as u
+import numpy as np
+import scipy
+import scipy.constants as const
 from scipy.linalg import lstsq
 
 from poppy.fresnel import FresnelWavefront, QuadraticLens
 
 from . import accel_math
-from .accel_math import xp, ensure_not_on_gpu
+from .accel_math import ensure_not_on_gpu, xp
 
-import scipy
 if accel_math._USE_CUPY:
     lstsq = xp.linalg.lstsq
 else:
@@ -48,7 +48,7 @@ class PhysicalFresnelWavefront(FresnelWavefront):
                  M2=1.0,
                  n0=1.00027398,  # refractive index of air @ 15 deg C, lambda=1064nm
                  **kwargs):
-        super(PhysicalFresnelWavefront, self).__init__(
+        super().__init__(
             beam_radius=beam_radius,
             units=units,
             rayleigh_factor=rayleigh_factor,
@@ -136,7 +136,7 @@ class PhysicalFresnelWavefront(FresnelWavefront):
         """
 
         pow = xp.array(self.power)
-        super(PhysicalFresnelWavefront, self).propagate_fresnel(z, **kwargs)
+        super().propagate_fresnel(z, **kwargs)
         self.scale_power(pow * xp.exp(-attenuation_coeff * z.to(u.m).value))
 
     def center(self, mask=1.0):

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -1,23 +1,20 @@
-import numpy as np
-import multiprocessing
 import copy
-import time
 import enum
-import warnings
+import multiprocessing
 import textwrap
+import time
 from abc import ABC, abstractmethod
-
-import matplotlib.pyplot as plt
-import matplotlib
 
 import astropy.io.fits as fits
 import astropy.units as u
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
 
+from . import accel_math, conf, utils
+from .accel_math import _complex, _float, _scipy, xp
 from .matrixDFT import MatrixFourierTransform
-from . import utils
-from . import conf
-from . import accel_math
-from .accel_math import xp, _scipy, _float, _complex
+
 if accel_math._NUMEXPR_AVAILABLE:
     import numexpr as ne
 
@@ -129,8 +126,8 @@ class BaseWavefront(ABC):
         self.ispadded = False  # is the wavefront padded for oversampling?
         self.history = []  # List of strings giving a descriptive history of actions
                            # performed on the wavefront. Saved to FITS headers.
-        self.history.append("Created wavefront: wavelength={0:.4g}, diam={1:.4g}".format(self.wavelength, self.diam))
-        self.history.append(" using array size %s" % (self.wavefront.shape,))
+        self.history.append(f"Created wavefront: wavelength={self.wavelength:.4g}, diam={self.diam:.4g}")
+        self.history.append(f" using array size {self.wavefront.shape}")
         self.location = 'Entrance Pupil'    # Descriptive string for where a wavefront is instantaneously located.
                                             # Used mostly for titling displayed plots.
 
@@ -138,10 +135,10 @@ class BaseWavefront(ABC):
 
     def __str__(self):
         # TODO add switches for image/pupil planes
-        return """Wavefront:
-        wavelength = {}
-        shape = {}
-        sampling = {}""".format(self.wavelength.to(u.micron), self.wavefront.shape, self.pixelscale)
+        return f"""Wavefront:
+        wavelength = {self.wavelength.to(u.micron)}
+        shape = {self.wavefront.shape}
+        sampling = {self.pixelscale}"""
 
     def copy(self):
         """Return a copy of the wavefront as a different object."""
@@ -177,8 +174,7 @@ class BaseWavefront(ABC):
         phasor = optic.get_phasor(self)
 
         if not np.isscalar(phasor) and phasor.size > 1:
-            assert self.wavefront.shape == phasor.shape, "Phasor shape {} does not match wavefront shape {}".format(
-                phasor.shape, self.wavefront.shape)
+            assert self.wavefront.shape == phasor.shape, f"Phasor shape {phasor.shape} does not match wavefront shape {self.wavefront.shape}"
 
         self.wavefront *= phasor
         msg = "  Multiplied WF by phasor for " + str(optic)
@@ -201,16 +197,13 @@ class BaseWavefront(ABC):
             raise ValueError('Wavefronts can only be summed with other Wavefronts of the same class.')
 
         if not self.wavefront.shape == wave.wavefront.shape:
-            raise ValueError('Wavefronts can only be added if they have the same size and shape: {} vs {} '.format(
-                self.wavefront.shape, wave.wavefront.shape))
+            raise ValueError(f'Wavefronts can only be added if they have the same size and shape: {self.wavefront.shape} vs {wave.wavefront.shape} ')
 
         try:
             if not np.isclose(self.pixelscale.value, wave.pixelscale.to(self.pixelscale.unit).value):
-                raise ValueError('Wavefronts can only be added if they have the same pixelscale: {} vs {}'.format(
-                    self.pixelscale, wave.pixelscale))
+                raise ValueError(f'Wavefronts can only be added if they have the same pixelscale: {self.pixelscale} vs {wave.pixelscale}')
         except u.UnitConversionError:
-            raise ValueError('Wavefronts can only be added if they have equivalent units: {} vs {}'.format(
-                self.pixelscale.unit, wave.pixelscale.unit))
+            raise ValueError(f'Wavefronts can only be added if they have equivalent units: {self.pixelscale.unit} vs {wave.pixelscale.unit}')
 
         self.wavefront += wave.wavefront
         self.history.append("Summed with another wavefront!")
@@ -325,7 +318,7 @@ class BaseWavefront(ABC):
 
         """
         self.as_fits(**kwargs).writeto(filename, overwrite=overwrite)
-        _log.info("  Wavefront saved to %s" % filename)
+        _log.info(f"  Wavefront saved to {filename}")
 
     def display(self, what='intensity', nrows=1, row=1, showpadding=False,
                 imagecrop=None, pupilcrop=None,
@@ -759,16 +752,14 @@ class BaseWavefront(ABC):
         import scipy.interpolate
 
         pixscale_ratio = (self.pixelscale / detector.pixelscale).decompose().value
-        _log.info("Resampling wavefront to detector with {} pixels and {}. Zoom factor is {:.5f}".format(
-            detector.shape, detector.pixelscale, pixscale_ratio))
+        _log.info(f"Resampling wavefront to detector with {detector.shape} pixels and {detector.pixelscale}. Zoom factor is {pixscale_ratio:.5f}")
 
-        _log.debug("Wavefront pixel scale:        {:.3f}".format(self.pixelscale.to(detector.pixelscale.unit)))
-        _log.debug("Desired detector pixel scale: {:.3f}".format(detector.pixelscale))
+        _log.debug(f"Wavefront pixel scale:        {self.pixelscale.to(detector.pixelscale.unit):.3f}")
+        _log.debug(f"Desired detector pixel scale: {detector.pixelscale:.3f}")
         _log.debug("Wavefront FOV:        {} pixels, {:.3f}".format(self.shape,
                                                                     self.shape[0]*u.pixel*self.pixelscale.to(
                                                                     detector.pixelscale.unit)))
-        _log.debug("Desired detector FOV: {} pixels, {:.3f}".format(detector.shape,
-                                                                    detector.shape[0]*u.pixel*detector.pixelscale))
+        _log.debug(f"Desired detector FOV: {detector.shape} pixels, {detector.shape[0]*u.pixel*detector.pixelscale:.3f}")
 
         # Provide 2-pixel margin around image to reduce interpolation errors at edge, but also make
         # sure that image is centered properly after it gets cropped down to detector size
@@ -888,7 +879,7 @@ class BaseWavefront(ABC):
             tiltphasor = xp.exp(-2.0j * np.pi * (U * xangle_rad + V * yangle_rad) / self.wavelength.to(u.meter).value)
             self.wavefront *= tiltphasor
             self.history.append("Tilted wavefront by "
-                                "X={:2.2}, Y={:2.2} arcsec".format(Xangle, Yangle))
+                                f"X={Xangle:2.2}, Y={Yangle:2.2} arcsec")
 
         else:
             _log.warning("Wavefront.tilt() called, but requested tilt was zero. No change.")
@@ -918,7 +909,7 @@ class BaseWavefront(ABC):
             rot_imag = _scipy.ndimage.rotate(self.wavefront.imag, -angle, reshape=False)
         self.wavefront = rot_real + 1j * rot_imag
 
-        self.history.append('Rotated by {:.2f} degrees, CCW'.format(angle))
+        self.history.append(f'Rotated by {angle:.2f} degrees, CCW')
 
     def invert(self, axis='both'):
         """Invert coordinates, i.e. flip the direction of the X and Y axes
@@ -940,7 +931,7 @@ class BaseWavefront(ABC):
             self.wavefront = self.wavefront[::-1]
         else:
             raise ValueError("Invalid/unknown value for the 'axis' parameter. Must be 'x', 'y', or 'both'.")
-        self.history.append('Inverted axis direction for {} axes'.format(axis.upper()))
+        self.history.append(f'Inverted axis direction for {axis.upper()} axes')
 
     @abstractmethod
     def coordinates(self):
@@ -992,7 +983,7 @@ class Wavefront(BaseWavefront):
     @utils.quantity_input(wavelength=u.meter, diam=u.meter, pixelscale=u.arcsec / u.pixel)
     def __init__(self, wavelength=1e-6 * u.meter, npix=1024, dtype=None, diam=8.0 * u.meter,
                  oversample=2, pixelscale=None):
-        super(Wavefront, self).__init__(wavelength=wavelength,
+        super().__init__(wavelength=wavelength,
                                         npix=npix,
                                         dtype=dtype,
                                         diam=diam,
@@ -1029,11 +1020,11 @@ class Wavefront(BaseWavefront):
                 _log.debug("  Resampling wavefront to match detector pixelation.")
                 self._resample_wavefront_pixelscale(optic)
             else:
-                _log.debug("  Wavefront and optic %s already at same plane type, no propagation needed." % optic.name)
+                _log.debug(f"  Wavefront and optic {optic.name} already at same plane type, no propagation needed.")
             self.current_plane_index += 1
             return
         else:
-            msg = "  Propagating wavefront to %s. " % str(optic)
+            msg = f"  Propagating wavefront to {str(optic)}. "
             _log.debug(msg)
             self.history.append(msg)
 
@@ -1076,8 +1067,8 @@ class Wavefront(BaseWavefront):
             self.wavefront = utils.pad_to_oversample(self.wavefront, self.oversample)
             self.ispadded = True
             if optic.verbose:
-                _log.debug("    Padded WF array for oversampling by %dx" % self.oversample)
-            self.history.append("    Padded WF array for oversampling by %dx" % self.oversample)
+                _log.debug(f"    Padded WF array for oversampling by {self.oversample}")
+            self.history.append(f"    Padded WF array for oversampling by {self.oversample}")
 
         # Set up for computation - figure out direction & normalization
         if self.planetype == PlaneType.pupil and optic.planetype == PlaneType.image:
@@ -1092,7 +1083,7 @@ class Wavefront(BaseWavefront):
             self.planetype = PlaneType.image
             self.pixelscale = (self.wavelength / self.diam * u.radian / self.oversample).to(u.arcsec) / u.pixel
             self.fov = self.wavefront.shape[0] * u.pixel * self.pixelscale
-            self.history.append('   FFT {},  to IMAGE plane  scale={:.4f}'.format(self.wavefront.shape, self.pixelscale))
+            self.history.append(f'   FFT {self.wavefront.shape},  to IMAGE plane  scale={self.pixelscale:.4f}')
 
         elif self.planetype == PlaneType.image and optic.planetype == PlaneType.pupil:
             # SIGN CONVENTION: plus signs in exponent for basic forward propagation, with
@@ -1105,7 +1096,7 @@ class Wavefront(BaseWavefront):
             # (pre-)update state:
             self.planetype = PlaneType.pupil
             self.pixelscale = self.diam * self.oversample / (self.wavefront.shape[0] * u.pixel)
-            self.history.append('   FFT {},  to PUPIL scale={:.4f}'.format(self.wavefront.shape, self.pixelscale))
+            self.history.append(f'   FFT {self.wavefront.shape},  to PUPIL scale={self.pixelscale:.4f}')
 
         # do FFT
         if conf.enable_flux_tests: _log.debug("\tPre-FFT total intensity: " + str(self.total_intensity))
@@ -1123,7 +1114,7 @@ class Wavefront(BaseWavefront):
 
         if conf.enable_speed_tests:  # pragma: no cover
             t1 = time.time()
-            _log.debug("\tTIME %f s\t for the FFT" % (t1 - t0))
+            _log.debug(f"\tTIME {t1-t0:f} s\t for the FFT" )
 
         if conf.enable_flux_tests:
             _log.debug("\tPost-FFT total intensity: " + str(self.total_intensity))
@@ -1162,12 +1153,9 @@ class Wavefront(BaseWavefront):
 
         pixelscale = det.pixelscale if det.pixelscale is not None else det.fov_arcsec/det.fov_pixels
         if not np.isscalar(det_fov_lam_d):  # hasattr(det_fov_lam_d,'__len__'):
-            msg = '    Propagating w/ MFT: {:.4f}     fov=[{:.3f},{:.3f}] lam/D    npix={} x {}'.format(
-                pixelscale / det.oversample, det_fov_lam_d[0], det_fov_lam_d[1],
-                det_calc_size_pixels[0], det_calc_size_pixels[1])
+            msg = f'    Propagating w/ MFT: {pixelscale / det.oversample:.4f}     fov=[{det_fov_lam_d[0]:.3f},{det_fov_lam_d[1]:.3f}] lam/D    npix={det_calc_size_pixels[0]} x {det_calc_size_pixels[1]}'
         else:
-            msg = '    Propagating w/ MFT: {:.4f}     fov={:.3f} lam/D    npix={:d}'.format(
-                pixelscale / det.oversample, det_fov_lam_d, int(det_calc_size_pixels))
+            msg = f'    Propagating w/ MFT: {pixelscale / det.oversample:.4f}     fov={det_fov_lam_d:.3f} lam/D    npix={int(det_calc_size_pixels):d}'
         _log.debug(msg)
         self.history.append(msg)
 
@@ -1177,8 +1165,7 @@ class Wavefront(BaseWavefront):
 
         self.wavefront = mft.perform(self.wavefront, det_fov_lam_d, det_calc_size_pixels,
                                      offset=None if det.offset is None else det.offset * det._offset_sign)  # sign flip intentional, see note in Detector class
-        _log.debug("     Result wavefront: at={0} shape={1} ".format(
-            self.location, str(self.shape)))
+        _log.debug(f"     Result wavefront: at={self.location} shape={str(self.shape)} ")
         self._last_transform_type = 'MFT'
 
         self.planetype = PlaneType.image
@@ -1219,12 +1206,12 @@ class Wavefront(BaseWavefront):
                 # Use next optic's shape, extent, and pixelscale to define the target sampling
                 pupil_npix = pupil.shape[0]
                 next_pupil_diam = pupil.shape[0]*pupil.pixelscale*u.pixel
-                _log.debug("Got post-invMFT pupil npix from next optic: {} pix, {} diam".format(pupil_npix, next_pupil_diam))
+                _log.debug(f"Got post-invMFT pupil npix from next optic: {pupil_npix} pix, {next_pupil_diam} diam")
             else:
                 # Use the prior pupil's shape, extent, and pixelscale to define the target sampling
                 pupil_npix = self._preMFT_pupil_shape[0]
                 next_pupil_diam = self.diam
-                _log.debug("Got post-invMFT pupil npix from pre-MFT pupil: {} pix, {} diam ".format(pupil_npix, self.diam))
+                _log.debug(f"Got post-invMFT pupil npix from pre-MFT pupil: {pupil_npix} pix, {self.diam} diam ")
 
         # extract everything from Quantities to regular scalars here
         lam_d = (self.wavelength / next_pupil_diam * u.radian).to(u.arcsec).value
@@ -1233,13 +1220,12 @@ class Wavefront(BaseWavefront):
         mft = MatrixFourierTransform(centering='ADJUSTABLE', verbose=False)
 
         # these can be either scalar or 2-element lists/tuples/ndarrays
-        msg_pixscale = ('{0:.4f}'.format(self.pixelscale) if np.isscalar(self.pixelscale.value) else
-                        '{0:.4f} x {1:.4f} arcsec/pix'.format(self.pixelscale.value[0], self.pixelscale.value[1]))
-        msg_det_fov = ('{0:.4f} lam/D'.format(det_fov_lam_d) if np.isscalar(det_fov_lam_d) else
-                       '{0:.4f} x {1:.4f}  lam/D'.format(det_fov_lam_d[0], det_fov_lam_d[1]))
+        msg_pixscale = (f'{self.pixelscale:.4f}' if np.isscalar(self.pixelscale.value) else
+                        f'{self.pixelscale.value[0]:.4f} x {self.pixelscale.value[1]:.4f} arcsec/pix')
+        msg_det_fov = (f'{det_fov_lam_d:.4f} lam/D' if np.isscalar(det_fov_lam_d) else
+                       f'{det_fov_lam_d[0]:.4f} x {det_fov_lam_d[1]:.4f}  lam/D')
 
-        msg = '    Propagating w/ InvMFT:  scale={0}    fov={1}    npix={2:d} x {2:d}'.format(
-            msg_pixscale, msg_det_fov, pupil_npix)
+        msg = f'    Propagating w/ InvMFT:  scale={msg_pixscale}    fov={msg_det_fov}    npix={pupil_npix:d} x {pupil_npix:d}'
         _log.debug(msg)
         self.history.append(msg)
 
@@ -1382,7 +1368,7 @@ class Wavefront(BaseWavefront):
         # Deal with metadata
         new_wf.history = wf.history.copy()
         new_wf.history.append("Converted to Fraunhofer propagation")
-        new_wf.history.append("  Fraunhofer array pixel scale = {:.4g}, oversample = {}".format(new_wf.pixelscale, new_wf.oversample))
+        new_wf.history.append(f"  Fraunhofer array pixel scale = {new_wf.pixelscale:.4g}, oversample = {new_wf.oversample}")
         # Copy over the contents of the array
         new_wf.wavefront = utils.pad_or_crop_to_shape(wf.wavefront, new_wf.shape)
         # Copy over misc internal info
@@ -1479,7 +1465,7 @@ class BaseOpticalSystem(ABC):
             self.planes.append(optic)
         else:
             self.planes.insert(index, optic)
-        if self.verbose: _log.info("Added {}: {}".format(logstring, optic.name))
+        if self.verbose: _log.info(f"Added {logstring}: {optic.name}")
         return optic
 
     def add_rotation(self, angle=0.0, index=None, *args, **kwargs):
@@ -1555,9 +1541,7 @@ class BaseOpticalSystem(ABC):
         optic = Detector(pixelscale, oversample=oversample, **kwargs)
 
         return self._add_plane(optic, index=index,
-                               logstring="detector with pixelscale={} and oversampling={}".format(
-                                   pixelscale,
-                                   oversample))
+                               logstring=f"detector with pixelscale={pixelscale} and oversampling={oversample}")
 
     @abstractmethod
     def propagate(self, wavefront):
@@ -1657,7 +1641,7 @@ class BaseOpticalSystem(ABC):
 
         # loop over wavelengths
         if self.verbose:
-            _log.info("Calculating PSF with %d wavelengths" % (len(wavelength)))
+            _log.info(f"Calculating PSF with {len(wavelength)} wavelengths")
         outfits = None
         intermediate_wfs = None
         if save_intermediates or return_intermediates:
@@ -1707,7 +1691,7 @@ class BaseOpticalSystem(ABC):
             pool = ctx.Pool(int(nproc))
 
             # build a single iterable containing the required function arguments
-            _log.info("Beginning multiprocessor job using {0} processes".format(nproc))
+            _log.info(f"Beginning multiprocessor job using {nproc} processes")
             worker_arguments = [(self, wlen, retain_intermediates, return_final, normalize, _USE_FFTW)
                                 for wlen in wavelength]
             results = pool.map(_wrap_propagate_for_multiprocessing, worker_arguments)
@@ -1719,17 +1703,15 @@ class BaseOpticalSystem(ABC):
             outfits[0].data *= normwts[0]
             for idx, wavefront in enumerate(intermediate_wfs):
                 intermediate_wfs[idx] *= normwts[0]
-            _log.info("got results for wavelength channel {} / {} ({:g} meters)".format(
-                0, len(tuple(wavelength)), wavelength[0]))
+            _log.info(f"got results for wavelength channel {0} / {len(tuple(wavelength))} ({wavelength[0]:g} meters)")
             for i in range(1, len(normwts)):
                 mono_psf, mono_intermediate_wfs = results[i]
                 wave_weight = normwts[i]
-                _log.info("got results for wavelength channel {} / {} ({:g} meters)".format(
-                    i, len(tuple(wavelength)), wavelength[i]))
+                _log.info(f"got results for wavelength channel {i} / {len(tuple(wavelength))} ({wavelength[i]:g} meters)")
                 outfits[0].data += mono_psf[0].data * wave_weight
                 for idx, wavefront in enumerate(mono_intermediate_wfs):
                     intermediate_wfs[idx] += wavefront * wave_weight
-            outfits[0].header.add_history("Multiwavelength PSF calc using {} processes completed.".format(nproc))
+            outfits[0].header.add_history(f"Multiwavelength PSF calc using {nproc} processes completed.")
 
         else:  # ######### single-threaded computations (may still use multi cores if FFTW enabled ######
             if display:
@@ -1778,15 +1760,14 @@ class BaseOpticalSystem(ABC):
         if save_intermediates:
             _log.info('Saving intermediate wavefronts:')
             for idx, wavefront in enumerate(intermediate_wfs):
-                filename = 'wavefront_plane_{:03d}.fits'.format(idx)
+                filename = f'wavefront_plane_{idx:03d}.fits'
                 wavefront.writeto(filename, what=save_intermediates_what)
-                _log.info('  saved {} to {} ({} / {})'.format(save_intermediates_what, filename,
-                                                              idx, len(intermediate_wfs)))
+                _log.info(f'  saved {save_intermediates_what} to {filename} ({idx} / {len(intermediate_wfs)})')
 
         tstop = time.time()
         tdelta = tstop - tstart
-        _log.info("  Calculation completed in {0:.3f} s".format(tdelta))
-        outfits[0].header.add_history("Calculation completed in {0:.3f} seconds".format(tdelta))
+        _log.info(f"  Calculation completed in {tdelta:.3f} s")
+        outfits[0].header.add_history(f"Calculation completed in {tdelta:.3f} seconds")
 
         if _USE_FFTW and conf.autosave_fftw_wisdom:
             utils.fftw_save_wisdom()
@@ -1861,7 +1842,7 @@ class BaseOpticalSystem(ABC):
         if conf.enable_speed_tests:  # pragma: no cover
             t_start = time.time()
         if self.verbose:
-            _log.info(" Propagating wavelength = {0:g}".format(wavelength))
+            _log.info(f" Propagating wavelength = {wavelength:g}")
 
         wavefront = self.input_wavefront(wavelength, inwave=inwave)
 
@@ -1882,7 +1863,7 @@ class BaseOpticalSystem(ABC):
 
         if conf.enable_speed_tests:  # pragma: no cover
             t_stop = time.time()
-            _log.debug("\tTIME %f s\tfor propagating one wavelength" % (t_stop - t_start))
+            _log.debug(f"\tTIME {t_stop-t_start:f} s\tfor propagating one wavelength")
 
         return wavefront.as_fits(), intermediate_wfs
 
@@ -1896,7 +1877,7 @@ class BaseOpticalSystem(ABC):
         planes_to_display = [p for p in self.planes if (not isinstance(p, Detector) and not p._suppress_display)]
         nplanes = len(planes_to_display)
         for i, plane in enumerate(planes_to_display):
-            _log.info("Displaying plane {0:s} in row {1:d} of {2:d}".format(plane.name, i + 1, nplanes))
+            _log.info(f"Displaying plane {plane.name:s} in row {i + 1:d} of {nplanes:d}")
             plane.display(nrows=nplanes, row=i + 1, **kwargs)
 
 
@@ -1991,8 +1972,7 @@ class OpticalSystem(BaseOpticalSystem):
             optic = optics.ScalarTransmission()  # placeholder optic, transmission=100%
             optic.planetype = PlaneType.pupil
         else:
-            raise TypeError("Not sure how to handle an Optic input of the provided type, {0}".format(
-                str(optic.__class__)))
+            raise TypeError(f"Not sure how to handle an Optic input of the provided type, {str(optic.__class__)}")
 
         return self._add_plane(optic, index=index, logstring="pupil plane")
 
@@ -2057,7 +2037,7 @@ class OpticalSystem(BaseOpticalSystem):
             elif function == 'FQPM':
                 fn = optics.IdealFQPM
             elif function is not None:
-                raise ValueError("Analytic mask type '%s' is unknown." % function)
+                raise ValueError(f"Analytic mask type '{function}' is unknown.")
             elif len(kwargs) > 0:  # create image from files specified in kwargs
                 fn = FITSOpticalElement
             else:
@@ -2139,8 +2119,7 @@ class OpticalSystem(BaseOpticalSystem):
         else:
             raise ValueError("Input wavefront must be a Wavefront() object or None, when using OpticalSystem().")
 
-        _log.debug("Input wavefront has wavelength={}, npix={:d}, diam={:.3g}, pixel scale={:.3g} meters/pixel".format(
-            wavelength, npix, diam, diam / npix))
+        _log.debug(f"Input wavefront has wavelength={wavelength}, npix={npix:d}, diam={diam:.3g}, pixel scale={diam / npix:.3g} meters/pixel")
 
         if np.abs(self.source_offset_r) > 0:
             # Add a tilt to the input wavefront.
@@ -2237,8 +2216,7 @@ class OpticalSystem(BaseOpticalSystem):
                     [p.planetype is PlaneType.pupil for p in self.planes]))[0].max() + 1
                 if wavefront.current_plane_index == last_pupil_plane_index:
                     wavefront.normalize()
-                    _log.debug("normalizing at exit pupil (plane {0}) to 1.0 total intensity".format(
-                        wavefront.current_plane_index))
+                    _log.debug(f"normalizing at exit pupil (plane {wavefront.current_plane_index}) to 1.0 total intensity")
             elif normalize.lower() == 'last' and wavefront.current_plane_index == len(self.planes):
                 wavefront.normalize()
                 _log.debug("normalizing at last plane to 1.0 total intensity")
@@ -2320,8 +2298,8 @@ class CompoundOpticalSystem(OpticalSystem):
                 raise ValueError("All items in the optical system list must be OpticalSystem instances, not "+repr(item))
 
         if name is None:
-            name = "CompoundOpticalSystem containing {} systems".format(len(optsyslist))
-        super(CompoundOpticalSystem, self).__init__(name=name,  **kwargs)
+            name = f"CompoundOpticalSystem containing {len(optsyslist)} systems"
+        super().__init__(name=name,  **kwargs)
 
         self.optsyslist = optsyslist
 
@@ -2377,7 +2355,7 @@ class CompoundOpticalSystem(OpticalSystem):
                 loghistory(wavefront, "CompoundOpticalSystem: Converted wavefront to Fraunhofer type")
 
             # Propagate
-            loghistory(wavefront, "CompoundOpticalSystem: Propagating through system {}: {}".format(i+1, optsys.name))
+            loghistory(wavefront, f"CompoundOpticalSystem: Propagating through system {i+1}: {optsys.name}")
             retval = optsys.propagate(wavefront,
                                       normalize=normalize,
                                       return_intermediates=return_intermediates,
@@ -2410,7 +2388,7 @@ class CompoundOpticalSystem(OpticalSystem):
 # ------ core Optical Element Classes ------
 
 
-class OpticalElement(object):
+class OpticalElement:
     """ Base class for all optical elements, whether from FITS files or analytic functions.
 
     If instantiated on its own, this just produces a null optical element (empty space,
@@ -2525,7 +2503,7 @@ class OpticalElement(object):
         if self.pixelscale is not None and hasattr(wave, 'pixelscale') and abs(
                 wave.pixelscale - self.pixelscale) / self.pixelscale >= float_tolerance:
             _log.debug("Non-matching pixel scales for wavefront and optic. Need to interpolate. "
-                       "Pixelscales: wave {}, optic {}".format(wave.pixelscale, self.pixelscale))
+                       f"Pixelscales: wave {wave.pixelscale}, optic {self.pixelscale}")
             if hasattr(self, '_resampled_scale') and abs(
                     self._resampled_scale - wave.pixelscale) / self._resampled_scale >= float_tolerance:
                 # we already did this same resampling, so just re-use it!
@@ -2538,9 +2516,8 @@ class OpticalElement(object):
                 original_amplitude = self.get_transmission(wave)
                 resampled_amplitude = _scipy.ndimage.zoom(original_amplitude, zoom, output=original_amplitude.dtype, order=self.interp_order)
                 _log.debug("resampled optic to match wavefront via spline interpolation by a" +
-                           " zoom factor of {:.3g}".format(zoom))
-                _log.debug("resampled optic shape: {}   wavefront shape: {}".format(resampled_amplitude.shape,
-                                                                                    wave.shape))
+                           f" zoom factor of {zoom:.3g}")
+                _log.debug(f"resampled optic shape: {resampled_amplitude.shape}   wavefront shape: {wave.shape}")
 
                 lx, ly = resampled_amplitude.shape
                 # crop down to match size of wavefront:
@@ -2559,14 +2536,14 @@ class OpticalElement(object):
                                         border_y:border_y + resampled_opd.shape[1]] = resampled_opd
                     self._resampled_amplitude[border_x:border_x + resampled_opd.shape[0],
                                               border_y:border_y + resampled_opd.shape[1]] = resampled_amplitude
-                    _log.debug("padded an optic with a {:d} x {:d} border to "
-                               "optic to match the wavefront".format(border_x, border_y))
+                    _log.debug(f"padded an optic with a {border_x:d} x {border_y:d} border to "
+                               "optic to match the wavefront")
 
                 else:
                     self._resampled_opd = resampled_opd[border_x:border_x + lx_w, border_y:border_y + ly_w]
                     self._resampled_amplitude = resampled_amplitude[border_x:border_x + lx_w, border_y:border_y + ly_w]
-                    _log.debug("trimmed a border of {:d} x {:d} pixels from "
-                               "optic to match the wavefront".format(border_x, border_y))
+                    _log.debug(f"trimmed a border of {border_x:d} x {border_y:d} pixels from "
+                               "optic to match the wavefront")
 
                 self.phasor = self._resampled_amplitude * xp.exp(1j * self._resampled_opd * scale)
 
@@ -2688,14 +2665,14 @@ class OpticalElement(object):
                 else:
                     diam = 1.0 * u.meter
                 temp_wavefront = Wavefront(wavelength=wavelength, npix=npix, diam=diam)
-            _log.info("Computing {0} for {1} sampled onto {2} pixel grid with "
-                      "pixelscale {3}".format(what, self.name, npix, temp_wavefront.pixelscale))
+            _log.info(f"Computing {what} for {self.name} sampled onto {npix} pixel grid with "
+                      f"pixelscale {temp_wavefront.pixelscale}")
 
             disp_pixelscale = temp_wavefront.pixelscale
             disp_shape = temp_wavefront.shape
 
         # Determine the extent of the image in physical units, for axes labels.
-        _log.debug("Display pixel scale = {} ".format(disp_pixelscale))
+        _log.debug(f"Display pixel scale = {disp_pixelscale} ")
         if disp_pixelscale.decompose().unit == u.m / u.pix:
             halfsize = disp_pixelscale.to(u.m / u.pix).value * disp_shape[0] / 2
         elif disp_pixelscale.decompose().unit == u.radian / u.pix:
@@ -2788,12 +2765,11 @@ class OpticalElement(object):
 
     def __str__(self):
         if self.planetype == PlaneType.pupil:
-            return "Pupil plane: {} ".format(self.name)
+            return f"Pupil plane: {self.name} "
         elif self.planetype == PlaneType.image:
-            desc = "({}x{} pixels, scale={} arcsec/pixel)".format(self.shape[0], self.shape[0],
-                                                                  self.pixelscale) if \
+            desc = f"({self.shape[0]}x{self.shape[0]} pixels, scale={self.pixelscale} arcsec/pixel)" if \
                                                                   self.pixelscale is not None else "(Analytic)"
-            return "Image plane: %s %s" % (self.name, desc)
+            return f"Image plane: {self.name} {desc}"
         else:
             return "Optic: " + self.name
 
@@ -2814,7 +2790,7 @@ class ArrayOpticalElement(OpticalElement):
     """
 
     def __init__(self, opd=None, transmission=None, pixelscale=None, **kwargs):
-        super(ArrayOpticalElement, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if opd is not None:
             self.opd = opd
         if transmission is not None:
@@ -2977,7 +2953,7 @@ class FITSOpticalElement(OpticalElement):
                         transmission_index = 0
                     self.amplitude_slice_index = transmission_index
                     self.amplitude = self.amplitude[self.amplitude_slice_index, :, :]
-                    _log.debug(" Datacube detected, using slice ={0}".format(self.amplitude_slice_index))
+                    _log.debug(f" Datacube detected, using slice ={self.amplitude_slice_index}")
             else:
                 _log.debug("No transmission supplied - will assume uniform throughput = 1 ")
                 # if transmission is none, wait until after OPD is loaded, below, and then create a matching
@@ -3015,8 +2991,8 @@ class FITSOpticalElement(OpticalElement):
                 self.opd = self.opd.astype('=f8')
                 self.opd = self.opd[self.opd_slice, :, :]
                 if self.name == 'unnamed optic':
-                    self.name = 'OPD from %s, plane %d' % (self.opd_file, self.opd_slice)
-                _log.info(self.name + ": Loaded OPD from  %s, plane %d" % (self.opd_file, self.opd_slice))
+                    self.name = f'OPD from {self.opd_file}, plane {self.opd_slice}'
+                _log.info(self.name + f": Loaded OPD from  {self.opd_file}, plane {self.opd_slice}")
             else:
                 raise TypeError('Not sure how to use an OPD parameter of type ' + str(type(transmission)))
 
@@ -3028,7 +3004,7 @@ class FITSOpticalElement(OpticalElement):
                     opd_index = 0
                 self.opd_slice = opd_index
                 self.opd = self.opd[self.opd_slice, :, :]
-                _log.debug(" Datacube detected, using slice ={0}".format(self.opd_slice))
+                _log.debug(f" Datacube detected, using slice ={self.opd_slice}")
 
             if transmission is None:
                 _log.info("No info supplied on amplitude transmission; assuming uniform throughput = 1")
@@ -3059,8 +3035,8 @@ class FITSOpticalElement(OpticalElement):
                 self._opd_in_radians = True
             else:
                 raise ValueError(
-                    "Got opdunits (or BUNIT header keyword) {}. Valid options "
-                    "are meter, micron, nanometer, or radian.".format(repr(opdunits))
+                    f"Got opdunits (or BUNIT header keyword) {repr(opdunits)}. Valid options "
+                    "are meter, micron, nanometer, or radian."
                 )
 
             if self.opd_header is not None and not self._opd_in_radians:
@@ -3105,7 +3081,7 @@ class FITSOpticalElement(OpticalElement):
                     wnoise = (self.amplitude < 1e-3) & (self.amplitude > 0)
                     self.amplitude[wnoise] = 0
                     self.opd = _scipy.ndimage.rotate(self.opd, -rotation, reshape=False)  # negative = CCW
-                _log.info("  Rotated optic by %f degrees counter clockwise." % rotation)
+                _log.info(f"  Rotated optic by {rotation:f} degrees counter clockwise.")
                 self._rotation = rotation
 
             # ---- Determine the pixel scale for this image. ----
@@ -3171,8 +3147,8 @@ class FITSOpticalElement(OpticalElement):
                                str(pixelscale))
                     self.pixelscale = float(pixelscale)
                 except ValueError:
-                    raise ValueError("pixelscale=%s is neither a FITS keyword string "
-                                     "nor a floating point value." % str(pixelscale))
+                    raise ValueError(f"pixelscale={str(pixelscale)} is neither a FITS keyword string "
+                                     "nor a floating point value.")
             # now turn the pixel scale into a Quantity
             if self.planetype == PlaneType.image:
                 self.pixelscale *= u.arcsec / u.pixel
@@ -3191,8 +3167,8 @@ class FITSOpticalElement(OpticalElement):
                     if shift_y is None: shift_y = 0
                     rollx = int(shift_x/self.pixelscale.to(u.m/u.pixel).value)
                     rolly = int(shift_y/self.pixelscale.to(u.m/u.pixel).value)
-                    _log.info("Requested optic shift of ({:6.3f}, {:6.3f}) meters".format(shift_x, shift_y))
-                    _log.info("Actual shift applied  = ({:6.3f}, {:6.3f}) pixels".format(rollx, rolly))
+                    _log.info(f"Requested optic shift of ({shift_x:6.3f}, {shift_y:6.3f}) meters")
+                    _log.info(f"Actual shift applied  = ({rollx:6.3f}, {rolly:6.3f}) pixels")
 
                 elif shift is not None:
                     # determine shift using the shift tuple
@@ -3204,8 +3180,7 @@ class FITSOpticalElement(OpticalElement):
                                                                                 # but X,Y order for shift
                     rollx = int(np.round(self.amplitude.shape[1] * shift[0]))
                     _log.info("Requested optic shift of ({:6.3f}, {:6.3f}) fraction of pupil ".format(*shift))
-                    _log.info("Actual shift applied   = (%6.3f, %6.3f) " % (
-                              rollx * 1.0 / self.amplitude.shape[1], rolly * 1.0 / self.amplitude.shape[0]))
+                    _log.info(f"Actual shift applied   = ({rollx * 1.0 / self.amplitude.shape[1]:6.3f}, {rolly * 1.0 / self.amplitude.shape[0]:6.3f}) ")
                     self._shift = (rollx * 1.0 / self.amplitude.shape[1], rolly * 1.0 / self.amplitude.shape[0])
 
                 self.amplitude = _scipy.ndimage.shift(self.amplitude, (rolly, rollx))
@@ -3311,14 +3286,14 @@ class Rotation(CoordinateTransform):
         elif units == 'degrees':
             pass
         else:
-            raise ValueError("Unknown value for units='%s'. Must be degrees or radians." % units)
+            raise ValueError(f"Unknown value for units='{units}'. Must be degrees or radians.")
         self.angle = angle
 
-        CoordinateTransform.__init__(self, name="Rotation by %.2f degrees" % angle,
+        CoordinateTransform.__init__(self, name=f"Rotation by {angle:.2f} degrees",
                                      planetype=PlaneType.rotation, hide=hide, **kwargs)
 
     def __str__(self):
-        return "Rotation by %f degrees counter clockwise" % self.angle
+        return f"Rotation by {self.angle:f} degrees counter clockwise"
 
 
 class CoordinateInversion(CoordinateTransform):
@@ -3342,7 +3317,7 @@ class CoordinateInversion(CoordinateTransform):
                                      planetype=PlaneType.inversion, hide=hide, **kwargs)
 
     def __str__(self):
-        return "Coordinate Inversion in {} axis".format(self.axis)
+        return f"Coordinate Inversion in {self.axis} axis"
 
 
 # ------ Detector ------
@@ -3445,7 +3420,7 @@ class Detector(OpticalElement):
         return (int(fpix), int(fpix)) if np.isscalar(fpix) else fpix.astype(int)[0:2]
 
     def __str__(self):
-        return "Detector plane: {} ({}x{} pixels, {:.3f})".format(self.name, self.shape[1], self.shape[0], self.pixelscale)
+        return f"Detector plane: {self.name} ({self.shape[1]}x{self.shape[0]} pixels, {self.pixelscale:.3f})"
 
     @staticmethod
     def _handle_pixelscale_units_flexibly(pixelscale, fov_pixels):
@@ -3489,6 +3464,6 @@ class Detector(OpticalElement):
                              " must be a number or quantity convertible to"
                              " units=arcsec/pixel or micron/pixel. Note, make sure your pixelscale units are specified per pixel!".format('pixelscale',
                                                                            'Detector.__init__',
-                                                                           pixelscale))
+                                                                           ))
 
         return new_pixelscale

--- a/poppy/special_prop.py
+++ b/poppy/special_prop.py
@@ -1,14 +1,13 @@
 # Specialized optical system propagators
 # In particular for efficient modeling of astronomical coronagraphs
 
-import numpy as np
-import time
 import logging
-import astropy.units as u
+import time
 
-from . import poppy_core
-from . import utils
-from . import conf
+import astropy.units as u
+import numpy as np
+
+from . import conf, poppy_core
 
 _log = logging.getLogger('poppy')
 
@@ -49,7 +48,7 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
     def __init__(self, existing_optical_system, oversample=8, occulter_box=1.0,
                  fpm_index=1, **kwargs):
         from . import optics
-        super(SemiAnalyticCoronagraph, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.name = "SemiAnalyticCoronagraph for " + existing_optical_system.name
         self.verbose = existing_optical_system.verbose
@@ -72,15 +71,14 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
         self.mask_function = optics.InverseTransmission(self.occulter)
 
         pt = poppy_core.PlaneType
-        for label, plane, typecode in zip(["Occulter (plane {})".format(fpm_index),
-                                           "Lyot (plane {})".format(fpm_index + 1),
+        for label, plane, typecode in zip([f"Occulter (plane {fpm_index})",
+                                           f"Lyot (plane {fpm_index + 1})",
                                            "Detector (last plane)"],
                                           [self.occulter, self.lyotplane, self.detector],
                                           [pt.image, pt.pupil, pt.detector]):
             if not plane.planetype == typecode:
-                raise ValueError("Plane {0} is not of the right type for a semianalytic \
-                        coronagraph calculation: should be {1:s} but is {2:s}.".format(label,
-                                                                                       typecode, plane.planetype))
+                raise ValueError(f"Plane {label} is not of the right type for a semianalytic \
+                        coronagraph calculation: should be {typecode:s} but is {plane.planetype:s}.")
 
         self.oversample = oversample
 
@@ -105,8 +103,8 @@ class SemiAnalyticCoronagraph(poppy_core.OpticalSystem):
         """
 
         if self.verbose:
-            _log.info(" Propagating wavelength = {0:g} meters using "
-                      "Fast Semi-Analytic Coronagraph method".format(wavefront.wavelength))
+            _log.info(f" Propagating wavelength = {wavefront.wavelength:g} meters using "
+                      "Fast Semi-Analytic Coronagraph method")
 
         intermediate_wfs = []
 
@@ -236,7 +234,7 @@ class MatrixFTCoronagraph(poppy_core.OpticalSystem):
 
     def __init__(self, existing_optical_system, oversample=4, occulter_box=1.0,
                  **kwargs):
-        super(MatrixFTCoronagraph, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if len(existing_optical_system.planes) < 4:
             raise ValueError("Input optical system must have at least 4 planes "
@@ -277,8 +275,8 @@ class MatrixFTCoronagraph(poppy_core.OpticalSystem):
         if conf.enable_speed_tests:  # pragma: no cover
             t_start = time.time()
         if self.verbose:
-            _log.info(" Propagating wavelength = {0:g} meters using "
-                      "Matrix FTs".format(wavefront.wavelength))
+            _log.info(f" Propagating wavelength = {wavefront.wavelength:g} meters using "
+                      "Matrix FTs")
         intermediate_wfs = []
 
         wavefront.history.append("Propagating using Matrix FT Coronagraph Method")
@@ -315,8 +313,8 @@ class MatrixFTCoronagraph(poppy_core.OpticalSystem):
                                                               for p in self.planes]))[0].max() + 1
                 if current_plane_index == last_pupil_plane_index:
                     wavefront.normalize()
-                    _log.debug("normalizing at exit pupil (plane {0}) "
-                               "to 1.0 total intensity".format(current_plane_index))
+                    _log.debug(f"normalizing at exit pupil (plane {current_plane_index}) "
+                               "to 1.0 total intensity")
             elif normalize.lower() == 'last' and current_plane_index == len(self.planes):
                 wavefront.normalize()
                 _log.debug("normalizing at last plane to 1.0 total intensity")

--- a/poppy/sub_sampled_optics.py
+++ b/poppy/sub_sampled_optics.py
@@ -3,16 +3,18 @@ Written by Ewan Douglas, 2018
 Updated by Rachel Morgan, 2019-2020 (debugging, testing, reformatting, adding functions, updating to work with most recent POPPY)
 """
 
-import numpy as np
-import poppy
-import matplotlib.pyplot as plt
+import logging
+
 import astropy.units as u
-import astropy.io.fits as fits
-from .poppy_core import OpticalElement, Detector, Wavefront, PlaneType, _PUPIL, _IMAGE, _RADIANStoARCSEC
+import matplotlib.pyplot as plt
+import numpy as np
+
+import poppy
+
 from .optics import CircularAperture
+from .poppy_core import Detector, OpticalElement, PlaneType, Wavefront
 from .utils import measure_centroid
 
-import logging
 _log = logging.getLogger('poppy')
 
 

--- a/poppy/tests/test_accel_math.py
+++ b/poppy/tests/test_accel_math.py
@@ -1,14 +1,9 @@
 # Test accelerated math functions
 import numpy as np
-import matplotlib
-import matplotlib.pyplot as plt
-import astropy.io.fits as fits
-
 import pytest
 
-from .. import matrixDFT
-from .. import accel_math
-from .. import optics
+from .. import accel_math, matrixDFT, optics
+
 
 @pytest.mark.skipif(accel_math._USE_CUPY, reason="Test not relevant if using CuPy")
 @pytest.mark.skipif(accel_math._NUMEXPR_AVAILABLE is False, reason="numexpr not available")

--- a/poppy/tests/test_active_optics.py
+++ b/poppy/tests/test_active_optics.py
@@ -1,7 +1,8 @@
 
-import poppy
 import astropy.units as u
 import numpy as np
+
+import poppy
 
 
 def test_TipTiltStage(display=False, verbose=False):

--- a/poppy/tests/test_core.py
+++ b/poppy/tests/test_core.py
@@ -1,12 +1,13 @@
 # Test functions for core poppy functionality
 import os
 
-import numpy as np
-from poppy.accel_math import xp   # May be numpy, or CuPy on GPU
-from astropy.io import fits
 import astropy.units as u
-import pytest
 import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from poppy.accel_math import xp  # May be numpy, or CuPy on GPU
 
 try:
     import scipy
@@ -14,8 +15,8 @@ except ImportError:
     scipy = None
 
 import poppy
-from .. import poppy_core
-from .. import optics
+
+from .. import optics, poppy_core
 
 ####### Test Common Infrastructure #######
 
@@ -70,7 +71,7 @@ def test_input_wavefront_size():
         #pupil = optics.CircularAperture(radius=1)
         wf = osys.input_wavefront()
         expected_shape = (1024,1024) if (wf.ispadded == False) else (1024*oversamp, 1024*oversamp)
-        assert wf.shape == expected_shape, 'Wavefront is not the expected size: is {} expects {}'.format(wf.shape,  expected_shape)
+        assert wf.shape == expected_shape, f'Wavefront is not the expected size: is {wf.shape} expects {expected_shape}'
 
 
     # test setting the size based on the npix parameter, with no optical system planes
@@ -80,7 +81,7 @@ def test_input_wavefront_size():
         #pupil = optics.CircularAperture(radius=1)
         wf = osys.input_wavefront()
         expected_shape = (size,size)
-        assert wf.shape == expected_shape, 'Wavefront is not the expected size: is {} expects {}'.format(wf.shape,  expected_shape)
+        assert wf.shape == expected_shape, f'Wavefront is not the expected size: is {wf.shape} expects {expected_shape}'
 
     # test setting the size based on the npix parameter, with a non-null optical system
     # (so it infers the system diameter from the first optic's diameter)
@@ -89,7 +90,7 @@ def test_input_wavefront_size():
         osys.add_pupil(optics.CircularAperture(radius=1))
         wf = osys.input_wavefront()
         expected_shape = (size,size)
-        assert wf.shape == expected_shape, 'Wavefront is not the expected size: is {} expects {}'.format(wf.shape,  expected_shape)
+        assert wf.shape == expected_shape, f'Wavefront is not the expected size: is {wf.shape} expects {expected_shape}'
 
 
     # test setting the size based on an input optical element
@@ -101,8 +102,8 @@ def test_input_wavefront_size():
 
         wf = osys.input_wavefront()
         expected_shape = (npix,npix)
-        assert pupil_fits[0].data.shape == expected_shape, 'FITS array from optic element is not the expected size: is {} expects {}'.format(pupil_fits[0].data.shape,  expected_shape)
-        assert wf.shape == expected_shape, 'Wavefront is not the expected size: is {} expects {}'.format(wf.shape,  expected_shape)
+        assert pupil_fits[0].data.shape == expected_shape, f'FITS array from optic element is not the expected size: is {pupil_fits[0].data.shape} expects {expected_shape}'
+        assert wf.shape == expected_shape, f'Wavefront is not the expected size: is {wf.shape} expects {expected_shape}'
 
 
 
@@ -132,9 +133,10 @@ def test_CircularAperture_Airy(display=False):
     assert xp.all(xp.abs(difference) < 3e-5)
 
     if display:
-        from .. import utils
         #comparison of the two
         from matplotlib.colors import LogNorm
+
+        from .. import utils
         norm = LogNorm(vmin=1e-6, vmax=1e-2)
 
         plt.figure(figsize=(15,5))
@@ -332,8 +334,9 @@ def test_unit_conversions():
     """ Test the astropy.Quantity unit conversions
     This is a modified version of test_CircularAperture
     """
-    from ..misc import airy_2d
     import astropy.units as u
+
+    from ..misc import airy_2d
     # Analytic PSF for 1 meter diameter aperture
     analytic = airy_2d(diameter=1)
     analytic /= analytic.sum() # for comparison with poppy outputs normalized to total=1
@@ -429,9 +432,9 @@ def test_rotation_in_OpticalSystem(display=False, npix=1024):
         if display:
             fig, axes = plt.subplots(figsize=(16, 5), ncols=2)
             poppy.display_psf(psf1, ax=axes[0])
-            axes[0].set_title("Optic rotated {} deg".format(angle))
+            axes[0].set_title(f"Optic rotated {angle} deg")
             poppy.display_psf(psf2, ax=axes[1])
-            axes[1].set_title("Wavefront rotated {} deg".format(angle))
+            axes[1].set_title(f"Wavefront rotated {angle} deg")
 
         assert xp.allclose(psf1[0].data, psf2[0].data, atol=atol), ("PSFs did not agree "
                                                                     f"within the requested tolerance, for angle={angle}."

--- a/poppy/tests/test_dms.py
+++ b/poppy/tests/test_dms.py
@@ -1,13 +1,9 @@
 # Tests for deformable mirror classes
 
-import matplotlib.pyplot as pl
-import numpy as np
-import astropy.io.fits as fits
 import astropy.units as u
+import numpy as np
 
-from .. import poppy_core
-from .. import optics
-from .. import dms
+from .. import dms, optics, poppy_core
 
 
 def test_basic_continuous_dm():
@@ -25,11 +21,11 @@ def test_basic_continuous_dm():
 
     for actx, acty in ( (3,7), (7,3)):
         dm.set_actuator(actx, acty, 1e-6) # 1000 nm = 1 micron
-        assert np.allclose(dm.surface[acty, actx],  1e-6), "Actuator ({}, {}) did not move as expected using bare floats".format(actx,acty)
+        assert np.allclose(dm.surface[acty, actx],  1e-6), f"Actuator ({actx}, {acty}) did not move as expected using bare floats"
 
     for actx, acty in ( (5,2), (6,9)):
         dm.set_actuator(actx, acty, 1*u.nm) # 1 nm
-        assert np.allclose(dm.surface[acty, actx],  1e-9), "Actuator ({}, {}) did not move as expected using astropy quantities".format(actx,acty)
+        assert np.allclose(dm.surface[acty, actx],  1e-9), f"Actuator ({actx}, {acty}) did not move as expected using astropy quantities"
 
 
     psf_aberrated = osys.calc_psf()
@@ -87,16 +83,16 @@ def test_basic_hex_dm():
 
     for act in ( 3,6):
         dm.set_actuator(act, 1e-6, 0, 1e-4) # 1000 nm = 1 micron
-        assert np.allclose(dm.surface[act,0],  1e-6), "Segment {} did not move as expected using bare floats".format(actx,acty)
-        assert np.allclose(dm.surface[act,2],  1e-4), "Segment {} did not move as expected using bare floats".format(actx,acty)
+        assert np.allclose(dm.surface[act,0],  1e-6), f"Segment {actx} did not move as expected using bare floats"
+        assert np.allclose(dm.surface[act,2],  1e-4), f"Segment {actx} did not move as expected using bare floats"
 
     for act in ( 5,2):
         dm.set_actuator(act, 1*u.nm, 0, 0) # 1 nm
-        assert np.allclose(dm.surface[act,0],  1e-9), "Segment {} did not move as expected in piston using astropy quantities".format(actx,acty)
+        assert np.allclose(dm.surface[act,0],  1e-9), f"Segment {actx} did not move as expected in piston using astropy quantities"
 
     for act in ( 1,4):
         dm.set_actuator(act,  0, 1*u.milliradian, 0) # 1 nm
-        assert np.allclose(dm.surface[act,1],  1e-3), "Segment {} did not move as expected in tilt using astropy quantities".format(actx,acty)
+        assert np.allclose(dm.surface[act,1],  1e-3), f"Segment {actx} did not move as expected in tilt using astropy quantities"
 
 
 
@@ -176,16 +172,16 @@ def test_basic_circular_dm():
 
     for act in ( 3,6):
         dm.set_actuator(act, 1e-6, 0, 1e-7) # 1000 nm = 1 micron
-        assert np.allclose(dm.surface[act,0],  1e-6), "Segment {} did not move as expected using bare floats".format(actx,acty)
-        assert np.allclose(dm.surface[act,2],  1e-7), "Segment {} did not move as expected using bare floats".format(actx,acty)
+        assert np.allclose(dm.surface[act,0],  1e-6), f"Segment {actx} did not move as expected using bare floats"
+        assert np.allclose(dm.surface[act,2],  1e-7), f"Segment {actx} did not move as expected using bare floats"
 
     for act in ( 5,2):
         dm.set_actuator(act, 1*u.nm, 0, 0) # 1 nm
-        assert np.allclose(dm.surface[act,0],  1e-9), "Segment {} did not move as expected in piston using astropy quantities".format(actx,acty)
+        assert np.allclose(dm.surface[act,0],  1e-9), f"Segment {actx} did not move as expected in piston using astropy quantities"
 
     for act in ( 1,4):
         dm.set_actuator(act,  0, 1*u.microradian, 0) # 1 nm
-        assert np.allclose(dm.surface[act,1],  1e-6), "Segment {} did not move as expected in tilt using astropy quantities".format(actx,acty)
+        assert np.allclose(dm.surface[act,1],  1e-6), f"Segment {actx} did not move as expected in tilt using astropy quantities"
 
     psf_aberrated = osys.calc_psf()
 
@@ -211,16 +207,16 @@ def test_basic_wedge_dm():
 
     for act in ( 3,6):
         dm.set_actuator(act, 1e-6, 0, 1e-7) # 1000 nm = 1 micron
-        assert np.allclose(dm.surface[act,0],  1e-6), "Segment {} did not move as expected using bare floats".format(actx,acty)
-        assert np.allclose(dm.surface[act,2],  1e-7), "Segment {} did not move as expected using bare floats".format(actx,acty)
+        assert np.allclose(dm.surface[act,0],  1e-6), f"Segment {actx} did not move as expected using bare floats"
+        assert np.allclose(dm.surface[act,2],  1e-7), f"Segment {actx} did not move as expected using bare floats"
 
     for act in ( 5,2):
         dm.set_actuator(act, 1*u.nm, 0, 0) # 1 nm
-        assert np.allclose(dm.surface[act,0],  1e-9), "Segment {} did not move as expected in piston using astropy quantities".format(actx,acty)
+        assert np.allclose(dm.surface[act,0],  1e-9), f"Segment {actx} did not move as expected in piston using astropy quantities"
 
     for act in ( 1,4):
         dm.set_actuator(act,  0, 1*u.microradian, 0) # 1 nm
-        assert np.allclose(dm.surface[act,1],  1e-6), "Segment {} did not move as expected in tilt using astropy quantities".format(actx,acty)
+        assert np.allclose(dm.surface[act,1],  1e-6), f"Segment {actx} did not move as expected in tilt using astropy quantities"
 
     psf_aberrated = osys.calc_psf()
 

--- a/poppy/tests/test_errorhandling.py
+++ b/poppy/tests/test_errorhandling.py
@@ -1,11 +1,8 @@
 # This file contains code for testing various error handlers and user interface edge cases,
 # as opposed to testing the main body of functionality of the code.
 
-from .. import poppy_core
-from .. import optics
-from .. import matrixDFT
-from .. import zernike
-import sys
+
+from .. import matrixDFT, optics, poppy_core, zernike
 
 try:
     import pytest
@@ -134,8 +131,9 @@ if _HAVE_PYTEST:
 
     def test_add_incompatible_wavefronts():
         """ Test we can't add wavefronts to incompatible things. Verifies fix of #308 """
-        import poppy
         import astropy.units as u
+
+        import poppy
         n = 10
         w1 = poppy.Wavefront(npix=n)
         w2 = poppy.Wavefront(npix=n)

--- a/poppy/tests/test_fft.py
+++ b/poppy/tests/test_fft.py
@@ -1,25 +1,19 @@
 # Tests for FFT based propagation
 
 import numpy as np
-import astropy.io.fits as fits
-
 import pytest
-
-from .. import poppy_core
-from .. import optics
-from .. import accel_math
-from .test_core import check_wavefront
-
 
 # For some reason, the following block of code in poppy_core is not sufficient
 # to handle the "no pyfftw installed" case when running in test mode, even though it works
 # just fine when actually running poppy. Empirically this check has to be repeated
 # here in order to let the tests work when pyfftw is not present.
-from .. import conf
+from .. import accel_math, conf, optics, poppy_core
+from .test_core import check_wavefront
+
 if conf.use_fftw:
     try:
         # try to import FFTW and use it
-        import pyfftw
+        pass
     except:
         # we tried but failed to import it.
         conf.use_fftw = False
@@ -41,7 +35,7 @@ def test_fft_normalization():
     osys.add_pupil() # null plane to force FFT
     osys.add_detector(pixelscale=0.01, fov_arcsec=10.0) # use a large FOV so we grab essentially all the light
 
-    poppy_core._log.info('TEST: wavelen = {0}, radius = {1}'.format(wavelen, radius))
+    poppy_core._log.info(f'TEST: wavelen = {wavelen}, radius = {radius}')
 
     psf, waves = osys.calc_psf(wavelength=2.0e-6, normalize='first', return_intermediates=True)
 
@@ -50,7 +44,7 @@ def test_fft_normalization():
 
     # Expected value here is 0.9977, limited by FOV size as the aperture
     poppy_core._log.info('TEST: Computed PSF of circular aperture')
-    poppy_core._log.info('TEST: PSF total intensity sum is {0}'.format(psf[0].data.sum()))
+    poppy_core._log.info(f'TEST: PSF total intensity sum is {psf[0].data.sum()}')
     poppy_core._log.info('TEST:  Expected value is 0.9977 ')
 
     assert abs(psf[0].data.sum() - 0.9977) < 0.001
@@ -159,12 +153,12 @@ def test_parity_FFT_forward_inverse(display=False):
         for i, plane in enumerate(planes):
             ax = plt.subplot(2,nplanes,i+1)
             plane.display(ax = ax)
-            plt.title("Plane {0}".format(i))
+            plt.title(f"Plane {i}")
         plt.subplot(2,nplanes,nplanes+1)
         plt.imshow(absdiff)
         plt.title("Abs(Pupil0-Pupil2)")
         plt.colorbar()
-        print("Max abs(difference) = {}".format(maxabsdiff))
+        print(f"Max abs(difference) = {maxabsdiff}")
     return (p0,p2)
 
 
@@ -228,7 +222,7 @@ def test_pyfftw_vs_numpyfft(verbose=False):
     if verbose:
         print ("PSF difference: ", np.abs(psf_fftw[0].data-psf_numpy[0].data).max())
         for i in [1,2]:
-            print(" Int. WF {} intensity diff: {}".format(i, np.abs(intermediates[i].total_intensity-total_int_input)) )
+            print(f" Int. WF {i} intensity diff: {np.abs(intermediates[i].total_intensity-total_int_input)}" )
         print(" Final PSF intensity diff:", np.abs(intermediates[3].total_intensity-total_int_input) - expected)
 
     conf.use_fftw, conf.use_cuda, conf.use_opencl, conf.use_cupy = defaults
@@ -269,7 +263,7 @@ def test_opencl_vs_numpyfft(verbose=False):
     if verbose:
         print ("PSF difference: ", np.abs(psf_opencl[0].data-psf_numpy[0].data).max())
         for i in [1,2]:
-            print(" Int. WF {} intensity diff: {}".format(i, np.abs(intermediates[i].total_intensity-total_int_input)) )
+            print(f" Int. WF {i} intensity diff: {np.abs(intermediates[i].total_intensity-total_int_input)}" )
         print(" Final PSF intensity diff:", np.abs(intermediates[3].total_intensity-total_int_input) - expected)
 
     conf.use_fftw, conf.use_cuda, conf.use_opencl = defaults

--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -1,25 +1,19 @@
-import pytest
-from pkg_resources import parse_version as version
-
-from .. import poppy_core
-from .. import optics
-from .. import misc
-from .. import fresnel
-from .. import utils
-from poppy.poppy_core import _log, PlaneType
-
-import poppy
 import os
-
-from poppy.accel_math import xp   # may be numpy, or cupy on GPU
-import numpy as np     # Regular numpy, definitely in CPU memory
 
 import astropy.io.fits as fits
 import astropy.units as u
 import matplotlib.pyplot as plt
+import numpy as np  # Regular numpy, definitely in CPU memory
+import pytest
+from packaging.version import Version
+from scipy.ndimage import shift, zoom
 
-from .. import fwcentroid
-from scipy.ndimage import zoom,shift
+import poppy
+from poppy.accel_math import xp  # may be numpy, or cupy on GPU
+from poppy.poppy_core import PlaneType, _log
+
+from .. import fresnel, fwcentroid, misc, optics, poppy_core, utils
+
 
 def test_GaussianBeamParams():
     """Confirm that gaussian beam parameters agree with expectations"""
@@ -154,9 +148,9 @@ def test_Circular_Aperture_PTP_long(display=False, npix=512, display_proper=Fals
         plt.figure(figsize=(12,6))
 
         plt.plot(x[0,:], inten[inten.shape[1]//2,:], label='POPPY')
-        plt.title("z={:0.2e} , compare to Anderson and Enmark fig.6.15".format(z))
+        plt.title(f"z={z:0.2e} , compare to Anderson and Enmark fig.6.15")
         plt.gca().set_xlim(-1, 1)
-        plt.text(0.1, 2, "Max value: {0:.4f}\nExpected:   {1:.4f}".format(xp.max(inten), max(proper_y)))
+        plt.text(0.1, 2, f"Max value: {xp.max(inten):.4f}\nExpected:   {max(proper_y):.4f}")
 
 
         if display_proper:
@@ -170,7 +164,7 @@ def test_Circular_Aperture_PTP_long(display=False, npix=512, display_proper=Fals
 
 
     _log.debug("test_Circular_Aperture_PTP peak flux comparison: " + str(xp.abs(max(proper_y) - xp.max(inten))))
-    _log.debug("  allowed tolerance for {0} is {1}".format(npix, tolerance))
+    _log.debug(f"  allowed tolerance for {npix} is {tolerance}")
     #assert(np.round(3.3633280006866424,9) == np.round(np.max(gw.intensity),9))
     assert (xp.abs(max(proper_y) - xp.max(inten)) < tolerance)
 
@@ -193,14 +187,14 @@ def test_Circular_Aperture_PTP_long(display=False, npix=512, display_proper=Fals
 
 
 try:
-    from skimage.registration import phase_cross_correlation
     import skimage
+    from skimage.registration import phase_cross_correlation
     HAS_SKIMAGE = True
 except ImportError:
     HAS_SKIMAGE = False
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='This test requires having scikit-image installed.')
-@pytest.mark.skipif(HAS_SKIMAGE and (version(skimage.__version__) >= version('0.19')), reason='This test is known to fail for skimage > 0.19; see #552.')
+@pytest.mark.skipif(HAS_SKIMAGE and (Version(skimage.__version__) >= Version('0.19')), reason='This test is known to fail for skimage > 0.19; see #552.')
 def test_Circular_Aperture_PTP_short(display=False, npix=512, oversample=4, include_wfe=True, display_proper=False):
     """ Tests plane-to-plane propagation at short distances, by comparison
     of the results from propagate_ptp and propagate_direct calculations
@@ -478,7 +472,7 @@ def test_fresnel_FITS_Optical_element(tmpdir, display=False, verbose=False):
 
     """
     import os.path
-    import astropy.io.fits as fits
+
     from poppy import wfe
 
     # parameters for calculation test case:
@@ -516,8 +510,7 @@ def test_fresnel_FITS_Optical_element(tmpdir, display=False, verbose=False):
                                                    oversample=1)
 
         if verbose:
-            print("Astigmatism surface from FITS has pixelscale {}, npix={}".format(astig_surf.pixelscale,
-                                                                                    astig_surf.shape[0]))
+            print(f"Astigmatism surface from FITS has pixelscale {astig_surf.pixelscale}, npix={astig_surf.shape[0]}")
 
         # Now we put that FITSOpticalElement into a Fresnel optical system.
         fosys = fresnel.FresnelOpticalSystem(pupil_diameter=radius * 2, beam_ratio=0.25, npix=npix)

--- a/poppy/tests/test_fwcentroid.py
+++ b/poppy/tests/test_fwcentroid.py
@@ -1,8 +1,8 @@
 
 import numpy as np
+
 from .. import fwcentroid
 from ..fwcentroid import test_fwcentroid
-
 from .test_errorhandling import _exception_message_starts_with
 
 # fwcentroid is a standalone package that's just included as a copy in

--- a/poppy/tests/test_geometry.py
+++ b/poppy/tests/test_geometry.py
@@ -2,8 +2,10 @@
 #  Test functions for subpixel geometry code
 #
 
-from poppy.accel_math import xp
 import numpy as np
+
+from poppy.accel_math import xp
+
 from .. import geometry
 
 # Test routines for antialiased fractional circle

--- a/poppy/tests/test_instrument.py
+++ b/poppy/tests/test_instrument.py
@@ -1,11 +1,9 @@
 
-import matplotlib.pyplot as plt
 import numpy as np
-import astropy.io.fits as fits
 import pytest
 from astropy import units as u
 
-from poppy import poppy_core, instrument, optics, utils
+from poppy import instrument, poppy_core, utils
 from poppy.instrument import _HAS_SYNPHOT
 
 WEIGHTS_DICT = {'wavelengths': [2.0e-6, 2.1e-6, 2.2e-6], 'weights': [0.3, 0.5, 0.2]}
@@ -155,10 +153,10 @@ def test_instrument_gaussian_jitter():
         expected_post_sigma = np.sqrt((fwhm_no_jitter/fwhm_to_sigma)**2 + JITTER_SIGMA**2)
         pre_sigma = fwhm_no_jitter/fwhm_to_sigma
         post_sigma = fwhm_with_jitter/fwhm_to_sigma
-        poppy_core._log.info("TEST: Jitter sigma={0:.4f}.   PSF sigma pre: {1:.4f}    post: {2:.4f}    expected: {3:.4f}".format(JITTER_SIGMA, pre_sigma, post_sigma, expected_post_sigma))
+        poppy_core._log.info(f"TEST: Jitter sigma={JITTER_SIGMA:.4f}.   PSF sigma pre: {pre_sigma:.4f}    post: {post_sigma:.4f}    expected: {expected_post_sigma:.4f}")
 
         reldiff = np.abs(post_sigma-expected_post_sigma)/post_sigma
-        assert reldiff < tolerance, "Post-jitter PSF width is too different from expected width: {:.4f}, {:.4f} arcsec".format(post_sigma, expected_post_sigma)
+        assert reldiff < tolerance, f"Post-jitter PSF width is too different from expected width: {post_sigma:.4f}, {expected_post_sigma:.4f} arcsec"
 
 
 def test_instrument_calc_datacube():

--- a/poppy/tests/test_matrixDFT.py
+++ b/poppy/tests/test_matrixDFT.py
@@ -3,20 +3,18 @@
 #
 #
 
-import matplotlib
-import matplotlib.pyplot as plt
-import astropy.io.fits as fits
+import logging
 import os
 
-from poppy.accel_math import xp as np   # May or may not be on GPU
+import astropy.io.fits as fits
+import matplotlib
+import matplotlib.pyplot as plt
 
-from .. import poppy_core
-from .. import optics
-from .. import matrixDFT
+from poppy.accel_math import xp as np  # May or may not be on GPU
+
+from .. import matrixDFT, optics, poppy_core
 from .test_errorhandling import _exception_message_starts_with
 
-
-import logging
 _log = logging.getLogger('poppy_tests')
 
 
@@ -29,8 +27,8 @@ def complexinfo(a, str=None):
         print("\t", str)
     re = a.real.copy()
     im = a.imag.copy()
-    _log.debug("\t%.2e  %.2g  =  re.sum im.sum" % (re.sum(), im.sum()))
-    _log.debug("\t%.2e  %.2g  =  abs(re).sum abs(im).sum" % (abs(re).sum(), abs(im).sum()))
+    _log.debug("\t{:.2e}  {:.2g}  =  re.sum im.sum".format(re.sum(), im.sum()))
+    _log.debug("\t{:.2e}  {:.2g}  =  abs(re).sum abs(im).sum".format(abs(re).sum(), abs(im).sum()))
 
 
 
@@ -88,7 +86,7 @@ def test_MFT_flux_conservation(centering='FFTSTYLE', outdir=None, outname='test_
 
     # Set up constants for either a more precise test or a less precise but much
     # faster test:
-    print("Testing MFT flux conservation for centering = {}".format(centering))
+    print(f"Testing MFT flux conservation for centering = {centering}")
     if precision ==0.001:
         npupil = 800
         npix = 4096
@@ -262,9 +260,9 @@ def test_DFT_rect(centering='FFTSTYLE', outdir=None, outname='DFT1R_', npix=None
         plt.imshow(np.abs(pupil2))
         plt.gca().set_title('back to pupil')
         plt.draw()
-        plt.suptitle('Matrix DFT with rectangular arrays using centering={0}'.format(centering))
+        plt.suptitle(f'Matrix DFT with rectangular arrays using centering={centering}')
 
-        plt.savefig('test_DFT_rectangular_results_{0}.pdf'.format(centering))
+        plt.savefig(f'test_DFT_rectangular_results_{centering}.pdf')
 
     _log.info( "Post-inverse FFT total: "+str( abs(pupil2r).sum() ))
     _log.info( "Post-inverse pupil max: "+str(pupil2r.max()))
@@ -566,7 +564,7 @@ def test_parity_MFT_forward_inverse(display = False):
         for i, plane in enumerate(planes):
             ax = plt.subplot(2,nplanes,i+1)
             plane.display(ax = ax)
-            plt.title("Plane {0}".format(i))
+            plt.title(f"Plane {i}")
 
 
         plt.subplot(2,nplanes,nplanes+1)

--- a/poppy/tests/test_matrixFTcoronagraph.py
+++ b/poppy/tests/test_matrixFTcoronagraph.py
@@ -2,14 +2,13 @@
 #  Test functions for MatrixFTCoronagraph optical system subclass
 #
 
-import numpy as np
-import matplotlib
-import matplotlib.pyplot as plt
+import logging
 
-import os
+import matplotlib.pyplot as plt
+import numpy as np
+
 import poppy
 
-import logging
 _log = logging.getLogger('poppy_tests')
 
 def test_MatrixFT_FFT_Lyot_propagation_equivalence(display=False):
@@ -52,6 +51,6 @@ def test_MatrixFT_FFT_Lyot_propagation_equivalence(display=False):
         plt.title('Difference (MatrixFT - FFT)')
         plt.show()
 
-    print("Max of absolute difference: %.10g" % np.max(abs_diff_img))
+    print("Max of absolute difference: {:.10g}".format(np.max(abs_diff_img)))
 
     assert( np.all(abs_diff_img < 2e-7) )

--- a/poppy/tests/test_misc.py
+++ b/poppy/tests/test_misc.py
@@ -1,10 +1,11 @@
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import scipy
 
 import poppy.accel_math
-from ..misc import airy_1d, airy_2d, sinc2_2d, _RADtoARCSEC, _ARCSECtoRAD
+
+from ..misc import _ARCSECtoRAD, airy_1d, airy_2d, sinc2_2d
 
 airy_zeros = np.asarray([3.8317, 7.0156, 10.1735, 13.3237, 16.4706])/np.pi  # first several zeros of the Bessel function J1. See e.g. http://en.wikipedia.org/wiki/Airy_disk#Mathematical_details
 

--- a/poppy/tests/test_multiprocessing.py
+++ b/poppy/tests/test_multiprocessing.py
@@ -1,15 +1,12 @@
 # Test functions for poppy multiprocessing
 
-from .. import poppy_core
-from .. import optics
-from .. import conf
-from .. import utils
-
-import numpy as np
-import astropy
-import astropy.io.fits as fits
 import sys
 from distutils.version import LooseVersion
+
+import astropy
+import numpy as np
+
+from .. import conf, optics, poppy_core, utils
 
 try:
     import pytest
@@ -86,7 +83,7 @@ if _HAVE_PYTEST:
 
         for i in range(len(planes_single)):
             assert (np.allclose(planes_single[i].intensity, planes_multi[i].intensity)), \
-                "Intermediate plane {} from multiprocessing does not match same plane from single process.".format(i)
+                f"Intermediate plane {i} from multiprocessing does not match same plane from single process."
 
         return psf_single, psf_multi
 

--- a/poppy/tests/test_nonsquare.py
+++ b/poppy/tests/test_nonsquare.py
@@ -1,7 +1,7 @@
-from .. import poppy_core as poppy
-from .. import optics
 import numpy as np
-import astropy.io.fits as fits
+
+from .. import optics
+from .. import poppy_core as poppy
 
 
 def test_nonsquare_detector_axes_lengths():
@@ -68,8 +68,7 @@ def test_nonsquare_detector_values(oversample=1, pixelscale=0.010, wavelength=1e
         # the maximum ought to be the same no matter what 
         for i in range(1, len(fovs_to_test)):
             thispsf = results[i]
-            if verbose: print("i = {}, shape={}, Maxes= {}, {}, diff={}".format(i,
-                fovs_to_test[i], psf0.max(), thispsf.max(), psf0.max() - thispsf.max()))
+            if verbose: print(f"i = {i}, shape={fovs_to_test[i]}, Maxes= {psf0.max()}, {thispsf.max()}, diff={psf0.max() - thispsf.max()}")
 
 
             assert(np.allclose(psf0.max(), thispsf.max()))

--- a/poppy/tests/test_optics.py
+++ b/poppy/tests/test_optics.py
@@ -1,15 +1,12 @@
 # Tests for individual Optic classes
 
-import matplotlib.pyplot as pl
 import astropy.units as u
-
-from .. import poppy_core
-from .. import optics
-from .. import utils
-
-from .. import accel_math
+import matplotlib.pyplot as pl
 import numpy as np
+
 from poppy.accel_math import xp
+
+from .. import accel_math, optics, poppy_core
 
 wavelength=1e-6
 
@@ -194,7 +191,6 @@ def test_SquareFieldStop():
 
 
 def test_CircularPhaseMask():
-    import poppy
     optic= optics.CircularPhaseMask(radius=1, retardance=0.25, wavelength=3e-6)
     wave = poppy_core.Wavefront(npix=100, pixelscale=0.05, wavelength=3e-6)
 
@@ -442,9 +438,10 @@ def test_ObscuredCircularAperture_Airy(display=False):
 
 
     if display:
-        from .. import utils
         #comparison of the two
         from matplotlib.colors import LogNorm
+
+        from .. import utils
         norm = LogNorm(vmin=1e-6, vmax=1e-2)
 
         pl.figure(figsize=(15,5))
@@ -491,6 +488,7 @@ def test_CompoundAnalyticOptic(display=False):
 
     if display:
         from matplotlib import pyplot as plt
+
         from poppy import utils
         plt.figure()
         plt.subplot(1, 2, 1)

--- a/poppy/tests/test_physical_wavefront.py
+++ b/poppy/tests/test_physical_wavefront.py
@@ -1,10 +1,7 @@
-import numpy as np
 import astropy.units as u
+import numpy as np
 
-from .. import poppy_core
-from .. import physical_wavefront
-from .. import fresnel
-from .. import optics
+from .. import fresnel, optics, physical_wavefront
 
 wavelength=1e-6
 

--- a/poppy/tests/test_sign_conventions.py
+++ b/poppy/tests/test_sign_conventions.py
@@ -1,7 +1,7 @@
-from poppy.accel_math import xp as np
 import astropy.units as u
-import poppy
 
+import poppy
+from poppy.accel_math import xp as np
 
 ####################################
 # Test sign conventions

--- a/poppy/tests/test_special_prop.py
+++ b/poppy/tests/test_special_prop.py
@@ -1,19 +1,16 @@
 # Test functions for specialized propagators 
-import os
 
-import numpy as np
-import matplotlib.pyplot as plt
-from astropy.io import fits
 import time
-import pytest
+
+import matplotlib.pyplot as plt
+import numpy as np
+
 try:
     import scipy
 except ImportError:
     scipy = None
 
-from .. import poppy_core
-from .. import optics
-from .. import special_prop
+from .. import optics, poppy_core, special_prop
 
 wavelen = 1e-6
 radius = 6.5/2
@@ -56,7 +53,7 @@ def test_SAMC(fft_oversample=4, samc_oversample=8, npix=512,
                     return_intermediates=True)
     t_stop_sam = time.time()
 
-    print("SAMC calculation: {} s".format(t_stop_sam - t_start_sam))
+    print(f"SAMC calculation: {t_stop_sam - t_start_sam} s")
     if display:
         plt.suptitle("Calculation using SAMC method")
         plt.figure()
@@ -64,7 +61,7 @@ def test_SAMC(fft_oversample=4, samc_oversample=8, npix=512,
     t_start_fft = time.time()
     psf_fft = osys.calc_psf(display_intermediates=display)
     t_stop_fft = time.time()
-    print("Basic FFT calculation: {} s".format(t_stop_fft - t_start_fft))
+    print(f"Basic FFT calculation: {t_stop_fft - t_start_fft} s")
     if display:
         plt.suptitle("Calculation using Basic FFT method")
 

--- a/poppy/tests/test_sub_sampled_optics.py
+++ b/poppy/tests/test_sub_sampled_optics.py
@@ -2,13 +2,12 @@
 Rachel Morgan, Summer 2020
 '''
 
-import numpy as np
-import poppy
-import matplotlib.pyplot as plt
 import astropy.units as u
-import astropy.io.fits as fits
+import numpy as np
 
+import poppy
 from poppy import sub_sampled_optics
+
 
 def test_ShackHartmannWFS(n_lenslets=2):
     """

--- a/poppy/tests/test_utils.py
+++ b/poppy/tests/test_utils.py
@@ -1,18 +1,22 @@
 import warnings
-import numpy as np
-from poppy.accel_math import xp
+
 import astropy.io.fits as fits
+import numpy as np
 import pytest
+
+from poppy.accel_math import xp
 
 try:
     import pyfftw
 except ImportError:
     pyfftw = None
 
-from .. import utils
-from .. import poppy_core
-import poppy
 import scipy
+
+import poppy
+
+from .. import poppy_core, utils
+
 
 def test_pad_to_size():
 
@@ -23,7 +27,7 @@ def test_pad_to_size():
         for desiredshape in [ (500, 500), (400,632), (2048, 312)]:
             newshape = utils.pad_to_size(square, desiredshape).shape
             for i in [0,1]:
-                assert newshape[i] == desiredshape[i], "Error padding from {} to {}".format(starting_shape, desired_shape)
+                assert newshape[i] == desiredshape[i], f"Error padding from {starting_shape} to {desired_shape}"
 
 
 
@@ -224,10 +228,10 @@ def test_measure_FWHM(display=False, verbose=False):
 
         meas_fwhm = utils.measure_fwhm(testfits, center=center)
         if verbose:
-            print("Measured FWHM: {0:.4f} arcsec, {1:.4f} pixels ".format(meas_fwhm, meas_fwhm/pxscl))
+            print(f"Measured FWHM: {meas_fwhm:.4f} arcsec, {meas_fwhm/pxscl:.4f} pixels ")
 
         reldiff =  np.abs((meas_fwhm/pxscl) - desired_fwhm ) / desired_fwhm
-        result = "Measured: {3:.4f} pixels; Desired: {0:.4f} pixels. Relative difference: {1:.4f}    Tolerance: {2:.4f}".format(desired_fwhm, reldiff, tolerance, meas_fwhm/pxscl)
+        result = f"Measured: {meas_fwhm/pxscl:.4f} pixels; Desired: {desired_fwhm:.4f} pixels. Relative difference: {reldiff:.4f}    Tolerance: {tolerance:.4f}"
         if verbose:
             print(result)
         assert reldiff < tolerance, result
@@ -252,7 +256,7 @@ def test_measure_FWHM(display=False, verbose=False):
 
         reldiff =  np.abs((meas_fwhm - expected_fwhm ) / expected_fwhm)
 
-        result = "Measured: {3:.4f} arcsec; Desired: {0:.4f} arcsec. Relative difference: {1:.4f}    Tolerance: {2:.4f}".format(expected_fwhm, reldiff, tolerance, meas_fwhm)
+        result = f"Measured: {meas_fwhm:.4f} arcsec; Desired: {expected_fwhm:.4f} arcsec. Relative difference: {reldiff:.4f}    Tolerance: {tolerance:.4f}"
 
         assert reldiff < tolerance, result
 

--- a/poppy/tests/test_wavefront.py
+++ b/poppy/tests/test_wavefront.py
@@ -1,13 +1,11 @@
 
-import poppy
-from .. import poppy_core
-from .. import optics
-import numpy as np
 import astropy.io.fits as fits
-from .test_core import check_wavefront
 import astropy.units as u
+import numpy as np
 
+import poppy
 
+from .. import optics, poppy_core
 
 wavelength=1e-6*u.m
 
@@ -79,7 +77,7 @@ def test_wavefront_rot90_vs_ndimagerotate_consistency(plot=False):
 
     assert np.allclose(wave2.intensity, wave.intensity, atol=1e-5), "Inconsistent results from the two rotation methods"
 
-    from poppy.tests.test_sign_conventions import brighter_top_half, brighter_left_half
+    from poppy.tests.test_sign_conventions import brighter_left_half, brighter_top_half
 
     assert brighter_left_half(wave.intensity), "Rotated wavefront orientation not as expected"
     assert not brighter_top_half(wave.intensity), "Rotated wavefront orientation not as expected"

--- a/poppy/tests/test_wfe.py
+++ b/poppy/tests/test_wfe.py
@@ -1,13 +1,10 @@
 
-import numpy as np
 import astropy.units as u
+import numpy as np
 
-from poppy.accel_math import xp, ensure_not_on_gpu
-from .. import poppy_core
-from .. import optics
-from .. import zernike
-from .. import wfe
-from .. import physical_wavefront
+from poppy.accel_math import ensure_not_on_gpu, xp
+
+from .. import optics, physical_wavefront, poppy_core, wfe, zernike
 
 NWAVES = 0.5
 WAVELENGTH = 1e-6
@@ -66,7 +63,7 @@ def test_ZernikeAberration(display=False):
     r = np.sqrt(y**2 + x**2)
     stddev = np.std((zern_wave.phase - tl_wave.phase)[r < RADIUS])
 
-    assert stddev < 1e-16, ("ZernikeAberration disagrees with ThinLens! stddev {}".format(stddev))
+    assert stddev < 1e-16, (f"ZernikeAberration disagrees with ThinLens! stddev {stddev}")
 
 
 def test_zernike_get_opd():
@@ -211,20 +208,21 @@ def test_StatisticalPSDWFE(index=3, seed=1234, plot=False):
         psd_wfe.display(what='both')
         plt.figure()
         plt.loglog(rad[1:], prof_norm[1:],
-                   label='StatisticalPSD output for {}'.format(index))
+                   label=f'StatisticalPSD output for {index}')
         plt.plot(rad[drop:-drop], plaw_fit(rad[drop:-drop]),
-                 label='power law fit: {:.5f}'.format(plaw_fit.alpha.value))
+                 label=f'power law fit: {plaw_fit.alpha.value:.5f}')
         plt.xlabel("Spatial frequency [1/m]")
         plt.ylabel("Normalized PSD")
         plt.legend()
     
     # check the spectral index is as desired, within at least a few percent
     assert np.isclose(index, plaw_fit.alpha, rtol=0.03), ("Measured output spectral index doesn't "
-            "match input within 3%: {} vs {}".format(index, plaw_fit.alpha) )
+            f"match input within 3%: {index} vs {plaw_fit.alpha}" )
 
 def test_PowerSpectrumWFE(plot=False):
     # verify self-consistency of PowerSpectrumWFE with a reference case
     import os
+
     import astropy.io.fits as fits
     
     # declare internal functions
@@ -279,12 +277,12 @@ def test_PowerSpectrumWFE(plot=False):
         plt.figure(dpi=100)
         plt.imshow(surf_ref.value, origin='lower')
         plt.colorbar().set_label(surf_ref.unit)
-        plt.title('Ref surf, RMS={0:.4f}, PV={1:.2f}'.format(rms_ref, pv_ref))
+        plt.title(f'Ref surf, RMS={rms_ref:.4f}, PV={pv_ref:.2f}')
 
         plt.figure(dpi=100)
         plt.imshow(psd_opd.value, origin='lower')
         plt.colorbar().set_label(psd_opd.unit)
-        plt.title('PSD surf, RMS={0:.4f}, PV={1:.2f}'.format(psd_rms, psd_pv))
+        plt.title(f'PSD surf, RMS={psd_rms:.4f}, PV={psd_pv:.2f}')
 
 def test_KolmogorovWFE():
     CN2 = 1e-14*u.m**(-2/3)

--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -1,9 +1,9 @@
 import numpy as np
-from poppy import poppy_core
-from poppy import optics
-from poppy import zernike
-from poppy.accel_math import xp as np
+
 import poppy.accel_math
+from poppy import optics, poppy_core, zernike
+from poppy.accel_math import xp as np
+
 
 def test_zernikes_rms(nterms=10, size=500):
     """Verify RMS(Zernike[n,m]) == 1."""
@@ -12,7 +12,7 @@ def test_zernikes_rms(nterms=10, size=500):
         n, m = zernike.noll_indices(j)
         z = zernike.zernike(n, m, npix=size)
         rms = np.nanstd(z)  # exclude masked pixels
-        assert abs(1.0 - rms) < 0.001, "Zernike(j={}) has RMS value of {}".format(j, rms)
+        assert abs(1.0 - rms) < 0.001, f"Zernike(j={j}) has RMS value of {rms}"
 
 
 def test_ones_zernikes(nterms=10):
@@ -21,7 +21,7 @@ def test_ones_zernikes(nterms=10):
     for j in np.arange(nterms) + 1:
         n, m = zernike.noll_indices(j)
         rs = zernike.R(n, m, rho)
-        print("j=%d\tZ_(%d,%d) [1] = \t %s" % (j, n, m, str(rs)))
+        print(f"j={j}\tZ_({n},{m}) [1] = \t {rs}")
         assert rs[0] == rs[1] == rs[2], "Radial polynomial is not radially symmetric"
 
 
@@ -86,8 +86,7 @@ def _test_cross_zernikes(testj=4, nterms=10, npix=500):
         wg = np.where(np.isfinite(prod))
         cross_sum = np.abs(prod[wg].sum())
         assert cross_sum < 1e-9, (
-            "orthogonality failure, Sum[Zernike(j={}) * Zernike(j={})] = {} (> 1e-9)".format(
-                j, testj, cross_sum)
+            f"orthogonality failure, Sum[Zernike(j={j}) * Zernike(j={testj})] = {cross_sum} (> 1e-9)"
         )
 
 
@@ -133,8 +132,7 @@ def _test_cross_hexikes(testj=4, nterms=10, npix=500):
         # Threshold was originally 1e-9, but we ended up getting 1.19e-9 on some machines (not always)
         # this seems acceptable, so relaxing criteria slightly
         assert cross_sum < 2e-9, (
-            "orthogonality failure, Sum[Hexike(j={}) * Hexike(j={})] = {} (> 2e-9)".format(
-                j, testj, cross_sum)
+            f"orthogonality failure, Sum[Hexike(j={j}) * Hexike(j={testj})] = {cross_sum} (> 2e-9)"
         )
 
 
@@ -159,7 +157,7 @@ def test_arbitrary_basis_rms(nterms=10, size=500):
     assert np.nanstd(square_basis[0]) == 0.0, "Mode(j=0) has nonzero RMS"
     for j in range(1, nterms):
         rms = np.nanstd(square_basis[j])  # exclude masked pixels
-        assert abs(1.0 - rms) < 0.001, "Mode(j={}) has RMS value of {}".format(j, rms)
+        assert abs(1.0 - rms) < 0.001, f"Mode(j={j}) has RMS value of {rms}"
 
 
 def _test_cross_arbitrary_basis(testj=4, nterms=10, npix=500):
@@ -194,8 +192,7 @@ def _test_cross_arbitrary_basis(testj=4, nterms=10, npix=500):
         # Threshold was originally 1e-9, but we ended up getting 1.19e-9 on some machines (not always)
         # this seems acceptable, so relaxing criteria slightly
         assert cross_sum < 2e-9, (
-            "orthogonality failure, Sum[Mode(j={}) * Mode(j={})] = {} (> 2e-9)".format(
-                j, testj, cross_sum)
+            f"orthogonality failure, Sum[Mode(j={j}) * Mode(j={testj})] = {cross_sum} (> 2e-9)"
         )
 
 
@@ -255,7 +252,7 @@ def test_hex_aperture():
     for npix in npix_to_try:
         assert np.all(optics.HexagonAperture(side=1).sample(npix=npix, grid_size=2) -
                       zernike.hex_aperture( npix=npix) == 0), \
-                      "hex_aperture and HexagonAperture outputs differ for npix={}".format(npix)
+                      f"hex_aperture and HexagonAperture outputs differ for npix={npix}"
 
 
 def test_zern_name():

--- a/poppy/utils.py
+++ b/poppy/utils.py
@@ -8,26 +8,21 @@ import json
 import logging
 import os.path
 import pickle
+import warnings
 
+import astropy.io.fits as fits
+import astropy.units as u
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.interpolate
 import scipy.ndimage
-import warnings
-
 from astropy import config
-import astropy.units as u
-
-import astropy.io.fits as fits
 
 import poppy
 
-from importlib import reload
-
 from . import accel_math
-
-from .accel_math import xp, _scipy
+from .accel_math import xp
 
 try:
     import pyfftw
@@ -92,7 +87,7 @@ def imshow_with_mouseover(image0, ax=None, *args, **kwargs):
         img_x = np.floor((x - imext[0]) / (imext[1] - imext[0]) * imsize[1])
         img_x = int(img_x.clip(0, imsize[1] - 1))
 
-        return "(%6.3f, %6.3f)     %-12.6g" % (x, y, aximage[img_y, img_x])
+        return f"({x:6.3f}, {y:6.3f})     {aximage[img_y, img_x]:<12.6g}"
 
     ax.format_coord = report_pixel
     return ax
@@ -247,7 +242,7 @@ def display_psf(hdulist_or_filename, ext=0, vmin=1e-7, vmax=1e-1,
         ceny *= coordinate_rescale  # if display coordinate unit isn't arcseconds, rescale the centroid accordingly
         cenx *= coordinate_rescale
         ax.plot(cenx, ceny, 'k+', markersize=15, markeredgewidth=1)
-        _log.info("centroid: (%f, %f) " % (cenx, ceny))
+        _log.info(f"centroid: ({cenx:f}, {ceny:f}) ")
 
     if imagecrop is not None:
         halffov_x = min((imagecrop / 2.0, halffov_x))
@@ -259,7 +254,7 @@ def display_psf(hdulist_or_filename, ext=0, vmin=1e-7, vmax=1e-1,
         ax.axvline(0, ls=':', color='k')
     if title is None:
         try:
-            fspec = "%s, %s" % (hdulist[ext].header['INSTRUME'], hdulist[ext].header['FILTER'])
+            fspec = "{}, {}".format(hdulist[ext].header['INSTRUME'], hdulist[ext].header['FILTER'])
         except KeyError:
             fspec = str(hdulist_or_filename)
         title = "PSF sim for " + fspec
@@ -448,9 +443,9 @@ def display_ee(hdulist_or_filename=None, ext=0, overplot=False, ax=None, mark_le
     mark_levels : bool
         If set, mark and label on the plots the radii for 50%, 80%, 95% encircled energy.
         Default is True
-    levels : list 
+    levels : list
         if not None and mark_levels is true then this list specifies alternative levels
-        
+
     """
     if isinstance(hdulist_or_filename, str):
         hdu_list = fits.open(hdulist_or_filename)
@@ -479,7 +474,7 @@ def display_ee(hdulist_or_filename=None, ext=0, overplot=False, ax=None, mark_le
         for level in markers:
             ee_lev = radius[np.where(ee > level)[0][0]]
             yoffset = 0 if level < 0.9 else -0.05
-            plt.text(ee_lev + 0.1, level + yoffset, 'EE=%2d%% at r=%.3f"' % (level * 100, ee_lev))
+            plt.text(ee_lev + 0.1, level + yoffset, f'EE={level * 100:2d}% at r={ee_lev:.3f}"')
 
 
 def display_profiles(hdulist_or_filename=None, ext=0, overplot=False, title=None, **kwargs):
@@ -510,7 +505,7 @@ def display_profiles(hdulist_or_filename=None, ext=0, overplot=False, title=None
 
     if title is None:
         try:
-            title = "%s, %s" % (hdu_list[ext].header['INSTRUME'], hdu_list[ext].header['FILTER'])
+            title = "{}, {}".format(hdu_list[ext].header['INSTRUME'], hdu_list[ext].header['FILTER'])
         except KeyError:
             title = str(hdulist_or_filename)
 
@@ -523,7 +518,7 @@ def display_profiles(hdulist_or_filename=None, ext=0, overplot=False, title=None
     plt.semilogy(radius, profile)
 
     fwhm = 2 * radius[np.where(profile < profile[0] * 0.5)[0][0]]
-    plt.text(fwhm, profile[0] * 0.5, 'FWHM = %.3f"' % fwhm)
+    plt.text(fwhm, profile[0] * 0.5, f'FWHM = {fwhm:.3f}"')
 
     plt.subplot(2, 1, 2)
     # plt.semilogy(radius, ee, nonposy='clip')
@@ -536,7 +531,7 @@ def display_profiles(hdulist_or_filename=None, ext=0, overplot=False, title=None
         if (ee > level).any():
             ee_lev = radius[np.where(ee > level)[0][0]]
             yoffset = 0 if level < 0.9 else -0.05
-            plt.text(ee_lev + 0.1, level + yoffset, 'EE=%2d%% at r=%.3f"' % (level * 100, ee_lev))
+            plt.text(ee_lev + 0.1, level + yoffset, f'EE={level * 100:2d}% at r={ee_lev:.3f}"')
 
 
 def radial_profile(hdulist_or_filename=None, ext=0, ee=False, center=None, stddev=False, mad=False,
@@ -891,7 +886,7 @@ def measure_fwhm(hdulist_or_filename, ext=0, center=None, plot=False, threshold=
         FWHM in arcseconds
 
     """
-    from astropy.modeling import models, fitting
+    from astropy.modeling import fitting, models
 
     if isinstance(hdulist_or_filename, str):
         hdulist = fits.open(hdulist_or_filename)
@@ -905,21 +900,21 @@ def measure_fwhm(hdulist_or_filename, ext=0, center=None, plot=False, threshold=
 
     pixelscale = hdulist[ext].header['PIXELSCL']
 
-    _log.debug("Pixelscale is {} arcsec/pix.".format(pixelscale, ))
+    _log.debug(f"Pixelscale is {pixelscale} arcsec/pix.")
 
     # Prepare array r with radius in arcseconds
     y, x = np.indices(image.shape, dtype=float)
     if center is None:
         # get exact center of image
         center = tuple((a - 1) / 2.0 for a in image.shape[::-1])
-    _log.debug("Using PSF center = {}".format(center))
+    _log.debug(f"Using PSF center = {center}")
     x -= center[0]
     y -= center[1]
     r = np.sqrt(x ** 2 + y ** 2) * pixelscale  # radius in arcseconds
 
     # Select pixels above that threshold
     wpeak = np.where(image > threshold)  # note, image is normalized to peak=1 above
-    _log.debug("Using {} pixels above {} of peak".format(len(wpeak[0]), threshold))
+    _log.debug(f"Using {len(wpeak[0])} pixels above {threshold} of peak")
 
     rpeak = r[wpeak]
     impeak = image[wpeak]
@@ -929,7 +924,7 @@ def measure_fwhm(hdulist_or_filename, ext=0, center=None, plot=False, threshold=
         std_guess = hdulist[ext].header['DIFFLMT'] / 2.354
     else:
         std_guess = measure_fwhm_radprof(hdulist, ext=ext, center=center, nowarn=True) / 2.354
-    _log.debug("Initial guess Gaussian sigma= {} arcsec".format(std_guess))
+    _log.debug(f"Initial guess Gaussian sigma= {std_guess} arcsec")
 
     # Determine best fit Gaussian parameters
     g_init = models.Gaussian1D(amplitude=1., mean=0, stddev=std_guess)
@@ -937,7 +932,7 @@ def measure_fwhm(hdulist_or_filename, ext=0, center=None, plot=False, threshold=
 
     fit_g = fitting.LevMarLSQFitter()
     g = fit_g(g_init, rpeak, impeak)
-    _log.debug("Fit results for Gaussian: {}, {}".format(g.amplitude, g.stddev))
+    _log.debug(f"Fit results for Gaussian: {g.amplitude}, {g.stddev}")
 
     # Convert from the fit result sigma parameter to FWHM.
     # note, astropy fitting doesn't constrain the stddev to be positive for some reason.
@@ -955,7 +950,7 @@ def measure_fwhm(hdulist_or_filename, ext=0, center=None, plot=False, threshold=
 
         plt.axhline(0.5, ls=":")
         plt.axvline(fwhm / 2, ls=':')
-        plt.text(0.1, 0.2, 'FWHM={:.4f} arcsec'.format(fwhm), transform=plt.gca().transAxes, )
+        plt.text(0.1, 0.2, f'FWHM={fwhm:.4f} arcsec', transform=plt.gca().transAxes, )
 
         plt.gca().set_ylim(threshold * .5, 2)
 
@@ -1008,7 +1003,7 @@ def measure_fwhm_radprof(HDUlist_or_filename=None, ext=0, center=None, level=0.5
     if len(wlower[0]) == 0:
         raise ValueError(
             "The supplied array's pixel values never go below {0:.2f} of its maximum, {1:.3g}. " +
-            "Cannot measure FWHM.".format(level, rpmax))
+            "Cannot measure FWHM.")
     wmin = np.min(wlower[0])
     # go just a bit beyond the half way mark
     winterp = np.arange(0, wmin + 2, dtype=int)[::-1]
@@ -1104,7 +1099,7 @@ def measure_centroid(HDUlist_or_filename=None, ext=0, slice=0, boxsize=20, verbo
     cent_of_mass = fwcentroid(image, halfwidth=boxsize, **kwargs)
 
     if verbose:
-        print("Center of mass: (%.4f, %.4f)" % (cent_of_mass[1], cent_of_mass[0]))
+        print(f"Center of mass: ({cent_of_mass[1]:.4f}, {cent_of_mass[0]:.4f})")
 
     if relativeto == 'center':
         imcen = np.array([(image.shape[0] - 1) / 2., (image.shape[1] - 1) / 2.])
@@ -1234,15 +1229,15 @@ def pad_or_crop_to_shape(array, target_shape):
 
         resampled_array = xp.zeros(shape=(lx_w, ly_w), dtype=array.dtype)
         resampled_array[border_x:border_x + lx, border_y:border_y + ly] = array
-        _log.debug("  Padded with a {:d} x {:d} border to "
-                   " match the desired shape".format(border_x, border_y))
+        _log.debug(f"  Padded with a {border_x:d} x {border_y:d} border to "
+                   " match the desired shape")
 
     else:
         _log.debug("Array shape " + str(array.shape) + " is larger than desired shape " + str(
             [lx_w, ly_w]) + "; will crop out just the center part.")
         resampled_array = array[border_x:border_x + lx_w, border_y:border_y + ly_w]
-        _log.debug("  Trimmed a border of {:d} x {:d} pixels "
-                   "to match the desired shape".format(border_x, border_y))
+        _log.debug(f"  Trimmed a border of {border_x:d} x {border_y:d} pixels "
+                   "to match the desired shape")
     return resampled_array
 
 
@@ -1298,8 +1293,8 @@ def rebin_array(a=None, rc=(2, 2), verbose=False):
             Clo = ci * c
             b[ri, ci] = a[Rlo:Rlo + r, Clo:Clo + c].sum()
             if verbose:
-                print("    [%d:%d, %d:%d]" % (Rlo, Rlo + r, Clo, Clo + c))
-                print("%4.0f" % b[ri, ci])
+                print(f"    [{Rlo:d}:{Rlo + r:d}, {Clo:d}:{Clo + c:d}]")
+                print(f"{b[ri, ci]:4.0f}")
     return b
 
 
@@ -1330,7 +1325,7 @@ def krebin(a, shape):
 #
 
 
-class BackCompatibleQuantityInput(object):
+class BackCompatibleQuantityInput:
     # Modified from code in astropy.units.decorators.py
     # See http://docs.astropy.org/en/stable/_modules/astropy/units/decorators.html
 
@@ -1396,9 +1391,10 @@ class BackCompatibleQuantityInput(object):
         self.decorator_kwargs = kwargs
 
     def __call__(self, wrapped_function):
-        from functools import wraps
-        from astropy.units import UnitsError, add_enabled_equivalencies, Quantity
         import inspect
+        from functools import wraps
+
+        from astropy.units import Quantity, UnitsError, add_enabled_equivalencies
 
         # Extract the function signature for the function we are wrapping.
         wrapped_signature = inspect.signature(wrapped_function)
@@ -1440,30 +1436,26 @@ class BackCompatibleQuantityInput(object):
                         try:
                             tmp = np.asarray(arg, dtype=float)
                         except (ValueError, TypeError):
-                            raise ValueError("Argument '{0}' to function '{1}'"
-                                             " must be a number (not '{3}'), and convertible to"
-                                             " units='{2}'.".format(param.name,
-                                                                    wrapped_function.__name__,
-                                                                    target_unit.to_string(), arg))
+                            raise ValueError(f"Argument '{param.name}' to function '{wrapped_function.__name__}'"
+                                             f" must be a number (not '{arg}'), and convertible to"
+                                             f" units='{target_unit.to_string()}'.")
 
                     try:
                         equivalent = arg.unit.is_equivalent(target_unit,
                                                             equivalencies=self.equivalencies)
 
                         if not equivalent:
-                            raise UnitsError("Argument '{0}' to function '{1}'"
+                            raise UnitsError(f"Argument '{param.name}' to function '{wrapped_function.__name__}'"
                                              " must be in units convertible to"
-                                             " '{2}'.".format(param.name,
-                                                              wrapped_function.__name__,
-                                                              target_unit.to_string()))
+                                             f" '{target_unit.to_string()}'.")
 
                     # Either there is no .unit or no .is_equivalent
                     except AttributeError:
                         if hasattr(arg, "unit"):
                             error_msg = "a 'unit' attribute without an 'is_equivalent' method"
-                            raise TypeError("Argument '{0}' to function '{1}' has {2}. "
+                            raise TypeError(f"Argument '{param.name}' to function '{wrapped_function.__name__}' has {error_msg}. "
                                             "You may want to pass in an astropy Quantity instead."
-                                            .format(param.name, wrapped_function.__name__, error_msg))
+                                            )
                         else:
                             # apply the default unit here, without complaint
                             # print("Updating: "+param.name)
@@ -1520,13 +1512,13 @@ def spectrum_from_spectral_type(sptype, return_list=False, catalog=None):
         import os
         cdbs = os.getenv('PYSYN_CDBS')
         if cdbs is None:
-            raise EnvironmentError("Environment variable $PYSYN_CDBS must be defined for synphot")
+            raise OSError("Environment variable $PYSYN_CDBS must be defined for synphot")
         if os.path.exists(os.path.join(os.getenv('PYSYN_CDBS'), 'grid', 'phoenix')):
             catalog = 'phoenix'
         elif os.path.exists(os.path.join(os.getenv('PYSYN_CDBS'), 'grid', 'ck04models')):
             catalog = 'ck04'
         else:
-            raise IOError("Could not find either phoenix or ck04models subdirectories of $PYSYN_CDBS/grid")
+            raise OSError("Could not find either phoenix or ck04models subdirectories of $PYSYN_CDBS/grid")
 
     if catalog.lower() == 'ck04':
         catname = 'ck04models'
@@ -1650,7 +1642,7 @@ def spectrum_from_spectral_type(sptype, return_list=False, catalog=None):
         sptype_list.insert(0, "Flat spectrum in F_lambda")
         # add a variety of spectral type slopes, per request from Dean Hines
         for slope in [-3, -2, -1.5, -1, -0.75, -0.5, 0.5, 0.75, 1.0, 1.5, 2, 3]:
-            sptype_list.insert(0, "Power law F_nu ~ nu^(%s)" % str(slope))
+            sptype_list.insert(0, f"Power law F_nu ~ nu^({str(slope)})")
         # sptype_list.insert(0,"Power law F_nu ~ nu^(-0.75)")
         # sptype_list.insert(0,"Power law F_nu ~ nu^(-1.0)")
         # sptype_list.insert(0,"Power law F_nu ~ nu^(-1.5)")
@@ -1682,9 +1674,9 @@ def spectrum_from_spectral_type(sptype, return_list=False, catalog=None):
         keys = lookuptable[sptype]
         try:
             return grid_to_spec(catname, keys[0], keys[1], keys[2])
-        except IOError:
+        except OSError:
             errmsg = ("Could not find a match in catalog {0} for key {1}. Check that is a valid name in the " +
-                      "lookup table, and/or that synphot is installed properly.".format(catname, sptype))
+                      "lookup table, and/or that synphot is installed properly.")
             _log.critical(errmsg)
             raise LookupError(errmsg)
 
@@ -1735,8 +1727,7 @@ def estimate_optimal_nprocesses(osys, nwavelengths=None, padding_factor=None, me
     propinfo = osys._propagation_info()
     if 'FFT' in propinfo['steps']:
         wavefrontsize = wfshape[0] * wfshape[1] * osys.oversample ** 2 * 16  # 16 bytes = complex double size
-        _log.debug('FFT propagation with array={0}, oversample = {1} uses {2} bytes'.format(wfshape[0], osys.oversample,
-                                                                                            wavefrontsize))
+        _log.debug(f'FFT propagation with array={wfshape[0]}, oversample = {osys.oversample} uses {wavefrontsize} bytes')
         # The following is a very rough estimate
         # empirical tests show that an 8192x8192 propagation results in Python sessions with ~4 GB memory used w/ FFTW
         # using numpy FT, the memory usage per process can exceed 5 GB for an 8192x8192 propagation.
@@ -1744,7 +1735,7 @@ def estimate_optimal_nprocesses(osys, nwavelengths=None, padding_factor=None, me
     else:
         # oversampling not relevant for memory size in MFT mode
         wavefrontsize = wfshape[0] * wfshape[1] * 16  # 16 bytes = complex double size
-        _log.debug('MFT propagation with array={0} uses {2} bytes'.format(wfshape[0], osys.oversample, wavefrontsize))
+        _log.debug(f'MFT propagation with array={wfshape[0]} uses {wavefrontsize} bytes')
         padding_factor = 1
 
     mem_per_prop = wavefrontsize * padding_factor
@@ -1762,7 +1753,7 @@ def estimate_optimal_nprocesses(osys, nwavelengths=None, padding_factor=None, me
         if recommendation > nwavelengths:
             recommendation = nwavelengths
 
-    _log.info("estimated optimal # of processes is {0}".format(recommendation))
+    _log.info(f"estimated optimal # of processes is {recommendation}")
     return recommendation
 
 
@@ -1827,8 +1818,8 @@ def fftw_load_wisdom(filename=None):
         try:
             wisdom = json.load(wisdom_file)
         except ValueError:  # catches json.JSONDecodeError on Python 3.x too
-            warnings.warn("Unable to parse FFTW wisdom in {}. "
-                          "The file may be corrupt.".format(filename), FFTWWisdomWarning)
+            warnings.warn(f"Unable to parse FFTW wisdom in {filename}. "
+                          "The file may be corrupt.", FFTWWisdomWarning)
             return
 
     # Python 3.x+ doesn't let us use ascii implicitly, but PyFFTW only accepts bytestrings
@@ -1839,9 +1830,9 @@ def fftw_load_wisdom(filename=None):
 
     success_double, success_single, success_longdouble = pyfftw.import_wisdom(wisdom_tuple)
 
-    _log.debug("Reloaded double precision wisdom: {}".format(success_double))
-    _log.debug("Reloaded single precision wisdom: {}".format(success_single))
-    _log.debug("Reloaded longdouble precision wisdom: {}".format(success_longdouble))
+    _log.debug(f"Reloaded double precision wisdom: {success_double}")
+    _log.debug(f"Reloaded single precision wisdom: {success_single}")
+    _log.debug(f"Reloaded longdouble precision wisdom: {success_longdouble}")
 
     try:
         saved_fftw_init = pickle.loads(wisdom['_FFTW_INIT'].encode('ascii'))

--- a/poppy/wfe.py
+++ b/poppy/wfe.py
@@ -11,22 +11,17 @@ error in an OpticalSystem
 
 """
 
-import numpy as np
 import collections
 from functools import wraps
+
 import astropy.units as u
+import numpy as np
 
+from . import accel_math, utils, zernike
+from .accel_math import ensure_not_on_gpu, xp
 from .optics import AnalyticOpticalElement, CircularAperture
-from .poppy_core import Wavefront, PlaneType, BaseWavefront
-from poppy.fresnel import FresnelWavefront
 from .physical_wavefront import PhysicalFresnelWavefront
-
-from . import zernike
-from . import utils
-from . import accel_math
-
-from .accel_math import xp, ensure_not_on_gpu
-
+from .poppy_core import BaseWavefront, PlaneType
 
 __all__ = ['WavefrontError', 'ParameterizedWFE', 'ZernikeWFE', 'SineWaveWFE',
            'StatisticalPSDWFE', 'PowerSpectrumWFE', 'KolmogorovWFE', 'ThermalBloomingWFE']
@@ -56,7 +51,7 @@ class WavefrontError(AnalyticOpticalElement):
     def __init__(self, **kwargs):
         if 'planetype' not in kwargs:
             kwargs['planetype'] = PlaneType.pupil
-        super(WavefrontError, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         # in general we will want to see phase rather than intensity at this plane
         self.wavefront_display_hint = 'phase'
 
@@ -154,7 +149,7 @@ class ParameterizedWFE(WavefrontError):
         self.coefficients = coefficients
         self.basis_factory = basis_factory
         self._default_display_size = radius * 3
-        super(ParameterizedWFE, self).__init__(name=name, **kwargs)
+        super().__init__(name=name, **kwargs)
 
     @_check_wavefront_arg
     def get_opd(self, wave):
@@ -204,7 +199,7 @@ class ZernikeWFE(WavefrontError):
         self.circular_aperture = CircularAperture(radius=self.radius, gray_pixel=False, **kwargs)
         self._default_display_size = radius * 3
         kwargs.update({'name': name})
-        super(ZernikeWFE, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     @_check_wavefront_arg
     def get_opd(self, wave):
@@ -489,7 +484,7 @@ class PowerSpectrumWFE(WavefrontError):
         self.incident_angle = incident_angle
             
         if psd_weight is None:
-            self.psd_weight = xp.ones((len(psd_parameters))) # default to equal weights
+            self.psd_weight = xp.ones(len(psd_parameters)) # default to equal weights
         else:
             self.psd_weight = psd_weight
         
@@ -578,7 +573,7 @@ class PowerSpectrumWFE(WavefrontError):
         psd_scaled = (xp.sqrt(psd/(wave.pixelscale.value**2)) * rndm_noise)
 #         opd = ((np.fft.ifft2(np.fft.ifftshift(psd_scaled)).real*surf_unit).to(u.m)).value 
 #         opd = ((xp.fft.ifft2(xp.fft.ifftshift(psd_scaled)).real))*1e-9 # this is assuming the opd is calculated in nm
-        opd = ((xp.fft.ifft2(xp.fft.ifftshift(psd_scaled)).real))*(1*surf_unit).to_value(u.m) # fixed the hardcoded 1e-9
+        opd = (xp.fft.ifft2(xp.fft.ifftshift(psd_scaled)).real)*(1*surf_unit).to_value(u.m) # fixed the hardcoded 1e-9
         
         # Set rms value based on the active region of beam
         if self.rms is not None:
@@ -657,7 +652,7 @@ class KolmogorovWFE(WavefrontError):
         if dz is None and not all(item is not None for item in [r0, Cn2]):
             raise ValueError('To prepare a turbulent phase screen, dz and either Cn2 or r0 must be given.')
         
-        super(KolmogorovWFE, self).__init__(name=name, **kwargs)
+        super().__init__(name=name, **kwargs)
         
         self.r0 = r0
         self.Cn2 = Cn2
@@ -918,7 +913,7 @@ class ThermalBloomingWFE(WavefrontError):
                  p0=101.325*u.kPa, T0=300.0*u.K, direction='x',
                  isobaric=False, **kwargs):
         
-        super(ThermalBloomingWFE, self).__init__(name=name, **kwargs)
+        super().__init__(name=name, **kwargs)
         
         self.abs_coeff = abs_coeff.to(1/u.m).value
         self.dz = dz.to(u.m).value

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -22,22 +22,19 @@ Gram-Schmidt orthonormalization process as applied to this case is
     Mahajan and Dai, 2006. Optics Letters Vol 31, 16, p 2462:
 """
 
-import numpy as np
 import inspect
-from math import factorial
-import scipy
-
-import sys
 import logging
+from functools import lru_cache
+from math import factorial
 
 import astropy.units as u
+import numpy as np
+import scipy
 
 from poppy.poppy_core import Wavefront
 
 from . import accel_math
 from .accel_math import xp
-
-from functools import lru_cache
 
 __all__ = [
     'R', 'cached_zernike1', 'hex_aperture', 'hexike_basis', 'noll_indices',
@@ -75,7 +72,7 @@ def zern_name(i):
     if i < len(names):
         return names[i]
     else:
-        return "Z%d" % i
+        return f"Z{i}"
 
 
 def str_zernike(n, m):
@@ -98,11 +95,11 @@ def str_zernike(n, m):
         if n == 0:
             return "1"
         else:
-            return "sqrt(%d)* ( %s ) " % (n + 1, outstr)
+            return f"sqrt({n+1:d})* ( {outstr} ) "
     elif signed_m > 0:
-        return "\\sqrt{%d}* ( %s ) * \\cos(%d \\theta)" % (2 * (n + 1), outstr, m)
+        return f"\\sqrt{{{2 * (n + 1):d}}}* ( {outstr} ) * \\cos({m} \\theta)"
     else:
-        return "\\sqrt{%d}* ( %s ) * \\sin(%d \\theta)" % (2 * (n + 1), outstr, m)
+        return f"\\sqrt{{{2 * (n + 1):d}}}* ( {outstr} ) * \\sin({m} \\theta)"
 
 
 def noll_indices(j):
@@ -149,7 +146,7 @@ def noll_indices(j):
 
         m = row_m[resid] * sign
 
-    _log.debug("J=%d:\t(n=%d, m=%d)" % (j, n, m))
+    _log.debug(f"J={j:d}:\t(n={n}, m={m})")
     return n, m
 
 
@@ -230,9 +227,9 @@ def zernike(n, m, npix=100, rho=None, theta=None, outside=np.nan,
     if not n >= m:
         raise ValueError("Zernike index m must be >= index n")
     if (n - m) % 2 != 0:
-        _log.warning("Radial polynomial is zero for these inputs: m={}, n={} "
-                  "(are you sure you wanted this Zernike?)".format(m, n))
-    _log.debug("Zernike(n=%d, m=%d)" % (n, m))
+        _log.warning(f"Radial polynomial is zero for these inputs: m={m}, n={n} "
+                  "(are you sure you wanted this Zernike?)")
+    _log.debug(f"Zernike(n={n}, m={m})")
 
     if theta is None and rho is None:
         x = (xp.arange(npix, dtype=xp.float64) - (npix - 1) / 2.) / ((npix - 1) / 2.)
@@ -294,7 +291,7 @@ def zernike1(j, **kwargs):
     return zernike(n, m, **kwargs)
 
 
-@lru_cache()
+@lru_cache
 def cached_zernike1(j, shape, pixelscale, pupil_radius, outside=np.nan, noll_normalize=True):
     """Compute Zernike based on Noll index *j*, using an LRU cache
     for efficiency. Refer to the `zernike1` docstring for details.
@@ -360,7 +357,7 @@ def zernike_basis(nterms=15, npix=512, rho=None, theta=None, **kwargs):
     return zern_output
 
 
-@lru_cache()
+@lru_cache
 def zernike_basis_faster(nterms=15, npix=512, outside=np.nan):
     """
     Return a cube of Zernike terms from 1 to N each as a 2D array
@@ -401,7 +398,7 @@ def zernike_basis_faster(nterms=15, npix=512, outside=np.nan):
     aperture[rho > 1] = 0.0  # this is the aperture mask
     noll_normalize = True
 
-    @lru_cache()
+    @lru_cache
     def cached_R(n, m):
         """Compute R[n, m], the Zernike radial polynomial
 
@@ -575,7 +572,7 @@ def hexike_basis(nterms=15, npix=512, rho=None, theta=None,
             c[(j + 1, k)] = -1 / A * (Z[j + 1] * H[k] * apmask_float).sum()
             if c[(j + 1, k)] != 0:
                 nextG += c[(j + 1, k)] * H[k]
-            _log.debug("    c[%s] = %f", str((j + 1, k)), c[(j + 1, k)])
+            _log.debug("    c[{(j + 1, k)!s}] = {c[(j + 1, k)]}")
 
         nextH = nextG / np.sqrt((nextG ** 2).sum() / A)
 
@@ -782,8 +779,8 @@ def arbitrary_basis(aperture, nterms=15, rho=None, theta=None, outside=np.nan):
 
         # calculate padding for oversizing zernike_basis
         ceil = lambda x: xp.ceil(x) if x > 0 else 0  # avoid negative values
-        padding = (int(ceil((max_extent - (shape[0] - 1) / 2.))),
-                   int(ceil((max_extent - (shape[1] - 1) / 2.))))
+        padding = (int(ceil(max_extent - (shape[0] - 1) / 2.)),
+                   int(ceil(max_extent - (shape[1] - 1) / 2.)))
         padded_shape = (shape[0] + padding[0] * 2, shape[1] + padding[1] * 2)
         npix = padded_shape[0]
 
@@ -825,7 +822,7 @@ def arbitrary_basis(aperture, nterms=15, rho=None, theta=None, outside=np.nan):
 
     return basis
 
-class Segment_PTT_Basis(object):
+class Segment_PTT_Basis:
     def __init__(self, rings=2, flattoflat=1*u.m, gap=1*u.cm, center=False,
                  pupil_diam=None, **kwargs):
         """
@@ -896,7 +893,7 @@ class Segment_PTT_Basis(object):
         if nterms is None:
             nterms = 3*self.nsegments
         elif nterms > 3*self.nsegments:
-            raise ValueError("nterms must be <= {} for the specified segment aperture.".format(3*self.nsegments))
+            raise ValueError(f"nterms must be <= {3*self.nsegments} for the specified segment aperture.")
 
         # Re-use the machinery inside the HexSegmentedDM class to set up the
         # arrays defining the segment and zernike geometry.
@@ -934,7 +931,7 @@ class Segment_Piston_Basis(Segment_PTT_Basis):
         if nterms is None:
             nterms = self.nsegments
         elif nterms > self.nsegments:
-            raise ValueError("nterms must be <= {} for the specified segment aperture.".format(self.nsegments))
+            raise ValueError(f"nterms must be <= {self.nsegments} for the specified segment aperture.")
 
         aperture = self.hexdm.sample(npix=npix)
 
@@ -1106,7 +1103,7 @@ def decompose_opd_nonorthonormal_basis(opd, aperture=None, nterms=15, basis=zern
             opd_copy -= this_coeff * b
             coeffs[i] += this_coeff
         if verbose:
-            print("Iteration {}/{}: {}".format(count, iterations, coeffs))
+            print(f"Iteration {count}/{iterations}: {coeffs}")
 
     return coeffs
 
@@ -1287,7 +1284,7 @@ def decompose_opd_segments(opd, aperture=None, nterms=15, basis=None,
             coeffs[i] += this_coeff
 
         if verbose:
-            print("Iteration {}/{}: {}".format(count, iterations, coeffs))
+            print(f"Iteration {count}/{iterations}: {coeffs}")
     return coeffs
 
 # Back compatibility aliases, for the names in poppy pre 1.0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,3 +135,25 @@ omit = [
     "*/poppy/*/*/tests/*",
     "*/poppy/version*",
 ]
+
+[tool.ruff]
+line-length = 120          # scientific code with array literals often wants more room than 88
+target-version = "py311"   # match whatever you actually run
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes (unused imports, undefined names, etc.)
+    "I",   # isort (import sorting)
+    "UP",  # pyupgrade (modernize syntax)
+    "NPY", # numpy-specific rules, if you use numpy
+]
+ignore = [
+    "E501",  # line too long — formatter handles this; don't fight it on data literals
+]
+
+[tool.ruff.lint.per-file-ignores]
+"*.ipynb" = ["E402"]  # notebooks often have imports after code cells
+
+[tool.ruff.format]
+quote-style = "double"


### PR DESCRIPTION
Code listing cleanup using Ruff. Large set of minor/trivial changes in formatting and syntax. No functional or performance changes to Poppy code. 

A ruff config with some options is added to pyproject.toml in this PR. This specifies the set of listing rules that was used to implement this. 

None of these edits are is in any way essential or high priority; this was mostly done as an exercise in learning how to use some of these tools more effectively. 