### PR TITLE
new decomposition function based on matrix multiplication from D Aros…

### DIFF
--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -229,6 +229,45 @@ def test_decompose_opd(npix=512, input_coefficients=(0.1, 0.2, 0.3, 0.4, 0.5)):
     max_diff_v2 = np.max(np.abs(np.asarray(input_coefficients) - np.asarray(recovered_coeffs_v2)))
     assert max_diff_v2 < 1e-3, "recovered coefficients from wf_expand more than 0.1% off"
 
+def test_decompose_opd_basis_matrix(npix = 512,nterms = 10,input_coeffs = (0.1, 0.2, 0.3, 0.4, 0.5)):
+    """
+    Simple test for zernike.decompose_opd_basis_matrix
+    Checks that that function can run without errors and that a
+    reconstructed OPD return similar results as other functions
+    """
+
+
+    # Build OPD from those coefficients
+    opd = zernike.compose_opd_from_basis(input_coeffs, npix=npix)
+
+    aperture = np.isfinite(opd).astype(float)
+    opd_nan_filled = np.nan_to_num(opd)
+
+    #Run test_decompose_opd_basis_matrix  without error
+    coeffs_new = zernike.decompose_opd_basis_matrix(
+        opd_nan_filled, aperture=aperture, nterms=nterms
+    )
+
+    # Check correct number of coefficients returned
+    assert len(coeffs_new) == nterms
+
+    # Recovers coefficients between test_decompose_opd_basis_matrix
+    # and the actual input
+    assert np.allclose(coeffs_new[0:5], input_coeffs, atol=1e-3)
+
+    # Consistency with  existing decompose_opd nonorthonormal
+    # not necessarily identical result but similae
+    # not really "old" but other implementation
+    coeffs_old = zernike.decompose_opd_nonorthonormal_basis(opd_nan_filled, aperture=aperture, nterms=nterms)
+    assert np.allclose(coeffs_new[0:5], coeffs_old[0:5], atol=1e-3)
+
+    # Also test the faster_orthogonal=True branch runs and gives similar results
+    # when compare in the orthogonal case
+    coeffs_old_orthogonal = zernike.decompose_opd(opd_nan_filled, aperture=aperture, nterms=nterms)
+    coeffs_new_fast = zernike.decompose_opd_basis_matrix(
+        opd_nan_filled, aperture=aperture, nterms=nterms, faster_orthogonal=True
+    )
+    assert np.allclose(coeffs_new_fast[0:5], coeffs_old_orthogonal[0:5], atol=1e-3)
 
 def test_compose_opd_from_basis():
     coeffs = [0,0.1, 0.4, 2, -0.3]

--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -232,7 +232,7 @@ def test_decompose_opd(npix=512, input_coefficients=(0.1, 0.2, 0.3, 0.4, 0.5)):
 
 
 @pytest.mark.parametrize("aper_shape", ['circle', 'f']) # run test twice for each aperture parameter
-def test_decompose_opd_basis_matrix(npix=512, nterms=10, input_coeffs=(0.1, 0.2, 0.3, 0.4, 0.5), aper_shape='circle'):
+def test_decompose_opd_basis_matrix(npix=512, nterms=10, input_coeffs=(0.1, 0.2, 0.3, 0.4, 0.5), aper_shape):
     """
     Simple test for zernike.decompose_opd_basis_matrix
     Checks that that function can run without errors and that a

--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -232,7 +232,7 @@ def test_decompose_opd(npix=512, input_coefficients=(0.1, 0.2, 0.3, 0.4, 0.5)):
 
 
 @pytest.mark.parametrize("aper_shape", ['circle', 'f']) # run test twice for each aperture parameter
-def test_decompose_opd_basis_matrix(npix=512, nterms=10, input_coeffs=(0.1, 0.2, 0.3, 0.4, 0.5), aper_shape):
+def test_decompose_opd_basis_matrix(aper_shape, npix=512, nterms=10, input_coeffs=(0.1, 0.2, 0.3, 0.4, 0.5)):
     """
     Simple test for zernike.decompose_opd_basis_matrix
     Checks that that function can run without errors and that a

--- a/poppy/tests/test_zernike.py
+++ b/poppy/tests/test_zernike.py
@@ -3,6 +3,7 @@ import numpy as np
 import poppy.accel_math
 from poppy import optics, poppy_core, zernike
 from poppy.accel_math import xp as np
+import pytest
 
 
 def test_zernikes_rms(nterms=10, size=500):
@@ -229,21 +230,28 @@ def test_decompose_opd(npix=512, input_coefficients=(0.1, 0.2, 0.3, 0.4, 0.5)):
     max_diff_v2 = np.max(np.abs(np.asarray(input_coefficients) - np.asarray(recovered_coeffs_v2)))
     assert max_diff_v2 < 1e-3, "recovered coefficients from wf_expand more than 0.1% off"
 
-def test_decompose_opd_basis_matrix(npix = 512,nterms = 10,input_coeffs = (0.1, 0.2, 0.3, 0.4, 0.5)):
+
+@pytest.mark.parametrize("aper_shape", ['circle', 'f']) # run test twice for each aperture parameter
+def test_decompose_opd_basis_matrix(npix=512, nterms=10, input_coeffs=(0.1, 0.2, 0.3, 0.4, 0.5), aper_shape='circle'):
     """
     Simple test for zernike.decompose_opd_basis_matrix
     Checks that that function can run without errors and that a
     reconstructed OPD return similar results as other functions
     """
 
-
     # Build OPD from those coefficients
     opd = zernike.compose_opd_from_basis(input_coeffs, npix=npix)
 
-    aperture = np.isfinite(opd).astype(float)
+    if aper_shape == 'circle':
+        aperture = np.isfinite(opd).astype(float)
+    elif aper_shape == 'f':
+        aperture = poppy.LetterFAperture().sample(npix=npix)  # Very asymmetric test aperture
+        opd *= aperture
+    else:
+        raise ValueError('unknown aperture shape')
     opd_nan_filled = np.nan_to_num(opd)
 
-    #Run test_decompose_opd_basis_matrix  without error
+    # Run test_decompose_opd_basis_matrix  without error
     coeffs_new = zernike.decompose_opd_basis_matrix(
         opd_nan_filled, aperture=aperture, nterms=nterms
     )
@@ -253,21 +261,30 @@ def test_decompose_opd_basis_matrix(npix = 512,nterms = 10,input_coeffs = (0.1, 
 
     # Recovers coefficients between test_decompose_opd_basis_matrix
     # and the actual input
-    assert np.allclose(coeffs_new[0:5], input_coeffs, atol=1e-3)
+    assert np.allclose(coeffs_new[0:5], input_coeffs)
+    assert np.allclose(coeffs_new[5:], 0)
 
-    # Consistency with  existing decompose_opd nonorthonormal
-    # not necessarily identical result but similae
-    # not really "old" but other implementation
-    coeffs_old = zernike.decompose_opd_nonorthonormal_basis(opd_nan_filled, aperture=aperture, nterms=nterms)
-    assert np.allclose(coeffs_new[0:5], coeffs_old[0:5], atol=1e-3)
+    if aper_shape == 'circle':
+        # Some additional tests we can do on a circular aperture
 
-    # Also test the faster_orthogonal=True branch runs and gives similar results
-    # when compare in the orthogonal case
-    coeffs_old_orthogonal = zernike.decompose_opd(opd_nan_filled, aperture=aperture, nterms=nterms)
-    coeffs_new_fast = zernike.decompose_opd_basis_matrix(
-        opd_nan_filled, aperture=aperture, nterms=nterms, faster_orthogonal=True
-    )
-    assert np.allclose(coeffs_new_fast[0:5], coeffs_old_orthogonal[0:5], atol=1e-3)
+        # Consistency with existing decompose_opd, which implicitly assumes orthonormal basis
+        # not necessarily identical result but similar
+        coeffs_simple_algorithm = zernike.decompose_opd(opd_nan_filled, aperture=aperture, nterms=nterms)
+        assert np.allclose(coeffs_new[0:5], coeffs_simple_algorithm[0:5], atol=1e-3)
+
+        # Consistency with  existing decompose_opd nonorthonormal
+        # not necessarily identical result but similar
+        # not really "old" but other implementation
+        coeffs_old = zernike.decompose_opd_nonorthonormal_basis(opd_nan_filled, aperture=aperture, nterms=nterms)
+        assert np.allclose(coeffs_new[0:5], coeffs_old[0:5], atol=1e-3)
+
+        # Also test the faster_orthogonal=True branch runs and gives similar results
+        # when compare in the orthogonal case
+        coeffs_old_orthogonal = zernike.decompose_opd(opd_nan_filled, aperture=aperture, nterms=nterms)
+        coeffs_new_fast = zernike.decompose_opd_basis_matrix(
+            opd_nan_filled, aperture=aperture, nterms=nterms, faster_orthogonal=True
+        )
+        assert np.allclose(coeffs_new_fast[0:5], coeffs_old_orthogonal[0:5], atol=1e-3)
 
 def test_compose_opd_from_basis():
     coeffs = [0,0.1, 0.4, 2, -0.3]

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -1093,10 +1093,6 @@ def decompose_opd_basis_matrix(opd, aperture=None, nterms=15, basis=zernike_basi
 
         which basis function to use. Defaults to Zernike
 
-    iterations : int
-
-        Number of iterations for convergence. Default is 5
-
     faster_orthogonal = bool
 
         Faster performance for orthogonal case. Default is False

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -1033,73 +1033,55 @@ def decompose_opd_basis_matrix(opd, aperture=None, nterms=15, basis=zernike_basi
 
     orthonormal and *not* orthonormal. This function calculate the direct answer via matrix multiplications
 
-
-
-    This version is based on David Arostein python code on February 5, 2023. See description below.
-
-    We seek an expression like:
-
-    opd = sum(coeffs[i] * basis_set[i])
-
-    Apply the dot product with basis_set[j] to both sides:
-
-    opd . basis_set[j] = sum(coeffs[i] * basis_set[i]) . basis_set[j]
-
-    When you have an orthogonal basis, this becomes an expression for how to find coeffs[j];
-
-    this is used in the original code, in the "for" loop over iterations:
-
-    this_coeff = (opd_copy * b)[wgood].sum() / ngood
-
-    But when we don't have an orthogonal basis, the equation becomes a matrix equation for the coefficients:
-
-    B * coeffs = opd . basis_set
-
-    with:
-
-    B = a matrix with Bij = basis_set[i] . basis_set[j] = (basis_set[i] * basis_set[j])[wgood].sum()
-
-    f = opd . basis_set is a vector with elements f[i] = (opd * basis_set[i])[wgood].sum()
-
-    and you solve this system for coeffs
-
     Parameters
-
     -----------
-
     opd : 2d ndarray
-
         the OPD you want to fit
-
     aperture : 2D numpy array, optional
-
         Aperture mask for which pixels are included within the aperture.
-
         All positive nonzero values are considered within the aperture;
-
         any pixels with zero, negative, or NaN values will be considered
-
         outside the aperture, and set equal to the 'outside' parameter value.
-
         If this parameter is not set, the aperture will be inferred from
-
-        the finite (i.e. non-NaN) pixels in the OPD array.
-
+        the finite (i.e. non-NaN) pixels in the OPD array.`
     nterms : int
-
         number of terms to fit
-
     basis : function
-
         which basis function to use. Defaults to Zernike
-
     faster_orthogonal = bool
-
         Faster performance for orthogonal case. Default is False
 
+    Other Parameters
+    ----------------
+        Additional keyword arguments to this function are passed through to the `basis` callable.
+
+    Returns
+    -------
+    coeffs : list
+        List of coefficients (of length `nterms`) from which the
+        input OPD map can be constructed in the given basis.
+        (No additional unit conversions are performed. If the input
+        wavefront is in waves, coeffs will be in waves.)
+        Note that the first coefficient (element 0 in Python indexing)
+        corresponds to the Z=1 Zernike piston term, and so on.
+
+    Notes
+    -----
+    This version is based on David Arostein python code on February 5, 2023. See description below.
+    We seek an expression like:
+    opd = sum(coeffs[i] * basis_set[i])
+    Apply the dot product with basis_set[j] to both sides:
+    opd . basis_set[j] = sum(coeffs[i] * basis_set[i]) . basis_set[j]
+    When you have an orthogonal basis, this becomes an expression for how to find coeffs[j];
+    this is used in the original code, in the "for" loop over iterations:
+    this_coeff = (opd_copy * b)[wgood].sum() / ngood
+    But when we don't have an orthogonal basis, the equation becomes a matrix equation for the coefficients:
+    B * coeffs = opd . basis_set
+    with:
+    B = a matrix with Bij = basis_set[i] . basis_set[j] = (basis_set[i] * basis_set[j])[wgood].sum()
+    f = opd . basis_set is a vector with elements f[i] = (opd * basis_set[i])[wgood].sum()
+    and then solve thw system for coeffs
     """
-
-
 
     if aperture is None:
 
@@ -1118,11 +1100,8 @@ def decompose_opd_basis_matrix(opd, aperture=None, nterms=15, basis=zernike_basi
 
 
     # Determine if this basis function accepts an 'aperture' parameter or not
-
     # If so, append that into the function's kwargs. This check is needed to
-
     # handle e.g. both the zernike_basis function (which doesn't accept aperture)
-
     # and hexike_basis or arbitrary_basis (which do).
 
     if 'aperture' in inspect.signature(basis).parameters:

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -1086,85 +1086,40 @@ def decompose_opd_basis_matrix(opd, aperture=None, nterms=15, basis=zernike_basi
     if aperture is None:
 
         _log.warning("No aperture supplied - "
-
                   "using the finite (non-NaN) part of the OPD map as a guess.")
-
         aperture = np.isfinite(opd)
-
-
-
     # any pixels with zero or NaN in the aperture are outside the area
-
     apmask = (np.isfinite(aperture) & (aperture > 0))
-
-
-
     # Determine if this basis function accepts an 'aperture' parameter or not
     # If so, append that into the function's kwargs. This check is needed to
     # handle e.g. both the zernike_basis function (which doesn't accept aperture)
     # and hexike_basis or arbitrary_basis (which do).
-
     if 'aperture' in inspect.signature(basis).parameters:
-
         kwargs['aperture'] = aperture
-
-
-
     basis_set = basis(
-
         nterms=nterms,
-
         npix=opd.shape[0],
-
         outside=np.nan,
-
         **kwargs
-
     )
-
-
-
     wgood = (apmask & np.isfinite(basis_set[1]))
-
     ngood = apmask.sum()
-
-
     b = np.zeros((nterms, nterms))
-
     f = np.zeros(nterms)
-
-
-
     for i, Zi in enumerate(basis_set):
-
-
-
         f[i] = (opd * Zi)[wgood].sum()
-
-
-
         for j, Zj in enumerate(basis_set[:i+1]):
-
             b[i, j] = (Zi * Zj)[wgood].sum()
-
             if i != j:
-
                 b[j, i] = b[i, j]
 
-
-
     binv = np.linalg.pinv(b)
-
-
-
 
     if faster_orthogonal:
         coeffs = [binv[i, i] * fi for i, fi in enumerate(f)]
     else:
         coeffs = np.matmul(binv, f)
-
-
-
+        
     return coeffs
 
 

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -1025,6 +1025,174 @@ def decompose_opd(opd, aperture=None, nterms=15, basis=zernike_basis,
 
     return coeffs
 
+def decompose_opd_basis_matrix(opd, aperture=None, nterms=15, basis=zernike_basis_faster,
+
+                                       iterations=5, verbose=False, faster_orthogonal = False,  **kwargs):
+
+    """ Non-iterative version of  decompose_opd, it works for cases where the basis function is
+
+    orthonormal and *not* orthonormal. This function calculate the direct answer via matrix multiplications
+
+
+
+    This version is based on David Arostein python code on February 5, 2023. See description below.
+
+    We seek an expression like:
+
+    opd = sum(coeffs[i] * basis_set[i])
+
+    Apply the dot product with basis_set[j] to both sides:
+
+    opd . basis_set[j] = sum(coeffs[i] * basis_set[i]) . basis_set[j]
+
+    When you have an orthogonal basis, this becomes an expression for how to find coeffs[j];
+
+    this is used in the original code, in the "for" loop over iterations:
+
+    this_coeff = (opd_copy * b)[wgood].sum() / ngood
+
+    But when we don't have an orthogonal basis, the equation becomes a matrix equation for the coefficients:
+
+    B * coeffs = opd . basis_set
+
+    with:
+
+    B = a matrix with Bij = basis_set[i] . basis_set[j] = (basis_set[i] * basis_set[j])[wgood].sum()
+
+    f = opd . basis_set is a vector with elements f[i] = (opd * basis_set[i])[wgood].sum()
+
+    and you solve this system for coeffs
+
+    Parameters
+
+    -----------
+
+    opd : 2d ndarray
+
+        the OPD you want to fit
+
+    aperture : 2D numpy array, optional
+
+        Aperture mask for which pixels are included within the aperture.
+
+        All positive nonzero values are considered within the aperture;
+
+        any pixels with zero, negative, or NaN values will be considered
+
+        outside the aperture, and set equal to the 'outside' parameter value.
+
+        If this parameter is not set, the aperture will be inferred from
+
+        the finite (i.e. non-NaN) pixels in the OPD array.
+
+    nterms : int
+
+        number of terms to fit
+
+    basis : function
+
+        which basis function to use. Defaults to Zernike
+
+    iterations : int
+
+        Number of iterations for convergence. Default is 5
+
+    faster_orthogonal = bool
+
+        Faster performance for orthogonal case. Default is False
+
+    """
+
+
+
+    if aperture is None:
+
+        _log.warning("No aperture supplied - "
+
+                  "using the finite (non-NaN) part of the OPD map as a guess.")
+
+        aperture = np.isfinite(opd)
+
+
+
+    # any pixels with zero or NaN in the aperture are outside the area
+
+    apmask = (np.isfinite(aperture) & (aperture > 0))
+
+
+
+    # Determine if this basis function accepts an 'aperture' parameter or not
+
+    # If so, append that into the function's kwargs. This check is needed to
+
+    # handle e.g. both the zernike_basis function (which doesn't accept aperture)
+
+    # and hexike_basis or arbitrary_basis (which do).
+
+    if 'aperture' in inspect.signature(basis).parameters:
+
+        kwargs['aperture'] = aperture
+
+
+
+    basis_set = basis(
+
+        nterms=nterms,
+
+        npix=opd.shape[0],
+
+        outside=np.nan,
+
+        **kwargs
+
+    )
+
+
+
+    wgood = (apmask & np.isfinite(basis_set[1]))
+
+    ngood = apmask.sum()
+
+
+    b = np.zeros((nterms, nterms))
+
+    f = np.zeros(nterms)
+
+
+
+    for i, Zi in enumerate(basis_set):
+
+
+
+        f[i] = (opd * Zi)[wgood].sum()
+
+
+
+        for j, Zj in enumerate(basis_set[:i+1]):
+
+            b[i, j] = (Zi * Zj)[wgood].sum()
+
+            if i != j:
+
+                b[j, i] = b[i, j]
+
+
+
+    binv = np.linalg.pinv(b)
+
+
+
+
+    if faster_orthogonal:
+        coeffs = [binv[i, i] * fi for i, fi in enumerate(f)]
+    else:
+        coeffs = np.matmul(binv, f)
+
+
+
+    return coeffs
+
+
 
 def decompose_opd_nonorthonormal_basis(opd, aperture=None, nterms=15, basis=zernike_basis_faster,
                                        iterations=5, verbose=False, **kwargs):

--- a/poppy/zernike.py
+++ b/poppy/zernike.py
@@ -1027,7 +1027,7 @@ def decompose_opd(opd, aperture=None, nterms=15, basis=zernike_basis,
 
 def decompose_opd_basis_matrix(opd, aperture=None, nterms=15, basis=zernike_basis_faster,
 
-                                       iterations=5, verbose=False, faster_orthogonal = False,  **kwargs):
+                                       verbose=False, faster_orthogonal = False,  **kwargs):
 
     """ Non-iterative version of  decompose_opd, it works for cases where the basis function is
 


### PR DESCRIPTION
…tein circa 2023
This is a new phase decomposition function as developed by David Arostein (circa 2023). The inputs are the same as `opd_expand_nonorthonormal`, so it returns the Zernike coefficients as well. 

This is another function for phase decomposition that works with orthogonal and non-orthogonal basis, so it is a general purpose function not limited by convergence on the iteration loop as in the `opd_expand_nonorthonormal` function. 

to get the coefficients:
zernike_coeffs = poppy.zernike.decompose_opd_basis_matrix(opd, nterms=nterms, aperture = aperture), with opd, nterms and aperture as usually defined. 

Using a Roman phase map, here are some examples using 
`opd_expand_nonorthonormal` --> 210 terms
<img width="1442" height="372" alt="image" src="https://github.com/user-attachments/assets/f17f7cd9-77ea-426d-80d6-974dffae945c" />

Using the new function, `decompose_opd_basis_matrix`, same Zernike terms as before:
<img width="1442" height="372" alt="image" src="https://github.com/user-attachments/assets/e9820a87-ae14-48bc-86be-1fb62f8c6a84" />

Virtually indistinguishable. However, the new function does take a longer to execute, with a faster option for the orthogonal case (see function description)

A comparison between Zernike coefficients between functions shows a bit of scatter but as shown on the comparisons above the reconstructed phase maps and residuals looks comparables. Here "old" refers to  `opd_expand_nonorthonormal` and "new" to `decompose_opd_basis_matrix`

<img width="575" height="433" alt="image" src="https://github.com/user-attachments/assets/8e1411ed-71e1-48e3-89e2-8b77ac7123ad" />
 

