### PR TITLE
Replace pkg_resources version with importlib.metadata version

### DIFF
--- a/poppy/tests/test_fresnel.py
+++ b/poppy/tests/test_fresnel.py
@@ -1,5 +1,5 @@
 import pytest
-from pkg_resources import parse_version as version
+from importlib.metadata import version
 
 from .. import poppy_core
 from .. import optics


### PR DESCRIPTION
pkg_resources is deprecated, so it's being replaced here with importlib.