### PR TITLE
Improve docstrings for poppy_core.py and optics.py

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,16 @@
+# Usage of Generative AI
+STScI software maintainers welcome contributions, including those developed with the assistance of generative AI tools. However, the use of such tools does not change our expectations for contributor responsibility, engagement, or code quality. The following statements apply to all contributions. Pull requests that violate this policy will be closed.
+1. Prohibited Tools
+    1. Per STScI's AI policy, certain tools are prohibited and may not be used.  This currently includes, but may not be limited to, Deepseek and Grammarly.
+2. Human ownership and accountability
+    1. Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
+    2. Contributors must understand and be able to explain all changes during review and address any concerns raised by maintainers.
+    3. Contributors are responsible for ensuring all submitted code complies with STScI licensing, regardless of whether generative AI tools were used.
+3. Disclosure
+    1. Presence of this `AI_POLICY.md` file indicates AI tools may have been used to assist with portions of this work.
+    2. Committers are encouraged to apply a label of `ai-assisted` to pull requests that leveraged AI tools.
+4. Authentic engagement
+    1. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback themselves. Copying and pasting replies to/from a generative AI tool does not count as engaging with the reviewer.
+All pull requests must be reviewed by a human other than the contributor.
+5. Consistency with repository conventions and existing style
+    1. In the context of Generative AI, this particularly means adhering to any linting standards as well as conveying information (comments, documentation, etc.) in a style the repository uses, and that is appropriate and to the point.

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -52,11 +52,11 @@ class AnalyticOpticalElement(OpticalElement):
         transmission, opd : string
             These are *not allowed* for Analytic optical elements, and this class will raise an
             error if you try to set one.
-        shift_x, shift_y : astropy Quantity or float (length or angle, depending on plane type), optional
+        shift_x, shift_y : astropy Quantity (length or angle, depending on plane type) or float, optional
             Translations of this optic. Plain floats are interpreted in meters for pupil plane
             elements or arcseconds for image plane elements; astropy Quantities will be converted
             to the appropriate unit automatically.
-        rotation : astropy Quantity or float angle, optional
+        rotation : astropy Quantity angle or float, optional
             Rotation of the optic around its center, in degrees counterclockwise, or an
             angular astropy Quantity. Note that if you apply both shift and rotation,
             the optic rotates around its own center, rather than the optical axis.
@@ -256,7 +256,7 @@ class AnalyticOpticalElement(OpticalElement):
         ----------
         what : string
             What quantity to save. See the sample function of this class
-        wavelength : astropy Quantity or float length
+        wavelength : astropy Quantity length or float
             Wavelength for evaluating the optic; passed to sample(),
             in meters (plain float) or an astropy Quantity.
         npix : integer
@@ -418,7 +418,7 @@ class ScalarOpticalPathDifference(AnalyticOpticalElement):
     ----------
     name : string, optional
         Descriptive name. Auto-generated from OPD value if not given.
-    opd : astropy Quantity or float length
+    opd : astropy Quantity length or float
         Optical path difference to apply uniformly. Plain float is interpreted as meters.
         Default is 1 micron.
     """
@@ -506,7 +506,7 @@ class BandLimitedCoronagraph(AnalyticImagePlaneElement):
             occulters; these will raise a DeprecationWarning.
         sigma : float
             The numerical size parameter, as specified in Krist et al. 2009 SPIE
-        wavelength : astropy Quantity or float length, optional
+        wavelength : astropy Quantity length or float, optional
             Wavelength this BLC is optimized for (only used for the 'linear' kind).
             Plain float is interpreted as meters.
 
@@ -679,7 +679,7 @@ class IdealFQPM(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    wavelength : astropy Quantity or float length
+    wavelength : astropy Quantity length or float
         Wavelength at which there is exactly 1/2 a wave of retardance.
 
     """
@@ -715,9 +715,9 @@ class CircularPhaseMask(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    radius : astropy Quantity or float
+    radius : astropy Quantity angle or float
         Radius of the mask, in arcseconds (plain float) or as an astropy Quantity.
-    wavelength : astropy Quantity or float length
+    wavelength : astropy Quantity length or float
         Wavelength for which the phase mask was designed, in meters (plain float) or as an astropy Quantity.
     retardance : float
         Optical path delay at that wavelength, specified in waves
@@ -771,10 +771,10 @@ class RectangularFieldStop(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    width : astropy Quantity or float angle
+    width : astropy Quantity angle or float
         Width of the field stop, in arcseconds (plain float) or as an astropy Quantity.
         Default is 0.5 arcsec.
-    height : astropy Quantity or float angle
+    height : astropy Quantity angle or float
         Height of the field stop, in arcseconds (plain float) or as an astropy Quantity.
         Default is 5.0 arcsec.
     """
@@ -914,10 +914,10 @@ class AnnularFieldStop(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    radius_inner : astropy Quantity or float angle
+    radius_inner : astropy Quantity angle or float
         Radius of the central opaque region, in arcseconds (plain float) or as an astropy Quantity.
         Default is 0.0 (no central opaque spot).
-    radius_outer : astropy Quantity or float angle
+    radius_outer : astropy Quantity angle or float
         Radius of the circular field stop outer edge, in arcseconds (plain float) or as an
         astropy Quantity. Default is 1.0 arcsec. Set to 0.0 for no outer edge.
     """
@@ -965,7 +965,7 @@ class CircularOcculter(AnnularFieldStop):
     ----------
     name : string
         Descriptive name
-    radius : astropy Quantity or float angle
+    radius : astropy Quantity angle or float
         Radius of the occulting spot, in arcseconds (plain float) or as an astropy Quantity.
         Default is 1.0 arcsec.
 
@@ -984,10 +984,10 @@ class BarOcculter(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    width : astropy Quantity or float angle
+    width : astropy Quantity angle or float
         Width of the bar stop, in arcseconds (plain float) or as an astropy Quantity.
         Default is 1.0 arcsec.
-    height : astropy Quantity or float angle
+    height : astropy Quantity angle or float
         Height of the bar stop, in arcseconds (plain float) or as an astropy Quantity.
         Default is 10.0 arcsec.
 
@@ -1143,7 +1143,7 @@ class LetterFAperture(AnalyticOpticalElement):
     ----------
     name : string, optional
         Descriptive name. Auto-generated if not provided.
-    radius : astropy Quantity or float length
+    radius : astropy Quantity length or float
         Radius of the overall aperture, in meters. Default is 1.0 m.
     pad_factor : float, optional
         Factor by which to oversize the wavefront array relative to the pupil diameter.
@@ -1186,7 +1186,7 @@ class LetterFOpticalPathDifference(AnalyticOpticalElement):
     ----------
     name : string, optional
         Descriptive name. Auto-generated if not provided.
-    radius : astropy Quantity or float length
+    radius : astropy Quantity length or float
         Radius of the overall aperture, in meters. Default is 1.0 m.
     pad_factor : float, optional
         Factor by which to oversize the wavefront array relative to the pupil diameter.
@@ -1367,9 +1367,9 @@ class MultiSegmentAperture(AnalyticOpticalElement, ABC):
     ----------
     name : string, optional
         Descriptive name. Default is "MultiSegment".
-    segment_size : astropy Quantity or float length
+    segment_size : astropy Quantity length or float
         Characteristic size (e.g. flat-to-flat diameter) of each segment in meters.
-    gap : astropy Quantity or float length
+    gap : astropy Quantity length or float
         Gap between adjacent segments in meters. Default is 0.01 m.
     rings : int
         Number of rings of segments (not counting the center). Default is 1.
@@ -1703,7 +1703,7 @@ class KeystoneSegmentedCircularAperture(MultiSegmentAperture, CircularAperture):
     ----------
     name : string, optional
         Descriptive name. Auto-generated if not provided.
-    radius : astropy Quantity or float length
+    radius : astropy Quantity length or float
         Radius of the full circular aperture, in meters. Default is 1.0 m.
     rings : int
         Number of rings of segments. Default is 2.
@@ -1874,10 +1874,10 @@ class RectangleAperture(AnalyticOpticalElement):
     ----------
     name : string
         Descriptive name
-    width : astropy Quantity or float length
+    width : astropy Quantity length or float
         Width of the rectangle, in meters (plain float) or as an astropy Quantity.
         Default is 0.5 m.
-    height : astropy Quantity or float length
+    height : astropy Quantity length or float
         Height of the rectangle, in meters (plain float) or as an astropy Quantity.
         Default is 1.0 m.
     rotation : float
@@ -1956,13 +1956,13 @@ class SecondaryObscuration(AnalyticOpticalElement):
 
     Parameters
     ----------
-    secondary_radius : astropy Quantity or float length
+    secondary_radius : astropy Quantity length or float
         Radius of the circular secondary obscuration, in meters or other unit.
         Default 0.5 m
     n_supports : int
         Number of secondary mirror supports ("spiders"). These will be
         spaced equally around a circle.  Default is 4.
-    support_width : astropy Quantity or float length
+    support_width : astropy Quantity length or float
         Width of each support, in meters or other unit. Default is 0.01 m = 1 cm.
     support_angle_offset : float
         Angular offset, in degrees, of the first secondary support from the X axis.
@@ -2022,13 +2022,13 @@ class AsymmetricSecondaryObscuration(SecondaryObscuration):
 
     Parameters
     ----------
-    secondary_radius : astropy Quantity or float length
+    secondary_radius : astropy Quantity length or float
         Radius of the circular secondary obscuration, in meters (plain float) or as an
         astropy Quantity. Default 0.5 m
     support_angle : array_like of float
         The angle measured counterclockwise from +Y for each support, in degrees.
         Default is (0, 90, 240).
-    support_width : astropy Quantity or float length, or list thereof
+    support_width : astropy Quantity length or float, or list thereof
         if scalar, gives the width for all support struts
         if a list, gives separately the width for each support strut independently.
         Widths in meters or other unit if specified. Default is 0.01 m = 1 cm.
@@ -2114,10 +2114,10 @@ class ThinLens(CircularAperture):
         This is applied as a normalization over an area defined by the circumscribing circle
         of the input wavefront. That is, there will be nwaves defocus peak-to-valley
         over the region of the pupil that has nonzero input intensity.
-    reference_wavelength : astropy Quantity or float length
+    reference_wavelength : astropy Quantity length or float
         Wavelength at which ``nwaves`` defocus is specified,
         either in meters (plain float) or as an astropy Quantity.
-    radius : astropy Quantity or float length
+    radius : astropy Quantity length or float
         Pupil radius over which the Zernike defocus term should be computed such that rho = 1 at r = ``radius``,
         either in meters (plain float) or as an astropy Quantity.
     """
@@ -2167,13 +2167,13 @@ class GaussianAperture(AnalyticOpticalElement):
     ----------
     name : string
         Descriptive name
-    fwhm : astropy Quantity or float length, optional
+    fwhm : astropy Quantity length or float, optional
         Full width at half maximum for the Gaussian, in meters (plain float) or as an
         astropy Quantity.
-    w : astropy Quantity or float length, optional
+    w : astropy Quantity length or float, optional
         Beam radius parameter, equal to fwhm/(2*sqrt(ln(2))), in meters (plain float) or
         as an astropy Quantity. Exactly one of ``fwhm`` or ``w`` must be specified.
-    pupil_diam : astropy Quantity or float length, optional
+    pupil_diam : astropy Quantity length or float, optional
         Default pupil diameter for cases when it is not otherwise specified
         (e.g. displaying the optic by itself). Default value is 3x the FWHM.
 

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -41,20 +41,29 @@ class AnalyticOpticalElement(OpticalElement):
 
         Parameters
         ----------
-        name, verbose, oversample, planetype : various
-            Same as for OpticalElement
+        name : string, optional
+            Descriptive name.
+        verbose : bool, optional
+            Whether to print verbose output. Default True.
+        oversample : int, optional
+            Oversampling factor for this plane. Default 1.
+        planetype : PlaneType, optional
+            Type of the optical plane. Default PlaneType.unspecified.
         transmission, opd : string
             These are *not allowed* for Analytic optical elements, and this class will raise an
             error if you try to set one.
-        shift_x, shift_y : Optional floats
-            Translations of this optic, given in meters relative to the optical
-            axis for pupil plane elements, or arcseconds relative to the optical axis
-            for image plane elements.
-        rotation : Optional float
-            Rotation of the optic around its center, given in degrees
-            counterclockwise.  Note that if you apply both shift and rotation,
-            the optic rotates around its own center, rather than the optical
-            axis.
+        shift_x, shift_y : float or astropy Quantity, optional
+            Translations of this optic. Plain floats are interpreted in meters for pupil plane
+            elements or arcseconds for image plane elements; astropy Quantities will be converted
+            to the appropriate unit automatically.
+        rotation : float or astropy Quantity, optional
+            Rotation of the optic around its center, in degrees counterclockwise (plain float),
+            or any angular astropy Quantity. Note that if you apply both shift and rotation,
+            the optic rotates around its own center, rather than the optical axis.
+        inclination_x, inclination_y : float, optional
+            Inclination of the optic around the X or Y axis, in degrees. A non-zero inclination
+            rescales the corresponding coordinate by ``1/cos(inclination)``, simulating a tilted
+            flat optic. It is physically inconsistent to set both at the same time.
 
     """
 
@@ -109,9 +118,13 @@ class AnalyticOpticalElement(OpticalElement):
 
         Parameters
         ----------
-        wave : float or obj
-            either a scalar wavelength or a Wavefront object
+        wave : float or Wavefront
+            Either a scalar wavelength in meters or a Wavefront object.
 
+        Returns
+        -------
+        phasor : ndarray
+            Complex phasor array suitable for multiplying by the wavefront amplitude.
         """
         if isinstance(wave, BaseWavefront):
             wavelength = wave.wavelength
@@ -159,13 +172,21 @@ class AnalyticOpticalElement(OpticalElement):
             6.5 meters or 2 arcseconds depending on plane.
         what : string
             What to return: optic 'amplitude' transmission, 'intensity' transmission,
-            'phase', or 'opd'.  Note that optical path difference, OPD, is given in meters.
+            'phase', 'opd', or 'complex' phasor.  Note that optical path difference, OPD,
+            is given in meters.
         phase_unit : string
             Unit for returned phase array IF what=='phase'. One of 'radians', 'waves', 'meters'.
             ('meters' option is deprecated; use what='opd' instead.)
-        return_scale : float
+        return_scale : bool
             if True, will return a tuple containing the desired array and a float giving the
             pixel scale.
+
+        Returns
+        -------
+        output_array : ndarray
+            The sampled optic array.
+        pixel_scale : astropy Quantity
+            The pixel scale of the output array. Only returned if ``return_scale=True``.
         """
         if self.planetype != PlaneType.image:
             if grid_size is not None:
@@ -232,8 +253,8 @@ class AnalyticOpticalElement(OpticalElement):
         ----------
         what : string
             What quantity to save. See the sample function of this class
-        wavelength : float
-            Wavelength in meters.
+        wavelength : float or astropy Quantity
+            Wavelength; plain float is interpreted as meters.
         npix : integer
             Number of pixels.
         outname : string, optional
@@ -241,6 +262,10 @@ class AnalyticOpticalElement(OpticalElement):
 
         See the sample() function for additional optional parameters.
 
+        Returns
+        -------
+        hdul : astropy.io.fits.HDUList
+            FITS HDUList containing the sampled optic data and header metadata.
         """
         try:
             from .version import version
@@ -308,6 +333,17 @@ class AnalyticOpticalElement(OpticalElement):
 
         For multiple transformations, the order of operations is:
             shift, rotate, incline.
+
+        Parameters
+        ----------
+        wave : Wavefront
+            Wavefront object defining the coordinate grid (pixel scale, shape, plane type).
+
+        Returns
+        -------
+        y, x : ndarrays
+            2D coordinate arrays in the plane of the optic, in meters (pupil) or
+            arcseconds (image), after applying any shifts, rotation, and inclination.
         """
 
         y, x = wave.coordinates()
@@ -344,10 +380,18 @@ class AnalyticOpticalElement(OpticalElement):
 
 
 class ScalarTransmission(AnalyticOpticalElement):
-    """ Uniform transmission between 0 and 1.0 in intensity.
+    """ Uniform amplitude transmission between 0 and 1.
 
     Either a null optic (empty plane) or some perfect ND filter...
-    But most commonly this is just used as a null optic placeholder """
+    But most commonly this is just used as a null optic placeholder.
+
+    Parameters
+    ----------
+    name : string, optional
+        Descriptive name. Auto-generated from transmission value if not given.
+    transmission : float
+        Amplitude transmission value (not intensity), between 0 and 1. Default is 1.0.
+    """
 
     def __init__(self, name=None, transmission=1.0, **kwargs):
         if name is None:
@@ -364,8 +408,15 @@ class ScalarTransmission(AnalyticOpticalElement):
 
 
 class ScalarOpticalPathDifference(AnalyticOpticalElement):
-    """Uniform and constant optical path difference
+    """Uniform and constant optical path difference across the full aperture.
 
+    Parameters
+    ----------
+    name : string, optional
+        Descriptive name. Auto-generated from OPD value if not given.
+    opd : float or astropy Quantity length
+        Optical path difference to apply uniformly. Plain float is interpreted as meters.
+        Default is 1 micron.
     """
     @utils.quantity_input(opd=u.meter)
     def __init__(self, name=None, opd=1.0*u.micron, **kwargs):
@@ -386,6 +437,12 @@ class InverseTransmission(AnalyticOpticalElement):
     return the inverse transmission 1 - T(x,y)
 
     This is a useful ingredient in the SemiAnalyticCoronagraph algorithm.
+
+    Parameters
+    ----------
+    optic : OpticalElement
+        Any optical element with a ``get_transmission`` method. The inverse
+        transmission of this optic will be computed as ``1 - T(x,y)``.
     """
 
     def __init__(self, optic=None):
@@ -441,13 +498,13 @@ class BandLimitedCoronagraph(AnalyticImagePlaneElement):
         kind : string
             Either 'circular' or 'linear'. The linear ones are custom shaped to NIRCAM's design
             with flat bits on either side of the linear tapered bit.
-            Also includes options 'nircamcircular' and 'nircamwedge' specialized for the
-            JWST NIRCam occulters, including the off-axis ND acq spots and the changing
-            width of the wedge occulter.
+            Also accepts (deprecated) 'nircamcircular' and 'nircamwedge' for JWST NIRCam
+            occulters; these will raise a DeprecationWarning.
         sigma : float
             The numerical size parameter, as specified in Krist et al. 2009 SPIE
-        wavelength : float
-            Wavelength this BLC is optimized for, only for the linear ones.
+        wavelength : float or astropy Quantity, optional
+            Wavelength this BLC is optimized for (only used for the 'linear' kind).
+            Plain float is interpreted as meters.
 
     """
     allowable_kinds = ['circular', 'linear']
@@ -618,9 +675,9 @@ class IdealFQPM(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    wavelength : float
-        Wavelength in meters for which the FQPM was designed, and at which there
-        is exactly 1/2 a wave of retardance.
+    wavelength : float or astropy Quantity
+        Wavelength in meters (plain float) or as an astropy Quantity, at which
+        there is exactly 1/2 a wave of retardance.
 
     """
 
@@ -655,10 +712,11 @@ class CircularPhaseMask(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    radius : float
-        Radius of the mask
-    wavelength : float
-        Wavelength in meters for which the phase mask was designed
+    radius : float or astropy Quantity
+        Radius of the mask in arcseconds (plain float) or as an astropy Quantity.
+    wavelength : float or astropy Quantity
+        Wavelength in meters (plain float) or as an astropy Quantity, for which the phase mask
+        was designed.
     retardance : float
         Optical path delay at that wavelength, specified in waves
         relative to the reference wavelength. Default is 0.5.
@@ -711,8 +769,12 @@ class RectangularFieldStop(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    width, height: float
-        Size of the field stop, in arcseconds. Default 0.5 width, height 5.
+    width : float or astropy Quantity angle
+        Width of the field stop in arcseconds (plain float) or as an astropy Quantity.
+        Default is 0.5 arcsec.
+    height : float or astropy Quantity angle
+        Height of the field stop in arcseconds (plain float) or as an astropy Quantity.
+        Default is 5.0 arcsec.
     """
 
     @utils.quantity_input(width=u.arcsec, height=u.arcsec)
@@ -850,10 +912,12 @@ class AnnularFieldStop(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    radius_inner : float
-        Radius of the central opaque region, in arcseconds. Default is 0.0 (no central opaque spot)
-    radius_outer : float
-        Radius of the circular field stop outer edge. Default is 10. Set to 0.0 for no outer edge.
+    radius_inner : float or astropy Quantity
+        Radius of the central opaque region in arcseconds (plain float) or as an astropy Quantity.
+        Default is 0.0 (no central opaque spot).
+    radius_outer : float or astropy Quantity
+        Radius of the circular field stop outer edge in arcseconds (plain float) or as an
+        astropy Quantity. Default is 1.0 arcsec. Set to 0.0 for no outer edge.
     """
 
     @utils.quantity_input(radius_inner=u.arcsec, radius_outer=u.arcsec)
@@ -899,8 +963,9 @@ class CircularOcculter(AnnularFieldStop):
     ----------
     name : string
         Descriptive name
-    radius : float
-        Radius of the occulting spot, in arcseconds. Default is 1.0
+    radius : float or astropy Quantity angle
+        Radius of the occulting spot in arcseconds (plain float) or as an astropy Quantity.
+        Default is 1.0 arcsec.
 
     """
 
@@ -917,10 +982,12 @@ class BarOcculter(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    width : float
-        width of the bar stop, in arcseconds. Default is 1.0
-    height: float
-        heightof the bar stop, in arcseconds. Default is 10.0
+    width : float or astropy Quantity angle
+        Width of the bar stop in arcseconds (plain float) or as an astropy Quantity.
+        Default is 1.0 arcsec.
+    height : float or astropy Quantity angle
+        Height of the bar stop in arcseconds (plain float) or as an astropy Quantity.
+        Default is 10.0 arcsec.
 
     """
 
@@ -1069,6 +1136,16 @@ class LetterFAperture(AnalyticOpticalElement):
     """ Define a capital letter F aperture. This is sometimes useful for
     disambiguating pupil orientations. See also AsymmetricParityTestAperture
     and LetterFOpticalPathDifference.
+
+    Parameters
+    ----------
+    name : string, optional
+        Descriptive name. Auto-generated if not provided.
+    radius : float or astropy Quantity length
+        Radius of the overall aperture, in meters. Default is 1.0 m.
+    pad_factor : float, optional
+        Factor by which to oversize the wavefront array relative to the pupil diameter.
+        Default is 1.5.
     """
 
     def __init__(self, name=None, radius=1.0 * u.meter, pad_factor=1.5, **kwargs):
@@ -1102,6 +1179,18 @@ class LetterFAperture(AnalyticOpticalElement):
 class LetterFOpticalPathDifference(AnalyticOpticalElement):
     """ Define a capital letter F in OPD. This is sometimes useful for
     disambiguating pupil orientations. See also LetterFAperture.
+
+    Parameters
+    ----------
+    name : string, optional
+        Descriptive name. Auto-generated if not provided.
+    radius : float or astropy Quantity length
+        Radius of the overall aperture, in meters. Default is 1.0 m.
+    pad_factor : float, optional
+        Factor by which to oversize the wavefront array relative to the pupil diameter.
+        Default is 1.5.
+    opd : astropy Quantity length
+        Optical path difference to apply within the letter F region. Default is 1 micron.
     """
 
     def __init__(self, name=None, radius=1.0 * u.meter, pad_factor=1.5, opd=1*u.micron, **kwargs):
@@ -1149,6 +1238,8 @@ class CircularAperture(AnalyticOpticalElement):
         This is in practice not very useful, but it provides a straightforward way
         of verifying during code testing that the amount of padding (or size of the circle)
         does not make any numerical difference in the final result.
+    planetype : PlaneType, optional
+        Plane type for this optic. Default is PlaneType.unspecified.
 
     """
 
@@ -1267,8 +1358,24 @@ class HexagonAperture(AnalyticOpticalElement):
 
 
 class MultiSegmentAperture(AnalyticOpticalElement, ABC):
-    """Abstract base class for an aperture made of sub-apertures
+    """Abstract base class for an aperture made of sub-apertures.
     This is subclassed to hexagons and circles below.
+
+    Parameters
+    ----------
+    name : string, optional
+        Descriptive name. Default is "MultiSegment".
+    segment_size : float or astropy Quantity length
+        Characteristic size (e.g. flat-to-flat diameter) of each segment in meters.
+    gap : float or astropy Quantity length
+        Gap between adjacent segments in meters. Default is 0.01 m.
+    rings : int
+        Number of rings of segments (not counting the center). Default is 1.
+    segmentlist : list of ints, optional
+        Indices of segments to include. If None, all segments in the specified number
+        of rings are included (minus the center if ``center=False``).
+    center : bool, optional
+        Whether to include the central (index 0) segment. Default is False.
     """
 
     @utils.quantity_input(segment_size=u.meter, gap=u.meter)
@@ -1588,44 +1695,37 @@ class MultiCircularAperture(MultiSegmentAperture):
 
 
 class KeystoneSegmentedCircularAperture(MultiSegmentAperture, CircularAperture):
+    """ Define a circular aperture made of pie-wedge or keystone shaped segments.
+
+    Parameters
+    ----------
+    name : string, optional
+        Descriptive name. Auto-generated if not provided.
+    radius : float or astropy Quantity length
+        Radius of the full circular aperture, in meters. Default is 1.0 m.
+    rings : int
+        Number of rings of segments. Default is 2.
+    nsections : int or list of ints
+        Number of segments per ring. If one int, the same number is used for each ring.
+        Provide a list to set different numbers per ring. Use 0 as the first element
+        to exclude the center for an on-axis aperture.
+    gap_radii : astropy Quantity length, optional
+        Radii from the center for the gaps between rings. Auto-computed if not given.
+    gap : astropy Quantity length, optional
+        Width of gaps between segments in both radial and azimuthal directions.
+        Default is 0.01 m.
+    gray_pixel : bool, optional
+        Apply gray pixel approximation to return fractional transmission for
+        edge pixels that are only partially within this aperture? Default is False.
+    rotation : float, optional
+        Rotation of the overall aperture in degrees counterclockwise. Default is 0.
+    """
+
     @utils.quantity_input(radius=u.meter, gap=u.meter)
     def __init__(self, name=None, radius=1.0 * u.meter,
                  rings=2, nsections=4, gap_radii=None, gap=0.01 * u.meter,
                  gray_pixel=False,
                  rotation=0, **kwargs):
-        """ Define a circular aperture made of pie-wedge or keystone shaped segments.
-
-        Parameters
-        ----------
-        name : string
-            Descriptive name
-        radius : float
-            Radius of the pupil, in meters.
-        rings : int
-            Number of rings of segments
-        nsections : int or list of ints
-            Number of segments per ring. If one int, same number of segments in each ring.
-            Or provide a list of ints to set different numbers per ring.
-            To exclude the center for an on-axis aperture, provide a 0 as the first
-            element of nsections to indicate 0 segments in the first ring.
-        gap_radii : quantity length
-            Radii from the center for the gaps between rings
-        gap : quantity length
-            Width of gaps between segments, in both radial and azimuthal directions
-        gray_pixel : bool, optional
-            Apply gray pixel approximation to return fractional transmission for
-            edge pixels that are only partially within this aperture?
-            (Note, currently this gives a warning; disabled by default)
-
-        kwargs : other kwargs are passed to CircularAperture
-
-        Potential TODO: also have this inherit from MultiSegmentedAperture and subclass
-        some of those functions as appropriate. Consider refactoring from gap_radii to instead
-        provide the widths of each segment. Add option for including the center segment or having
-        a missing one in the middle for on-axis apertures. Use grayscale approximation for rasterizing
-        the circular gaps between the rings.
-        """
-
         if name is None:
             name = f"Circle of Wedge Sections, radius={radius}"
         CircularAperture.__init__(self, name=name, radius=radius, rotation=rotation,
@@ -1772,12 +1872,14 @@ class RectangleAperture(AnalyticOpticalElement):
     ----------
     name : string
         Descriptive name
-    width : float
-        width of the rectangle, in meters. Default is 0.5
-    height : float
-        height of the rectangle, in meters. Default is 1.0
+    width : float or astropy Quantity length
+        Width of the rectangle, in meters (plain float) or as an astropy Quantity.
+        Default is 0.5 m.
+    height : float or astropy Quantity length
+        Height of the rectangle, in meters (plain float) or as an astropy Quantity.
+        Default is 1.0 m.
     rotation : float
-        Rotation angle for 'width' axis. Default is 0.
+        Rotation of the aperture counterclockwise in degrees. Default is 0.
 
     """
 
@@ -1918,19 +2020,21 @@ class AsymmetricSecondaryObscuration(SecondaryObscuration):
 
     Parameters
     ----------
-    secondary_radius : float
-        Radius of the circular secondary obscuration. Default 0.5 m
-    support_angle : ndarray or list of floats
-        The angle measured counterclockwise from +Y for each support
-    support_width : float or astropy Quantity of type length, or list of those
+    secondary_radius : float or astropy Quantity length
+        Radius of the circular secondary obscuration in meters (plain float) or as an
+        astropy Quantity. Default 0.5 m
+    support_angle : array_like of float
+        The angle measured counterclockwise from +Y for each support, in degrees.
+        Default is (0, 90, 240).
+    support_width : float or astropy Quantity length, or list thereof
         if scalar, gives the width for all support struts
         if a list, gives separately the width for each support strut independently.
         Widths in meters or other unit if specified. Default is 0.01 m = 1 cm.
-    support_offset_x : float, or list of floats.
-        Offset in the X direction of the start point for each support.
+    support_offset_x : float, or list of floats
+        Offset in meters in the X direction of the start point for each support.
         if scalar, applies to all supports; if a list, gives a separate offset for each.
-    support_offset_y : float, or list of floats.
-        Offset in the Y direction of the start point for each support.
+    support_offset_y : float, or list of floats
+        Offset in meters in the Y direction of the start point for each support.
         if scalar, applies to all supports; if a list, gives a separate offset for each.
     """
 
@@ -2008,11 +2112,12 @@ class ThinLens(CircularAperture):
         This is applied as a normalization over an area defined by the circumscribing circle
         of the input wavefront. That is, there will be nwaves defocus peak-to-valley
         over the region of the pupil that has nonzero input intensity.
-    reference_wavelength : float
-        Wavelength, in meters, at which that number of waves of defocus is specified.
-    radius : float
-        Pupil radius, in meters, over which the Zernike defocus term should be computed
-        such that rho = 1 at r = `radius`.
+    reference_wavelength : float or astropy Quantity length
+        Wavelength in meters (plain float) or as an astropy Quantity, at which ``nwaves``
+        defocus is specified.
+    radius : float or astropy Quantity length
+        Pupil radius in meters (plain float) or as an astropy Quantity, over which the
+        Zernike defocus term should be computed such that rho = 1 at r = ``radius``.
     """
 
     @utils.quantity_input(reference_wavelength=u.meter)
@@ -2060,14 +2165,15 @@ class GaussianAperture(AnalyticOpticalElement):
     ----------
     name : string
         Descriptive name
-    fwhm : float, optional.
-        Full width at half maximum for the Gaussian, in meters.
-    w : float, optional
-        Beam width parameter, equal to fwhm/(2*sqrt(ln(2))).
-    pupil_diam : float, optional
-        default pupil diameter for cases when it is not otherwise
-        specified (e.g. displaying the optic by itself.) Default
-        value is 3x the FWHM.
+    fwhm : float or astropy Quantity length, optional
+        Full width at half maximum for the Gaussian, in meters (plain float) or as an
+        astropy Quantity.
+    w : float or astropy Quantity length, optional
+        Beam radius parameter, equal to fwhm/(2*sqrt(ln(2))), in meters (plain float) or
+        as an astropy Quantity. Exactly one of ``fwhm`` or ``w`` must be specified.
+    pupil_diam : float or astropy Quantity length, optional
+        Default pupil diameter for cases when it is not otherwise specified
+        (e.g. displaying the optic by itself). Default value is 3x the FWHM.
 
     """
 
@@ -2113,13 +2219,14 @@ class TiltOpticalPathDifference(AnalyticOpticalElement):
 
     Parameters
     ----------
-    tilt_angle : angle, as an astropy unit
-        Angle of the tilt
-    rotation : float
-        Position angle, in degrees, for the direction in which the beam should be tilted
-
-    use the rotation parameter (available for any AnalyticOpticalElement)
-    to adjust the position angle of the tilt
+    tilt_angle : astropy Quantity angle
+        Angle of the tilt; any angular astropy Quantity (arcsec, radians, degrees, etc.)
+        is accepted. Default is 0.1 arcsec.
+    rotation : float, optional
+        Position angle in degrees counterclockwise for the direction in which the beam
+        should be tilted. Inherited from AnalyticOpticalElement. Default is 0.
+    name : string, optional
+        Descriptive name. Default is 'Tilt'.
 
     """
     def __init__(self, name='Tilt', tilt_angle=0.1 * u.arcsec, rotation=0, **kwargs):
@@ -2150,6 +2257,13 @@ class KnifeEdge(AnalyticOpticalElement):
     Rotation=0 yields a knife edge oriented vertically (edge parallel to +y)
     with the opaque side to the right.
 
+    Parameters
+    ----------
+    name : string, optional
+        Descriptive name. Auto-generated from rotation angle if not provided.
+    rotation : float, optional
+        Rotation angle in degrees counterclockwise. Default is 0 (vertical edge,
+        opaque side to the right).
     """
     def __init__(self, name=None, rotation=0, **kwargs):
         if name is None:
@@ -2187,6 +2301,10 @@ class CompoundAnalyticOptic(AnalyticOpticalElement):
                     subtracted.  (E.g. trans = trans1 + trans2 - trans1*trans2)
 
         In both methods, the resulting OPD is the sum of the constituents' OPDs.
+    name : string, optional
+        Descriptive name for the compound optic. Default is "unnamed".
+    verbose : bool, optional
+        Whether to print verbose output. Default is True.
 
     """
 
@@ -2306,7 +2424,7 @@ def fixed_sampling_optic(optic, wavefront, oversample=2):
     ----------
     optic : poppy.AnalyticOpticalElement
         Some optical element
-    wave : poppy.Wavefront
+    wavefront : poppy.Wavefront
         A wavefront to define the desired sampling pixel size and number.
     oversample : int
         Subpixel sampling factor for "gray pixel" approximation: the optic will be

--- a/poppy/optics.py
+++ b/poppy/optics.py
@@ -52,13 +52,13 @@ class AnalyticOpticalElement(OpticalElement):
         transmission, opd : string
             These are *not allowed* for Analytic optical elements, and this class will raise an
             error if you try to set one.
-        shift_x, shift_y : float or astropy Quantity, optional
+        shift_x, shift_y : astropy Quantity or float (length or angle, depending on plane type), optional
             Translations of this optic. Plain floats are interpreted in meters for pupil plane
             elements or arcseconds for image plane elements; astropy Quantities will be converted
             to the appropriate unit automatically.
-        rotation : float or astropy Quantity, optional
-            Rotation of the optic around its center, in degrees counterclockwise (plain float),
-            or any angular astropy Quantity. Note that if you apply both shift and rotation,
+        rotation : astropy Quantity or float angle, optional
+            Rotation of the optic around its center, in degrees counterclockwise, or an
+            angular astropy Quantity. Note that if you apply both shift and rotation,
             the optic rotates around its own center, rather than the optical axis.
         inclination_x, inclination_y : float, optional
             Inclination of the optic around the X or Y axis, in degrees. A non-zero inclination
@@ -124,7 +124,7 @@ class AnalyticOpticalElement(OpticalElement):
         Returns
         -------
         phasor : ndarray
-            Complex phasor array suitable for multiplying by the wavefront amplitude.
+            Complex phasor array suitable for multiplying the complex wavefront.
         """
         if isinstance(wave, BaseWavefront):
             wavelength = wave.wavelength
@@ -172,8 +172,11 @@ class AnalyticOpticalElement(OpticalElement):
             6.5 meters or 2 arcseconds depending on plane.
         what : string
             What to return: optic 'amplitude' transmission, 'intensity' transmission,
-            'phase', 'opd', or 'complex' phasor.  Note that optical path difference, OPD,
-            is given in meters.
+            'phase', 'opd', or 'complex' phasor.  Note that the transmissions are returned as
+            floating point values between 0 and 1, phase is returned as an angle with units
+            depending on the value of phase_unit, the optical path difference 'opd' is
+            given in meters, and the complex phasor is the product of the amplitude
+            transmission and the complex exponential of the phase
         phase_unit : string
             Unit for returned phase array IF what=='phase'. One of 'radians', 'waves', 'meters'.
             ('meters' option is deprecated; use what='opd' instead.)
@@ -253,8 +256,9 @@ class AnalyticOpticalElement(OpticalElement):
         ----------
         what : string
             What quantity to save. See the sample function of this class
-        wavelength : float or astropy Quantity
-            Wavelength; plain float is interpreted as meters.
+        wavelength : astropy Quantity or float length
+            Wavelength for evaluating the optic; passed to sample(),
+            in meters (plain float) or an astropy Quantity.
         npix : integer
             Number of pixels.
         outname : string, optional
@@ -408,13 +412,13 @@ class ScalarTransmission(AnalyticOpticalElement):
 
 
 class ScalarOpticalPathDifference(AnalyticOpticalElement):
-    """Uniform and constant optical path difference across the full aperture.
+    """Uniform and constant optical path difference
 
     Parameters
     ----------
     name : string, optional
         Descriptive name. Auto-generated from OPD value if not given.
-    opd : float or astropy Quantity length
+    opd : astropy Quantity or float length
         Optical path difference to apply uniformly. Plain float is interpreted as meters.
         Default is 1 micron.
     """
@@ -502,7 +506,7 @@ class BandLimitedCoronagraph(AnalyticImagePlaneElement):
             occulters; these will raise a DeprecationWarning.
         sigma : float
             The numerical size parameter, as specified in Krist et al. 2009 SPIE
-        wavelength : float or astropy Quantity, optional
+        wavelength : astropy Quantity or float length, optional
             Wavelength this BLC is optimized for (only used for the 'linear' kind).
             Plain float is interpreted as meters.
 
@@ -675,9 +679,8 @@ class IdealFQPM(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    wavelength : float or astropy Quantity
-        Wavelength in meters (plain float) or as an astropy Quantity, at which
-        there is exactly 1/2 a wave of retardance.
+    wavelength : astropy Quantity or float length
+        Wavelength at which there is exactly 1/2 a wave of retardance.
 
     """
 
@@ -712,11 +715,10 @@ class CircularPhaseMask(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    radius : float or astropy Quantity
-        Radius of the mask in arcseconds (plain float) or as an astropy Quantity.
-    wavelength : float or astropy Quantity
-        Wavelength in meters (plain float) or as an astropy Quantity, for which the phase mask
-        was designed.
+    radius : astropy Quantity or float
+        Radius of the mask, in arcseconds (plain float) or as an astropy Quantity.
+    wavelength : astropy Quantity or float length
+        Wavelength for which the phase mask was designed, in meters (plain float) or as an astropy Quantity.
     retardance : float
         Optical path delay at that wavelength, specified in waves
         relative to the reference wavelength. Default is 0.5.
@@ -769,11 +771,11 @@ class RectangularFieldStop(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    width : float or astropy Quantity angle
-        Width of the field stop in arcseconds (plain float) or as an astropy Quantity.
+    width : astropy Quantity or float angle
+        Width of the field stop, in arcseconds (plain float) or as an astropy Quantity.
         Default is 0.5 arcsec.
-    height : float or astropy Quantity angle
-        Height of the field stop in arcseconds (plain float) or as an astropy Quantity.
+    height : astropy Quantity or float angle
+        Height of the field stop, in arcseconds (plain float) or as an astropy Quantity.
         Default is 5.0 arcsec.
     """
 
@@ -912,11 +914,11 @@ class AnnularFieldStop(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    radius_inner : float or astropy Quantity
-        Radius of the central opaque region in arcseconds (plain float) or as an astropy Quantity.
+    radius_inner : astropy Quantity or float angle
+        Radius of the central opaque region, in arcseconds (plain float) or as an astropy Quantity.
         Default is 0.0 (no central opaque spot).
-    radius_outer : float or astropy Quantity
-        Radius of the circular field stop outer edge in arcseconds (plain float) or as an
+    radius_outer : astropy Quantity or float angle
+        Radius of the circular field stop outer edge, in arcseconds (plain float) or as an
         astropy Quantity. Default is 1.0 arcsec. Set to 0.0 for no outer edge.
     """
 
@@ -963,8 +965,8 @@ class CircularOcculter(AnnularFieldStop):
     ----------
     name : string
         Descriptive name
-    radius : float or astropy Quantity angle
-        Radius of the occulting spot in arcseconds (plain float) or as an astropy Quantity.
+    radius : astropy Quantity or float angle
+        Radius of the occulting spot, in arcseconds (plain float) or as an astropy Quantity.
         Default is 1.0 arcsec.
 
     """
@@ -982,11 +984,11 @@ class BarOcculter(AnalyticImagePlaneElement):
     ----------
     name : string
         Descriptive name
-    width : float or astropy Quantity angle
-        Width of the bar stop in arcseconds (plain float) or as an astropy Quantity.
+    width : astropy Quantity or float angle
+        Width of the bar stop, in arcseconds (plain float) or as an astropy Quantity.
         Default is 1.0 arcsec.
-    height : float or astropy Quantity angle
-        Height of the bar stop in arcseconds (plain float) or as an astropy Quantity.
+    height : astropy Quantity or float angle
+        Height of the bar stop, in arcseconds (plain float) or as an astropy Quantity.
         Default is 10.0 arcsec.
 
     """
@@ -1141,7 +1143,7 @@ class LetterFAperture(AnalyticOpticalElement):
     ----------
     name : string, optional
         Descriptive name. Auto-generated if not provided.
-    radius : float or astropy Quantity length
+    radius : astropy Quantity or float length
         Radius of the overall aperture, in meters. Default is 1.0 m.
     pad_factor : float, optional
         Factor by which to oversize the wavefront array relative to the pupil diameter.
@@ -1184,7 +1186,7 @@ class LetterFOpticalPathDifference(AnalyticOpticalElement):
     ----------
     name : string, optional
         Descriptive name. Auto-generated if not provided.
-    radius : float or astropy Quantity length
+    radius : astropy Quantity or float length
         Radius of the overall aperture, in meters. Default is 1.0 m.
     pad_factor : float, optional
         Factor by which to oversize the wavefront array relative to the pupil diameter.
@@ -1365,9 +1367,9 @@ class MultiSegmentAperture(AnalyticOpticalElement, ABC):
     ----------
     name : string, optional
         Descriptive name. Default is "MultiSegment".
-    segment_size : float or astropy Quantity length
+    segment_size : astropy Quantity or float length
         Characteristic size (e.g. flat-to-flat diameter) of each segment in meters.
-    gap : float or astropy Quantity length
+    gap : astropy Quantity or float length
         Gap between adjacent segments in meters. Default is 0.01 m.
     rings : int
         Number of rings of segments (not counting the center). Default is 1.
@@ -1701,7 +1703,7 @@ class KeystoneSegmentedCircularAperture(MultiSegmentAperture, CircularAperture):
     ----------
     name : string, optional
         Descriptive name. Auto-generated if not provided.
-    radius : float or astropy Quantity length
+    radius : astropy Quantity or float length
         Radius of the full circular aperture, in meters. Default is 1.0 m.
     rings : int
         Number of rings of segments. Default is 2.
@@ -1872,14 +1874,14 @@ class RectangleAperture(AnalyticOpticalElement):
     ----------
     name : string
         Descriptive name
-    width : float or astropy Quantity length
+    width : astropy Quantity or float length
         Width of the rectangle, in meters (plain float) or as an astropy Quantity.
         Default is 0.5 m.
-    height : float or astropy Quantity length
+    height : astropy Quantity or float length
         Height of the rectangle, in meters (plain float) or as an astropy Quantity.
         Default is 1.0 m.
     rotation : float
-        Rotation of the aperture counterclockwise in degrees. Default is 0.
+        Rotation of the 'width' axis of this rectangle, counterclockwise in degrees. Default is 0.
 
     """
 
@@ -1954,13 +1956,13 @@ class SecondaryObscuration(AnalyticOpticalElement):
 
     Parameters
     ----------
-    secondary_radius : float or astropy Quantity length
+    secondary_radius : astropy Quantity or float length
         Radius of the circular secondary obscuration, in meters or other unit.
         Default 0.5 m
     n_supports : int
         Number of secondary mirror supports ("spiders"). These will be
         spaced equally around a circle.  Default is 4.
-    support_width : float or astropy Quantity length
+    support_width : astropy Quantity or float length
         Width of each support, in meters or other unit. Default is 0.01 m = 1 cm.
     support_angle_offset : float
         Angular offset, in degrees, of the first secondary support from the X axis.
@@ -2020,13 +2022,13 @@ class AsymmetricSecondaryObscuration(SecondaryObscuration):
 
     Parameters
     ----------
-    secondary_radius : float or astropy Quantity length
-        Radius of the circular secondary obscuration in meters (plain float) or as an
+    secondary_radius : astropy Quantity or float length
+        Radius of the circular secondary obscuration, in meters (plain float) or as an
         astropy Quantity. Default 0.5 m
     support_angle : array_like of float
         The angle measured counterclockwise from +Y for each support, in degrees.
         Default is (0, 90, 240).
-    support_width : float or astropy Quantity length, or list thereof
+    support_width : astropy Quantity or float length, or list thereof
         if scalar, gives the width for all support struts
         if a list, gives separately the width for each support strut independently.
         Widths in meters or other unit if specified. Default is 0.01 m = 1 cm.
@@ -2112,12 +2114,12 @@ class ThinLens(CircularAperture):
         This is applied as a normalization over an area defined by the circumscribing circle
         of the input wavefront. That is, there will be nwaves defocus peak-to-valley
         over the region of the pupil that has nonzero input intensity.
-    reference_wavelength : float or astropy Quantity length
-        Wavelength in meters (plain float) or as an astropy Quantity, at which ``nwaves``
-        defocus is specified.
-    radius : float or astropy Quantity length
-        Pupil radius in meters (plain float) or as an astropy Quantity, over which the
-        Zernike defocus term should be computed such that rho = 1 at r = ``radius``.
+    reference_wavelength : astropy Quantity or float length
+        Wavelength at which ``nwaves`` defocus is specified,
+        either in meters (plain float) or as an astropy Quantity.
+    radius : astropy Quantity or float length
+        Pupil radius over which the Zernike defocus term should be computed such that rho = 1 at r = ``radius``,
+        either in meters (plain float) or as an astropy Quantity.
     """
 
     @utils.quantity_input(reference_wavelength=u.meter)
@@ -2165,13 +2167,13 @@ class GaussianAperture(AnalyticOpticalElement):
     ----------
     name : string
         Descriptive name
-    fwhm : float or astropy Quantity length, optional
+    fwhm : astropy Quantity or float length, optional
         Full width at half maximum for the Gaussian, in meters (plain float) or as an
         astropy Quantity.
-    w : float or astropy Quantity length, optional
+    w : astropy Quantity or float length, optional
         Beam radius parameter, equal to fwhm/(2*sqrt(ln(2))), in meters (plain float) or
         as an astropy Quantity. Exactly one of ``fwhm`` or ``w`` must be specified.
-    pupil_diam : float or astropy Quantity length, optional
+    pupil_diam : astropy Quantity or float length, optional
         Default pupil diameter for cases when it is not otherwise specified
         (e.g. displaying the optic by itself). Default value is 3x the FWHM.
 

--- a/poppy/poppy_core.py
+++ b/poppy/poppy_core.py
@@ -305,16 +305,16 @@ class BaseWavefront(ABC):
         Parameters
         ----------
         filename : string
-            filename to use
-        what : string
-            what to write. Must be one of 'parts', 'intensity', 'complex'
+            Filename to write to.
         overwrite : bool, optional
-            overwhat existing? default is True
+            Overwrite an existing file? Default is True.
+        what : string, optional
+            What to write. Must be one of 'all', 'parts', 'intensity', 'phase', or 'complex'.
+            Passed through to `as_fits`. Default is 'intensity'.
 
-        Returns
-        -------
-        outfile: file on disk
-            The output is written to disk.
+        Notes
+        -----
+        This method returns None; the output is written directly to disk.
 
         """
         self.as_fits(**kwargs).writeto(filename, overwrite=overwrite)
@@ -330,19 +330,20 @@ class BaseWavefront(ABC):
         Parameters
         ----------
         what : string
-           What to display. Must be one of {intensity, phase, wfe, best, 'both'}.
-           'intensity' shows the wavefront intensity,  'wfe' shows the wavefront
-           error in meters or microns, 'phase' is similar to 'wfe' but shows wavefront
-           phase in radians at the given wavelength.
-           'Best' implies to display the phase if there is nonzero OPD,
-           or else display the intensity for a perfect pupil.
-           'both' will show two panels, for the wavefront intensity and wavefront error.
+           What to display. Must be one of {'intensity', 'amplitude', 'phase', 'wfe', 'best', 'both'}.
+           'intensity' shows the wavefront intensity. 'amplitude' shows the electric field amplitude.
+           'wfe' shows the wavefront error in nanometers of OPD. 'phase' is similar to 'wfe' but shows
+           wavefront phase in radians at the given wavelength.
+           'best' displays phase if there is nonzero OPD, otherwise intensity for a perfect pupil.
+           'both' shows two panels: wavefront amplitude and wavefront phase.
         nrows : int
             Number of rows to display in current figure (used for
             showing steps in a calculation)
         row : int
             Which row to display this one in? If set to None, use the
             wavefront's self.current_plane_index
+        title : str, optional
+            Title string for the plot. If None, a default title is generated from the wavefront location.
         vmin, vmax : floats
             min and maximum values to display. When left unspecified, these default
             to [0, intens.max()] for linear (scale='linear') intensity plots,
@@ -369,6 +370,8 @@ class BaseWavefront(ABC):
             is given in units of meters, and the default is no cropping
             (i.e. the entire array will be displayed unless this keyword
             is set explicitly).
+        pupilcrop : float, optional
+            Accepted for API consistency but currently not implemented; has no effect.
         showpadding : bool, optional
             For wavefronts that have been padded with zeros for oversampling,
             show the entire padded arrays, or just the good parts?
@@ -391,8 +394,9 @@ class BaseWavefront(ABC):
 
         Returns
         -------
-        figure : matplotlib figure
-            The current figure is modified.
+        ax : matplotlib.axes.Axes or tuple of Axes
+            The matplotlib Axes instance(s) used for the plot. Returns a single Axes for
+            all ``what`` values except 'both', which returns a 2-tuple of Axes (intensity, phase).
         """
         if scale is None:
             scale = 'log' if self.planetype == PlaneType.image else 'linear'
@@ -656,11 +660,14 @@ class BaseWavefront(ABC):
         ----------
         optic : OpticalElement instance
             An optic that might have display hint information attached
-        default_nplanes :
+        default_nplanes : int
             How many rows to use for the display, if this is not
             already annotated onto this wavefront object itself.
 
-        Returns the plot axes instance.
+        Returns
+        -------
+        ax : matplotlib.axes.Axes
+            The plot axes instance.
         """
         display_what = getattr(optic, 'wavefront_display_hint', 'best')
         display_vmax = getattr(optic, 'wavefront_display_vmax_hint', None)
@@ -849,8 +856,9 @@ class BaseWavefront(ABC):
 
         Parameters
         ----------
-        Xangle, Yangle : float
-            tilt angles, specified in arcseconds
+        Xangle, Yangle : float or astropy.units.Quantity
+            Tilt angles. If given as plain floats they are interpreted as arcseconds.
+            Astropy Quantities with any angular unit are also accepted.
 
         """
         if self.planetype == PlaneType.image:
@@ -1188,6 +1196,20 @@ class Wavefront(BaseWavefront):
         This is only used if transforming back from a 'detector' type plane to a pupil, for instance
         inside the semi-analytic coronagraphy algorithm, but is not used in more typical propagations.
 
+        Parameters
+        ----------
+        pupil : OpticalElement
+            The pupil plane optic to propagate to. Used to determine the target sampling
+            if the optic has a defined shape and pixelscale.
+        pupil_npix : int, optional
+            Number of pixels on a side for the output pupil array. If None (default), the size
+            is inferred from the next optic's shape, or from the pupil shape that existed
+            before the preceding forward MFT.
+
+        Notes
+        -----
+        Modifies the wavefront in-place, updating ``wavefront``, ``planetype``,
+        ``pixelscale``, and ``diam``.
         """
 
         assert self.planetype == PlaneType.image
@@ -1249,9 +1271,15 @@ class Wavefront(BaseWavefront):
 
         shape : tuple of ints
             Shape of the wavefront array
-        pixelscale : float or 2-tuple of floats
+        pixelscale : float or astropy.units.Quantity
             the pixel scale in meters/pixel, optionally different in
             X and Y
+
+        Returns
+        -------
+        Y, X : ndarray
+            2D coordinate arrays in units of meters, centered at (0, 0),
+            following the numpy.indices convention (Y axis first).
         """
         y, x = xp.indices(shape, dtype=_float())
         pixelscale_mpix = pixelscale.to(u.meter / u.pixel).value if isinstance(pixelscale, u.Quantity) else pixelscale
@@ -1279,8 +1307,8 @@ class Wavefront(BaseWavefront):
 
         shape : tuple of ints
             Shape of the wavefront array
-        pixelscale : float or 2-tuple of floats
-            the pixelscale in meters/pixel, optionally different in
+        pixelscale : float or astropy.units.Quantity
+            the pixelscale in arcsec/pixel, optionally different in
             X and Y
         last_transform_type : string
             Was the last transformation on the Wavefront an FFT
@@ -1288,6 +1316,12 @@ class Wavefront(BaseWavefront):
         image_centered : string
             Was POPPY trying to keeping the center of the image on
             a pixel, crosshairs ('array_center'), or corner?
+
+        Returns
+        -------
+        Y, X : ndarray
+            2D coordinate arrays in units of arcseconds, with the origin at the
+            center of the PSF, following the numpy.indices convention (Y axis first).
         """
         y, x = xp.indices(shape, dtype=_float())
         pixelscale_arcsecperpix = pixelscale.to(u.arcsec / u.pixel).value
@@ -1352,9 +1386,16 @@ class Wavefront(BaseWavefront):
 
         Parameters
         ----------
-        fresnel_wavefront : Wavefront
-            The (Fresnel-type) wavefront to be converted.
+        fresnel_wavefront : FresnelWavefront
+            The Fresnel-type wavefront to be converted.
+        verbose : bool, optional
+            If True, print sampling information during conversion. Default is False.
 
+        Returns
+        -------
+        new_wf : Wavefront
+            A Fraunhofer-type Wavefront with the same array contents and sampling
+            as the input Fresnel wavefront (cropped to remove oversampling padding).
         """
         # Generate a Fraunhofer wavefront with the same sampling
         wf = fresnel_wavefront
@@ -1432,7 +1473,10 @@ class BaseOpticalSystem(ABC):
         pixel.  Default is 2.
     verbose : bool
         whether to be more verbose with log output while computing
-    pupil_diameter : astropy.Quantity of dimension length
+    npix : int, optional
+        Number of pixels per side for the input wavefront. If not set, the
+        size is inferred from the first optical element, or defaults to 1024.
+    pupil_diameter : astropy.units.Quantity of dimension length
         Diameter of entrance pupil. Defaults to size of first optical element
         if unspecified, or else 1 meter.
 
@@ -1584,7 +1628,7 @@ class BaseOpticalSystem(ABC):
             wavelength parameter. Defaults to 1s if not specified.
         save_intermediates : bool, optional
             whether to output intermediate optical planes to disk. Default is False
-        save_intermediate_what : string, optional
+        save_intermediates_what : string, optional
             What to save - phase, intensity, amplitude, complex, parts, all. Default is all.
         return_intermediates: bool, optional
             return intermediate wavefronts as well as PSF?
@@ -1605,6 +1649,9 @@ class BaseOpticalSystem(ABC):
             while iterating over wavelengths. Note, this requires the
             optional dependency package 'tqdm', which is not included as
             a requirement.
+        inwave : Wavefront, optional
+            If provided, use this as the input wavefront instead of creating one
+            automatically from the optical system's entrance pupil parameters.
 
         Returns
         -------
@@ -2077,8 +2124,12 @@ class OpticalSystem(BaseOpticalSystem):
 
         Parameters
         ----------
-        wavelength : float
-            Wavelength in meters
+        wavelength : float or astropy.units.Quantity
+            Wavelength in meters (or other units if specified as a Quantity).
+        inwave : Wavefront, optional
+            If provided, use this as the input wavefront directly, rather than
+            constructing one from the optical system's pupil parameters. Must be
+            a `Wavefront` instance. Any requested source offset tilt is still applied.
 
         Returns
         -------
@@ -2174,6 +2225,7 @@ class OpticalSystem(BaseOpticalSystem):
             Wavefront to propagate through this optical system
         normalize : string
             How to normalize the wavefront?
+            * 'none' = no normalization (default)
             * 'first' = set total flux = 1 after the first optic, presumably a pupil
             * 'last' = set total flux = 1 after the entire optical system.
             * 'exit_pupil' = set total flux = 1 at the last pupil of the optical system.
@@ -2184,8 +2236,13 @@ class OpticalSystem(BaseOpticalSystem):
             If True, the second return value of the method will be a list of `poppy.Wavefront` objects
             representing intermediate optical planes from the calculation.
 
-        Returns a wavefront, and optionally also the intermediate wavefronts after
-        each step of propagation.
+        Returns
+        -------
+        wavefront : Wavefront
+            The propagated wavefront after passing through all planes.
+        intermediate_wfs : list of Wavefront
+            Only returned if ``return_intermediates=True``. A list of `poppy.Wavefront` objects
+            representing intermediate optical planes from the calculation.
 
         """
 
@@ -2285,7 +2342,14 @@ class CompoundOpticalSystem(OpticalSystem):
 
         Parameters
         ----------
-        optsyslist : List of OpticalSystem and/or FresnelOpticalSystem instances.
+        optsyslist : list of OpticalSystem and/or FresnelOpticalSystem instances
+            The ordered list of optical systems to concatenate.
+        name : str, optional
+            Descriptive name for this compound system. If not provided, a name is
+            generated automatically from the number of sub-systems.
+        **kwargs
+            Additional keyword arguments are passed to the `BaseOpticalSystem` constructor
+            (e.g., ``verbose``, ``oversample``).
 
         """
         # validate the input optical systems make sense
@@ -2318,6 +2382,18 @@ class CompoundOpticalSystem(OpticalSystem):
         Input wavefronts for a compound system are defined by the first OpticalSystem in the list.
         We tweak the _display_hint_expected_planes to reflect the full compound system however.
 
+        Parameters
+        ----------
+        wavelength : float or astropy.units.Quantity
+            Wavelength in meters (or other units if given as a Quantity).
+        inwave : Wavefront, optional
+            If provided, use this as the input wavefront instead of generating one
+            from the first sub-system's entrance pupil parameters.
+
+        Returns
+        -------
+        inwave : Wavefront
+            Input wavefront appropriate for propagating through this compound system.
         """
         inwave = self.optsyslist[0].input_wavefront(wavelength, inwave=inwave)
         inwave._display_hint_expected_nplanes = len(self)     # For displaying a multi-step calculation nicely
@@ -2489,6 +2565,12 @@ class OpticalElement:
         wave : float or obj
             either a scalar wavelength or a Wavefront object
 
+        Returns
+        -------
+        phasor : ndarray of complex
+            Complex phasor array (transmission * exp(i * opd * 2*pi/lambda)), shaped to match
+            the wavefront. May be a scalar 1.0 if this is a null optic.
+
         """
 
         if isinstance(wave, BaseWavefront):
@@ -2605,6 +2687,12 @@ class OpticalElement:
             arcsec for image plane optics, meters for all other optics.
             If unspecified, a default value will be chosen instead, possibly
             from the ._default_display_size attribute, if present.
+
+        Returns
+        -------
+        ax : matplotlib.axes.Axes or tuple of Axes
+            The matplotlib Axes used for the plot. Returns a single Axes for all ``what``
+            values except 'both', which returns a 2-tuple ``(ax1, ax2)`` for amplitude and OPD.
         """
         if colorbar_orientation is None:
             colorbar_orientation = "horizontal" if nrows == 1 else 'vertical'
@@ -2790,6 +2878,22 @@ class ArrayOpticalElement(OpticalElement):
     """
 
     def __init__(self, opd=None, transmission=None, pixelscale=None, **kwargs):
+        """
+        Parameters
+        ----------
+        opd : ndarray, optional
+            Optical path difference array in meters. If not provided and ``transmission`` is
+            given, OPD defaults to an array of zeros with the same shape.
+        transmission : ndarray, optional
+            Electric field amplitude transmission array (values 0–1). If not provided and
+            ``opd`` is given, transmission defaults to an array of ones with the same shape.
+        pixelscale : astropy.units.Quantity or float, optional
+            Pixel scale of the provided arrays, in meters/pixel (pupil plane) or
+            arcsec/pixel (image plane). If not set, no pixel scale is associated with the optic.
+        **kwargs
+            Additional keyword arguments passed to `OpticalElement` (e.g., ``name``,
+            ``planetype``, ``oversample``).
+        """
         super().__init__(**kwargs)
         if opd is not None:
             self.opd = opd
@@ -2840,9 +2944,10 @@ class FITSOpticalElement(OpticalElement):
     transmission, opd : string or fits HDUList
         Either FITS filenames *or* actual fits.HDUList objects for the
         transmission (from 0-1) and opd (in meters)
-    transmission_slice, opd_slice : integers, optional
+    transmission_index, opd_index : ints, optional
         If either transmission or OPD files are datacubes, you can specify the
-        slice index using this argument.
+        slice index using this argument. (Formerly called ``transmission_slice``
+        and ``opd_slice`` in older versions of POPPY.)
     opdunits : string
         units for the OPD file. Default is 'meters'. can be 'meter', 'meters',
         'micron(s)', 'nanometer(s)', or their SI abbreviations. If this keyword
@@ -2869,7 +2974,7 @@ class FITSOpticalElement(OpticalElement):
         Rotation for that optic, in degrees counterclockwise. This is
         implemented using spline interpolation via the
         scipy.ndimage.rotate function.
-    pixelscale : optical str or float
+    pixelscale : optional str or float
         By default, poppy will attempt to determine the appropriate pixel scale
         by examining the FITS header, checking keywords "PIXELSCL", "PUPLSCAL" and/or 'PIXSCALE'.
         PIXELSCL is the default and should be preferred for new files; the latter two are
@@ -2878,9 +2983,6 @@ class FITSOpticalElement(OpticalElement):
         and use a different keyword, provide that as a string here. Alternatively,
         you can just set a floating point value directly too (in meters/pixel
         or arcsec/pixel, respectively, for pupil or image planes).
-    transmission_index, opd_index : ints, optional
-        If the input transmission or OPD files are datacubes, provide a scalar
-        index here for which cube slice should be used.
 
 
     *NOTE:* All mask files must be *squares*.
@@ -3303,7 +3405,9 @@ class CoordinateInversion(CoordinateTransform):
 
     Parameters
     ----------
-    axes : string
+    name : str, optional
+        Descriptive name for this element. Default is 'Coordinate inversion'.
+    axis : string
         either 'both', 'x', or 'y', for which axes to invert
     hide : bool
         Should this optic be displayed or hidden when showing the


### PR DESCRIPTION
Docstring cleanup and consistency check.

- Fill in missing input parameters and/or missing returned outputs to doc strings
- Update parameter type hints in doc strings, particularly for the many cases in which values can be supplied as an astropy Quantity or a plan float (which gets interpreted as having some default unit)
- Implement a handful of small corrections to a few mis-statements or out-of-date statements in the doc strings.

Implemented mostly using Github Copilot, then checked, verified, and refined by me. Per ST's recent policy, I therefore also add the standard AI_POLICY.md.