### PR TITLE
import scipy.ndimage instead of the removed scipy.ndimage.interpolation

### DIFF
--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-import scipy.ndimage.interpolation
+import scipy.ndimage
 import scipy.signal
 import astropy.io.fits as fits
 import astropy.units as u

--- a/poppy/dms.py
+++ b/poppy/dms.py
@@ -7,6 +7,7 @@ from abc import ABC
 import astropy.io.fits as fits
 import astropy.units as u
 import matplotlib.pyplot as plt
+import numpy as np
 import scipy.ndimage
 import scipy.signal
 

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -1,10 +1,3 @@
-import numpy as np
-import scipy.special
-import scipy.ndimage
-import matplotlib
-import astropy.io.fits as fits
-import astropy.units as u
-import warnings
 import logging
 import warnings
 from abc import ABC, abstractmethod
@@ -13,7 +6,7 @@ import astropy.io.fits as fits
 import astropy.units as u
 import matplotlib
 import numpy as np
-import scipy.ndimage.interpolation
+import scipy.ndimage
 import scipy.special
 
 from . import accel_math, conf, geometry, utils

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.special
-import scipy.ndimage.interpolation
+import scipy.ndimage
 import matplotlib
 import astropy.io.fits as fits
 import astropy.units as u

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -2892,7 +2892,7 @@ class FITSOpticalElement(OpticalElement):
     rotation : float
         Rotation for that optic, in degrees counterclockwise. This is
         implemented using spline interpolation via the
-        scipy.ndimage.interpolation.rotate function.
+        scipy.ndimage.rotate function.
     pixelscale : optical str or float
         By default, poppy will attempt to determine the appropriate pixel scale
         by examining the FITS header, checking keywords "PIXELSCL", "PUPLSCAL" and/or 'PIXSCALE'.


### PR DESCRIPTION
romanisim devdeps started failing this morning because we test against development versions of scipy, which removed the scipy.ndimage.interpolation module in preparation for 2.0.  poppy imports scipy.ndimage.interpolation but does not actually use it, so this is a simple fix.  Note that scipy.ndimage is used, so I've updated the import rather than removed it.  See https://github.com/scipy/scipy/pull/25595 .